### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,6 +13,8 @@ env:
 jobs:
   run-build:
     uses: ./.github/workflows/build.yaml
+    permissions:
+      contents: read
 
   build:
     name: Build


### PR DESCRIPTION
Potential fix for [https://github.com/openmcp-project/ui-frontend/security/code-scanning/4](https://github.com/openmcp-project/ui-frontend/security/code-scanning/4)

To fix the issue, add a `permissions` block to the `run-build` job in the `.github/workflows/main.yaml` file. This block should specify the least privileges required for the job to function correctly. Since the exact requirements of the `run-build` job are not provided, a minimal starting point can be used, such as `contents: read`. This ensures the job has only read access to the repository contents unless additional permissions are explicitly required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
