### PR TITLE
Fix: Remove redundant auth header

### DIFF
--- a/src/lib/api/fetch.ts
+++ b/src/lib/api/fetch.ts
@@ -5,7 +5,6 @@ const useCrateClusterHeader = 'X-use-crate';
 const projectNameHeader = 'X-project';
 const workspaceNameHeader = 'X-workspace';
 const mcpNameHeader = 'X-mcp';
-const mcpAuthHeader = 'X-mcp-authorization';
 const contextHeader = 'X-context';
 const jqHeader = 'X-jq';
 const authHeader = 'Authorization';
@@ -39,7 +38,6 @@ export const fetchApiServer = async (
     headers[workspaceNameHeader] = config.mcpConfig.workspaceName;
     headers[mcpNameHeader] = config.mcpConfig.controlPlaneName;
     headers[contextHeader] = config.mcpConfig.contextName;
-    headers[mcpAuthHeader] = config.mcpConfig.mcpAuthorization;
   } else {
     headers[useCrateClusterHeader] = 'true';
   }

--- a/src/lib/api/types/apiConfig.ts
+++ b/src/lib/api/types/apiConfig.ts
@@ -11,7 +11,6 @@ type McpConfig = {
   workspaceName: string;
   controlPlaneName: string;
   contextName: string;
-  mcpAuthorization: string;
 };
 
 //syntax basically combines all the atrributes from the types into one

--- a/src/lib/shared/McpContext.tsx
+++ b/src/lib/shared/McpContext.tsx
@@ -1,13 +1,7 @@
-import {
-  createContext,
-  ReactNode,
-  useContext,
-  useEffect,
-  useState,
-} from 'react';
+import { createContext, ReactNode, useContext } from 'react';
 import { ControlPlane as ManagedControlPlaneResource } from '../api/types/crate/controlPlanes.ts';
 import { GetAuthPropsForContextName } from '../oidc/shared.ts';
-import { AuthProvider, hasAuthParams, useAuth } from 'react-oidc-context';
+import { AuthProvider } from 'react-oidc-context';
 import {
   ApiConfigContext,
   ApiConfigProvider,
@@ -66,29 +60,9 @@ export const McpContextProvider = ({ children, context }: Props) => {
 };
 
 function RequireDownstreamLogin(props: { children?: ReactNode }) {
-  const auth = useAuth();
   const mcp = useContext(McpContext);
-  const [hasTriedSignin, setHasTriedSignin] = useState(false);
   const parentApiConfig = useContext(ApiConfigContext);
 
-  // automatically sign-in
-  useEffect(() => {
-    if (
-      !hasAuthParams() &&
-      !auth.isAuthenticated &&
-      !auth.activeNavigator &&
-      !auth.isLoading &&
-      !hasTriedSignin
-    ) {
-      auth.signinPopup().then((_) => {
-        setHasTriedSignin(true);
-      });
-    }
-  }, [auth, hasTriedSignin]);
-
-  if (!auth.isAuthenticated || auth.isLoading) {
-    return <>Elevating your permissions</>;
-  }
   return (
     <>
       <ApiConfigProvider
@@ -100,7 +74,6 @@ function RequireDownstreamLogin(props: { children?: ReactNode }) {
             projectName: mcp.project,
             workspaceName: mcp.workspace,
             controlPlaneName: mcp.name,
-            mcpAuthorization: auth.user?.access_token ?? '',
           },
         }}
       >


### PR DESCRIPTION
Backend PR: https://github.com/openmcp-project/ui-backend/pull/6

This PR removes the MCPAuthorization header. (Authorization is handled via the standard `Authorization` header.)
