### PR TITLE
fix: add debug options to clean-main-images.yml

### DIFF
--- a/.github/workflows/clean-main-images.yml
+++ b/.github/workflows/clean-main-images.yml
@@ -36,15 +36,19 @@ jobs:
             /orgs/${{ env.ORG }}/packages/container/${{ env.IMAGE_NAME }}/versions \
             --paginate | jq -r '.[] | select(.metadata.container.tags[] | startswith("${{ env.TAG_PREFIX }}")) | "\(.id) \(.metadata.container.tags[])"' | grep '^.* ${{ env.TAG_PREFIX }}' | sort -k2 -r)
 
-          # Get the IDs to delete (skip the first ${{ env.KEEP_X_IMAGES }} versions)
-          IDS_TO_DELETE=$(echo "$VERSIONS" | awk '{print $1}' | sed "1,${{ env.KEEP_X_IMAGES }}d" | sort -u)
+          # Get the lines to delete (skip the first ${{ env.KEEP_X_IMAGES }} versions)
+          TO_DELETE=$(echo "$VERSIONS" | sed "1,${{ env.KEEP_X_IMAGES }}d")
 
-          echo "Version IDs to delete: $IDS_TO_DELETE"
-          for id in $IDS_TO_DELETE; do
-            echo "Deleting version ID $id"
+          echo "Deleting the following tags:"
+          echo "$TO_DELETE" | awk '{print $2}'
+
+          while read -r line; do
+            id=$(echo "$line" | awk '{print $1}')
+            tag=$(echo "$line" | awk '{print $2}')
+            echo "Deleting tag $tag (version ID $id)"
             gh api -X DELETE -H "Accept: application/vnd.github+json" \
-              /orgs/${{ env.ORG }}/packages/container/${{ env.IMAGE_NAME }}/versions/$id || echo "Failed to delete version $id"
-          done
+              /orgs/${{ env.ORG }}/packages/container/${{ env.IMAGE_NAME }}/versions/$id || echo "Failed to delete version $id ($tag)"
+          done <<< "$TO_DELETE"
 
       - name: List remaining ${{ env.TAG_PREFIX }}* tags and their version IDs (debug)
         run: |

--- a/.github/workflows/clean-main-images.yml
+++ b/.github/workflows/clean-main-images.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Delete old main branch images
         uses: actions/delete-package-versions@v5
         with:
-          package-name: ${{ env.FULL_IMAGE_NAME }}
+          package-name: ${{ env.IMAGE_NAME }}
           package-type: 'container'
           min-versions-to-keep: ${{ env.KEEP_X_IMAGES }}
           ignore-versions: '^(?!main-).*$'

--- a/.github/workflows/clean-main-images.yml
+++ b/.github/workflows/clean-main-images.yml
@@ -43,6 +43,11 @@ jobs:
           echo "Deleting the following tags:"
           echo "$TO_DELETE" | awk '{print $2}'
 
+          if [ -z "$TO_DELETE" ]; then
+            echo "No tags to delete."
+            exit 0
+          fi
+
           FAILED_DELETIONS=""
           while read -r line; do
             id=$(echo "$line" | awk '{print $1}')

--- a/.github/workflows/clean-main-images.yml
+++ b/.github/workflows/clean-main-images.yml
@@ -30,9 +30,11 @@ jobs:
           echo "Listing images before cleanup:"
           gh api -H "Accept: application/vnd.github+json" \
             /users/${{ github.repository_owner }}/packages/container/${{ env.IMAGE_NAME }}/versions | jq '.[].metadata.container.tags'
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Delete old main branch images
-        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5
+        uses: actions/delete-package-versions@v5
         with:
           package-name: ${{ env.FULL_IMAGE_NAME }}
           package-type: 'container'
@@ -44,3 +46,5 @@ jobs:
           echo "Listing images after cleanup:"
           gh api -H "Accept: application/vnd.github+json" \
             /users/${{ github.repository_owner }}/packages/container/${{ env.IMAGE_NAME }}/versions | jq '.[].metadata.container.tags'
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/clean-main-images.yml
+++ b/.github/workflows/clean-main-images.yml
@@ -8,6 +8,7 @@ on:
 env:
   REGISTRY: ghcr.io/openmcp-project
   IMAGE_NAME: mcp-ui-frontend
+  FULL_IMAGE_NAME: openmcp-project/mcp-ui-frontend
   KEEP_X_IMAGES: 5
 
 jobs:
@@ -17,11 +18,29 @@ jobs:
     permissions:
       packages: write
     steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: List images before cleanup (debug)
+        run: |
+          echo "Listing images before cleanup:"
+          gh api -H "Accept: application/vnd.github+json" \
+            /users/${{ github.repository_owner }}/packages/container/${{ env.IMAGE_NAME }}/versions | jq '.[].metadata.container.tags'
+
       - name: Delete old main branch images
         uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5
         with:
-          package-name: ${{ env.IMAGE_NAME }}
+          package-name: ${{ env.FULL_IMAGE_NAME }}
           package-type: 'container'
           min-versions-to-keep: ${{ env.KEEP_X_IMAGES }}
-          # Ignore any version that does NOT start with 'main-'
           ignore-versions: '^(?!main-).*$'
+
+      - name: List images after cleanup (debug)
+        run: |
+          echo "Listing images after cleanup:"
+          gh api -H "Accept: application/vnd.github+json" \
+            /users/${{ github.repository_owner }}/packages/container/${{ env.IMAGE_NAME }}/versions | jq '.[].metadata.container.tags'

--- a/.github/workflows/clean-main-images.yml
+++ b/.github/workflows/clean-main-images.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Delete old ${{ env.TAG_PREFIX }}* tags using GitHub API, keep ${{ env.KEEP_X_IMAGES }}
         run: |
           set -e
+          set -o pipefail
 
           # Get all ${{ env.TAG_PREFIX }}* tags and their version IDs, sorted by tag (descending)
           VERSIONS=$(gh api -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/clean-main-images.yml
+++ b/.github/workflows/clean-main-images.yml
@@ -6,10 +6,11 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: ghcr.io/openmcp-project
+  REGISTRY: ghcr.io
+  ORG: openmcp-project
   IMAGE_NAME: mcp-ui-frontend
-  FULL_IMAGE_NAME: openmcp-project/mcp-ui-frontend
   KEEP_X_IMAGES: 5
+  TAG_PREFIX: 'main-'
 
 jobs:
   clean:
@@ -17,34 +18,36 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: List images before cleanup (debug)
+      - name: List all ${{ env.TAG_PREFIX }} tags and their version IDs (debug)
         run: |
-          echo "Listing images before cleanup:"
           gh api -H "Accept: application/vnd.github+json" \
-            /users/${{ github.repository_owner }}/packages/container/${{ env.IMAGE_NAME }}/versions | jq '.[].metadata.container.tags'
-        env:
-          GH_TOKEN: ${{ github.token }}
+            /orgs/${{ env.ORG }}/packages/container/${{ env.IMAGE_NAME }}/versions \
+            --paginate | jq -r '.[] | select(.metadata.container.tags[] | startswith("${{ env.TAG_PREFIX }}")) | "\(.id) \(.metadata.container.tags[])"' | grep '^.* ${{ env.TAG_PREFIX }}' | sort -k2 -r
 
-      - name: Delete old main branch images
-        uses: actions/delete-package-versions@v5
-        with:
-          package-name: ${{ env.IMAGE_NAME }}
-          package-type: 'container'
-          min-versions-to-keep: ${{ env.KEEP_X_IMAGES }}
-          ignore-versions: '^(?!main-).*$'
-
-      - name: List images after cleanup (debug)
+      - name: Delete old ${{ env.TAG_PREFIX }}* tags using GitHub API, keep ${{ env.KEEP_X_IMAGES }}
         run: |
-          echo "Listing images after cleanup:"
+          set -e
+
+          # Get all ${{ env.TAG_PREFIX }}* tags and their version IDs, sorted by tag (descending)
+          VERSIONS=$(gh api -H "Accept: application/vnd.github+json" \
+            /orgs/${{ env.ORG }}/packages/container/${{ env.IMAGE_NAME }}/versions \
+            --paginate | jq -r '.[] | select(.metadata.container.tags[] | startswith("${{ env.TAG_PREFIX }}")) | "\(.id) \(.metadata.container.tags[])"' | grep '^.* ${{ env.TAG_PREFIX }}' | sort -k2 -r)
+
+          # Get the IDs to delete (skip the first ${{ env.KEEP_X_IMAGES }} versions)
+          IDS_TO_DELETE=$(echo "$VERSIONS" | awk '{print $1}' | sed "1,${{ env.KEEP_X_IMAGES }}d" | sort -u)
+
+          echo "Version IDs to delete: $IDS_TO_DELETE"
+          for id in $IDS_TO_DELETE; do
+            echo "Deleting version ID $id"
+            gh api -X DELETE -H "Accept: application/vnd.github+json" \
+              /orgs/${{ env.ORG }}/packages/container/${{ env.IMAGE_NAME }}/versions/$id || echo "Failed to delete version $id"
+          done
+
+      - name: List remaining ${{ env.TAG_PREFIX }}* tags and their version IDs (debug)
+        run: |
           gh api -H "Accept: application/vnd.github+json" \
-            /users/${{ github.repository_owner }}/packages/container/${{ env.IMAGE_NAME }}/versions | jq '.[].metadata.container.tags'
-        env:
-          GH_TOKEN: ${{ github.token }}
+            /orgs/${{ env.ORG }}/packages/container/${{ env.IMAGE_NAME }}/versions \
+            --paginate | jq -r '.[] | select(.metadata.container.tags[] | startswith("${{ env.TAG_PREFIX }}")) | "\(.id) \(.metadata.container.tags[])"' | grep '^.* ${{ env.TAG_PREFIX }}' | sort -k2 -r

--- a/.github/workflows/clean-main-images.yml
+++ b/.github/workflows/clean-main-images.yml
@@ -43,14 +43,25 @@ jobs:
           echo "Deleting the following tags:"
           echo "$TO_DELETE" | awk '{print $2}'
 
+          FAILED_DELETIONS=""
           while read -r line; do
             id=$(echo "$line" | awk '{print $1}')
             tag=$(echo "$line" | awk '{print $2}')
             echo "Deleting tag $tag (version ID $id)"
-            gh api -X DELETE -H "Accept: application/vnd.github+json" \
-              /orgs/${{ env.ORG }}/packages/container/${{ env.IMAGE_NAME }}/versions/$id || echo "Failed to delete version $id ($tag)"
+            if ! gh api -X DELETE -H "Accept: application/vnd.github+json" \
+              /orgs/${{ env.ORG }}/packages/container/${{ env.IMAGE_NAME }}/versions/$id; then
+              echo "Failed to delete version $id ($tag)"
+              FAILED_DELETIONS="${FAILED_DELETIONS}\n$id ($tag)"
+            fi
+              echo "Failed to delete version $id ($tag)"
+              FAILED_DELETIONS="${FAILED_DELETIONS}\n$id ($tag)"
+            fi
           done <<< "$TO_DELETE"
 
+          if [ -n "$FAILED_DELETIONS" ]; then
+            echo -e "The following deletions failed:\n$FAILED_DELETIONS"
+            exit 1
+          fi
       - name: List remaining ${{ env.TAG_PREFIX }}* tags and their version IDs (debug)
         run: |
           gh api -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
**What this PR does / why we need it**:
As the current cleanup does not worked, this PR fixes it now.

This pull request introduces significant changes to the `.github/workflows/clean-main-images.yml` file to enhance the process of cleaning old container images. The workflow now uses the GitHub API directly for listing and deleting image tags, replacing the previous reliance on the `actions/delete-package-versions` action. Additionally, new environment variables have been added to improve flexibility and debugging capabilities.

### Enhancements to the image cleanup workflow:

* **Direct GitHub API integration for image management**: Replaced the `actions/delete-package-versions` action with custom scripts using the GitHub API to list and delete container image tags. This allows finer control over the cleanup process and better debugging capabilities.
* **Environment variable additions**: Added new environment variables, including `ORG` and `TAG_PREFIX`, to improve configurability and flexibility in identifying and managing container tags.
* **Debugging improvements**: Added steps to list tags before and after deletion for better visibility into the cleanup process, aiding debugging and validation.



