### PR TITLE
Clean frontend-config-json

### DIFF
--- a/frontend-config.json
+++ b/frontend-config.json
@@ -1,6 +1,6 @@
 {
   "backendUrl": "http://localhost:3000",
-  "gatewayUrl": "https://gateway.ui.dev-core.mcpd.shoot.canary.k8s-hana.ondemand.com/kubernetes/graphql",
+  "gatewayUrl": "http://localhost:3000",
   "landscape": "LOCAL",
   "documentationBaseUrl": "http://localhost:3000",
   "oidcConfig": {


### PR DESCRIPTION
Removes the graphql backend from the (template) `frontend-config.json`.