### PR TITLE
Increase toast notification time

### DIFF
--- a/src/context/ToastContext.tsx
+++ b/src/context/ToastContext.tsx
@@ -35,7 +35,7 @@ export const ToastProvider: FC<{ children: ReactNode }> = ({ children }) => {
     setTimeout(() => {
       setToastContent({
         text: message,
-        duration: duration || 3000,
+        duration: duration || 8000,
       });
       setToastVisible(true);
     }, 100);


### PR DESCRIPTION
**What this PR does / why we need it**:

Increase toast notification time because we noticed that users do not have enough of time to read them.
