### PR TITLE
fix: remove x-mcp-authorization

### DIFF
--- a/server/plugins/http-proxy.js
+++ b/server/plugins/http-proxy.js
@@ -83,8 +83,7 @@ function proxyPlugin(fastify) {
     replyOptions: {
       rewriteRequestHeaders: (req, headers) => ({
         ...headers,
-        authorization: req.session.get("accessToken"),
-        "X-mcp-authorization": req.session.get("accessToken"), // no support for different MCP IdPs at the moment
+        authorization: req.session.get("accessToken")
       }),
     },
   });


### PR DESCRIPTION
Removes the `X-mcp-authorization` header in the bff (see also #107)
