### PR TITLE
feat: switch to multi-arch supporting action & cleanup untagged

### DIFF
--- a/.github/workflows/clean-main-images.yml
+++ b/.github/workflows/clean-main-images.yml
@@ -13,59 +13,75 @@ env:
   TAG_PREFIX: 'main-'
 
 jobs:
-  clean:
-    name: 'Clean main images'
+  # clean:
+  #   name: 'Clean main images'
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     packages: write
+  #   env:
+  #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   steps:
+  #     - name: List all ${{ env.TAG_PREFIX }} tags and their version IDs (debug)
+  #       run: |
+  #         gh api -H "Accept: application/vnd.github+json" \
+  #           /orgs/${{ env.ORG }}/packages/container/${{ env.IMAGE_NAME }}/versions \
+  #           --paginate | jq -r '.[] | select(.metadata.container.tags[] | startswith("${{ env.TAG_PREFIX }}")) | "\(.id) \(.metadata.container.tags[])"' | grep '^.* ${{ env.TAG_PREFIX }}' | sort -k2 -r
+
+  #     - name: Delete old ${{ env.TAG_PREFIX }}* tags using GitHub API, keep ${{ env.KEEP_X_IMAGES }}
+  #       run: |
+  #         set -e
+  #         set -o pipefail
+
+  #         # Get all ${{ env.TAG_PREFIX }}* tags and their version IDs, sorted by tag (descending)
+  #         VERSIONS=$(gh api -H "Accept: application/vnd.github+json" \
+  #           /orgs/${{ env.ORG }}/packages/container/${{ env.IMAGE_NAME }}/versions \
+  #           --paginate | jq -r '.[] | select(.metadata.container.tags[] | startswith("${{ env.TAG_PREFIX }}")) | "\(.id) \(.metadata.container.tags[])"' | grep '^.* ${{ env.TAG_PREFIX }}' | sort -k2 -r)
+
+  #         # Get the lines to delete (skip the first ${{ env.KEEP_X_IMAGES }} versions)
+  #         TO_DELETE=$(echo "$VERSIONS" | sed "1,${{ env.KEEP_X_IMAGES }}d")
+
+  #         echo "Deleting the following tags:"
+  #         echo "$TO_DELETE" | awk '{print $2}'
+
+  #         if [ -z "$TO_DELETE" ]; then
+  #           echo "No tags to delete."
+  #           exit 0
+  #         fi
+
+  #         FAILED_DELETIONS=""
+  #         while read -r line; do
+  #           id=$(echo "$line" | awk '{print $1}')
+  #           tag=$(echo "$line" | awk '{print $2}')
+  #           echo "Deleting tag $tag (version ID $id)"
+  #           if ! gh api -X DELETE -H "Accept: application/vnd.github+json" \
+  #             /orgs/${{ env.ORG }}/packages/container/${{ env.IMAGE_NAME }}/versions/$id; then
+  #             echo "Failed to delete version $id ($tag)"
+  #             FAILED_DELETIONS="${FAILED_DELETIONS}\n$id ($tag)"
+  #           fi
+  #         done <<< "$TO_DELETE"
+
+  #         if [ -n "$FAILED_DELETIONS" ]; then
+  #           echo -e "The following deletions failed:\n$FAILED_DELETIONS"
+  #           exit 1
+  #         fi
+  #     - name: List remaining ${{ env.TAG_PREFIX }}* tags and their version IDs (debug)
+  #       run: |
+  #         gh api -H "Accept: application/vnd.github+json" \
+  #           /orgs/${{ env.ORG }}/packages/container/${{ env.IMAGE_NAME }}/versions \
+  #           --paginate | jq -r '.[] | select(.metadata.container.tags[] | startswith("${{ env.TAG_PREFIX }}")) | "\(.id) \(.metadata.container.tags[])"' | grep '^.* ${{ env.TAG_PREFIX }}' | sort -k2 -r
+
+  delete-untagged-images:
+    name: Delete Untagged Images
     runs-on: ubuntu-latest
     permissions:
       packages: write
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: List all ${{ env.TAG_PREFIX }} tags and their version IDs (debug)
-        run: |
-          gh api -H "Accept: application/vnd.github+json" \
-            /orgs/${{ env.ORG }}/packages/container/${{ env.IMAGE_NAME }}/versions \
-            --paginate | jq -r '.[] | select(.metadata.container.tags[] | startswith("${{ env.TAG_PREFIX }}")) | "\(.id) \(.metadata.container.tags[])"' | grep '^.* ${{ env.TAG_PREFIX }}' | sort -k2 -r
-
-      - name: Delete old ${{ env.TAG_PREFIX }}* tags using GitHub API, keep ${{ env.KEEP_X_IMAGES }}
-        run: |
-          set -e
-          set -o pipefail
-
-          # Get all ${{ env.TAG_PREFIX }}* tags and their version IDs, sorted by tag (descending)
-          VERSIONS=$(gh api -H "Accept: application/vnd.github+json" \
-            /orgs/${{ env.ORG }}/packages/container/${{ env.IMAGE_NAME }}/versions \
-            --paginate | jq -r '.[] | select(.metadata.container.tags[] | startswith("${{ env.TAG_PREFIX }}")) | "\(.id) \(.metadata.container.tags[])"' | grep '^.* ${{ env.TAG_PREFIX }}' | sort -k2 -r)
-
-          # Get the lines to delete (skip the first ${{ env.KEEP_X_IMAGES }} versions)
-          TO_DELETE=$(echo "$VERSIONS" | sed "1,${{ env.KEEP_X_IMAGES }}d")
-
-          echo "Deleting the following tags:"
-          echo "$TO_DELETE" | awk '{print $2}'
-
-          if [ -z "$TO_DELETE" ]; then
-            echo "No tags to delete."
-            exit 0
-          fi
-
-          FAILED_DELETIONS=""
-          while read -r line; do
-            id=$(echo "$line" | awk '{print $1}')
-            tag=$(echo "$line" | awk '{print $2}')
-            echo "Deleting tag $tag (version ID $id)"
-            if ! gh api -X DELETE -H "Accept: application/vnd.github+json" \
-              /orgs/${{ env.ORG }}/packages/container/${{ env.IMAGE_NAME }}/versions/$id; then
-              echo "Failed to delete version $id ($tag)"
-              FAILED_DELETIONS="${FAILED_DELETIONS}\n$id ($tag)"
-            fi
-          done <<< "$TO_DELETE"
-
-          if [ -n "$FAILED_DELETIONS" ]; then
-            echo -e "The following deletions failed:\n$FAILED_DELETIONS"
-            exit 1
-          fi
-      - name: List remaining ${{ env.TAG_PREFIX }}* tags and their version IDs (debug)
-        run: |
-          gh api -H "Accept: application/vnd.github+json" \
-            /orgs/${{ env.ORG }}/packages/container/${{ env.IMAGE_NAME }}/versions \
-            --paginate | jq -r '.[] | select(.metadata.container.tags[] | startswith("${{ env.TAG_PREFIX }}")) | "\(.id) \(.metadata.container.tags[])"' | grep '^.* ${{ env.TAG_PREFIX }}' | sort -k2 -r
+      - uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          dry-run: true
+          packages: ${{ env.IMAGE_NAME }}
+          delete-tags: main-*
+          delete-untagged: true
+          keep-n-tagged: ${{ env.KEEP_X_IMAGES }}
+          delete-ghost-images: true
+          delete-partial-images: true

--- a/.github/workflows/clean-main-images.yml
+++ b/.github/workflows/clean-main-images.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: '5 1 * * *'
   workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Dry run'
+        required: false
+        default: true
+        type: 'boolean'
 
 env:
   REGISTRY: ghcr.io
@@ -13,72 +19,15 @@ env:
   TAG_PREFIX: 'main-'
 
 jobs:
-  # clean:
-  #   name: 'Clean main images'
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     packages: write
-  #   env:
-  #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #   steps:
-  #     - name: List all ${{ env.TAG_PREFIX }} tags and their version IDs (debug)
-  #       run: |
-  #         gh api -H "Accept: application/vnd.github+json" \
-  #           /orgs/${{ env.ORG }}/packages/container/${{ env.IMAGE_NAME }}/versions \
-  #           --paginate | jq -r '.[] | select(.metadata.container.tags[] | startswith("${{ env.TAG_PREFIX }}")) | "\(.id) \(.metadata.container.tags[])"' | grep '^.* ${{ env.TAG_PREFIX }}' | sort -k2 -r
-
-  #     - name: Delete old ${{ env.TAG_PREFIX }}* tags using GitHub API, keep ${{ env.KEEP_X_IMAGES }}
-  #       run: |
-  #         set -e
-  #         set -o pipefail
-
-  #         # Get all ${{ env.TAG_PREFIX }}* tags and their version IDs, sorted by tag (descending)
-  #         VERSIONS=$(gh api -H "Accept: application/vnd.github+json" \
-  #           /orgs/${{ env.ORG }}/packages/container/${{ env.IMAGE_NAME }}/versions \
-  #           --paginate | jq -r '.[] | select(.metadata.container.tags[] | startswith("${{ env.TAG_PREFIX }}")) | "\(.id) \(.metadata.container.tags[])"' | grep '^.* ${{ env.TAG_PREFIX }}' | sort -k2 -r)
-
-  #         # Get the lines to delete (skip the first ${{ env.KEEP_X_IMAGES }} versions)
-  #         TO_DELETE=$(echo "$VERSIONS" | sed "1,${{ env.KEEP_X_IMAGES }}d")
-
-  #         echo "Deleting the following tags:"
-  #         echo "$TO_DELETE" | awk '{print $2}'
-
-  #         if [ -z "$TO_DELETE" ]; then
-  #           echo "No tags to delete."
-  #           exit 0
-  #         fi
-
-  #         FAILED_DELETIONS=""
-  #         while read -r line; do
-  #           id=$(echo "$line" | awk '{print $1}')
-  #           tag=$(echo "$line" | awk '{print $2}')
-  #           echo "Deleting tag $tag (version ID $id)"
-  #           if ! gh api -X DELETE -H "Accept: application/vnd.github+json" \
-  #             /orgs/${{ env.ORG }}/packages/container/${{ env.IMAGE_NAME }}/versions/$id; then
-  #             echo "Failed to delete version $id ($tag)"
-  #             FAILED_DELETIONS="${FAILED_DELETIONS}\n$id ($tag)"
-  #           fi
-  #         done <<< "$TO_DELETE"
-
-  #         if [ -n "$FAILED_DELETIONS" ]; then
-  #           echo -e "The following deletions failed:\n$FAILED_DELETIONS"
-  #           exit 1
-  #         fi
-  #     - name: List remaining ${{ env.TAG_PREFIX }}* tags and their version IDs (debug)
-  #       run: |
-  #         gh api -H "Accept: application/vnd.github+json" \
-  #           /orgs/${{ env.ORG }}/packages/container/${{ env.IMAGE_NAME }}/versions \
-  #           --paginate | jq -r '.[] | select(.metadata.container.tags[] | startswith("${{ env.TAG_PREFIX }}")) | "\(.id) \(.metadata.container.tags[])"' | grep '^.* ${{ env.TAG_PREFIX }}' | sort -k2 -r
-
-  delete-untagged-images:
-    name: Delete Untagged Images
+  clean:
+    name: Clean main images
     runs-on: ubuntu-latest
     permissions:
       packages: write
     steps:
       - uses: dataaxiom/ghcr-cleanup-action@v1
         with:
-          dry-run: true
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run == true }}
           packages: ${{ env.IMAGE_NAME }}
           delete-tags: main-*
           delete-untagged: true

--- a/.github/workflows/clean-main-images.yml
+++ b/.github/workflows/clean-main-images.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: dataaxiom/ghcr-cleanup-action@v1
         with:
-          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run == 'true' }}
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true' }}
           packages: ${{ env.IMAGE_NAME }}
           delete-tags: main-*
           delete-untagged: true

--- a/.github/workflows/clean-main-images.yml
+++ b/.github/workflows/clean-main-images.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: dataaxiom/ghcr-cleanup-action@v1
         with:
-          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run == true }}
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run == 'true' }}
           packages: ${{ env.IMAGE_NAME }}
           delete-tags: main-*
           delete-untagged: true


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request updates the GitHub Actions workflow for cleaning up container images, simplifying the implementation and adding flexibility for manual executions. The most important changes include introducing a dry-run option for workflow dispatch events and replacing custom cleanup logic with a reusable GitHub Action.

### Enhancements to workflow flexibility:

* Added a `dry-run` input to the `workflow_dispatch` event, allowing users to test the cleanup process without making actual changes. The input is optional, defaults to `true`, and is of type `boolean`. (`.github/workflows/clean-main-images.yml`, [.github/workflows/clean-main-images.ymlR7-R12](diffhunk://#diff-15ffe2de44cb81acc36dddc3de6f50588f3e761a2ad0fad31d3a5d2d1380ed3cR7-R12))

### Simplification of cleanup logic:

* Replaced the custom shell script for cleaning up container images with the `dataaxiom/ghcr-cleanup-action@v1` GitHub Action. This action handles deleting tags, untagged images, ghost images, and partial images, while respecting the `dry-run` input and keeping a specified number of tagged images.



