### PR TITLE
fix: encrypted session race condition

### DIFF
--- a/server/plugins/auth-utils.js
+++ b/server/plugins/auth-utils.js
@@ -77,7 +77,7 @@ async function authUtilsPlugin(fastify) {
     };
   });
 
-  fastify.decorate('prepareOidcLoginRedirect', (request, oidcConfig, authorizationEndpoint, stateKey) => {
+  fastify.decorate('prepareOidcLoginRedirect', async (request, oidcConfig, authorizationEndpoint, stateKey) => {
     if (stateKey === undefined) {
       stateKey = 'oauthState';
     }
@@ -88,7 +88,7 @@ async function authUtilsPlugin(fastify) {
       request.log.error(`Invalid redirectTo: "${redirectTo}".`);
       throw new AuthenticationError('Invalid redirectTo.');
     }
-    request.encryptedSession.set('postLoginRedirectRoute', redirectTo);
+    await request.encryptedSession.set('postLoginRedirectRoute', redirectTo);
 
     const { clientId, redirectUri, scopes } = oidcConfig;
 
@@ -96,8 +96,8 @@ async function authUtilsPlugin(fastify) {
     const codeVerifier = crypto.randomBytes(32).toString('base64url');
     const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url');
 
-    request.encryptedSession.set(stateKey, state);
-    request.encryptedSession.set('codeVerifier', codeVerifier);
+    await request.encryptedSession.set(stateKey, state);
+    await request.encryptedSession.set('codeVerifier', codeVerifier);
     request.log.info(
       {
         stateSet: Boolean(state),

--- a/server/plugins/http-proxy.js
+++ b/server/plugins/http-proxy.js
@@ -43,7 +43,7 @@ function proxyPlugin(fastify) {
       const refreshToken = request.encryptedSession.get(keyRefreshToken);
       if (!refreshToken) {
         request.log.error('Missing refresh token; deleting encryptedSession.');
-        request.encryptedSession.clear(); //TODO: also clear user encrpytion key?
+        await request.encryptedSession.clear(); //TODO: also clear user encrpytion key?
         return reply.unauthorized('Session expired without token refresh capability.');
       }
 
@@ -61,23 +61,23 @@ function proxyPlugin(fastify) {
         );
         if (!refreshedTokenData || !refreshedTokenData.accessToken) {
           request.log.error('Token refresh failed (no access token); deleting session.');
-          request.encryptedSession.clear(); //TODO: also clear user encrpytion key?
+          await request.encryptedSession.clear(); //TODO: also clear user encrpytion key?
           return reply.unauthorized('Session expired and token refresh failed.');
         }
 
         request.log.info('Token refresh successful; updating the session.');
 
-        request.encryptedSession.set(keyAccessToken, refreshedTokenData.accessToken);
+        await request.encryptedSession.set(keyAccessToken, refreshedTokenData.accessToken);
         if (refreshedTokenData.refreshToken) {
-          request.encryptedSession.set(keyRefreshToken, refreshedTokenData.refreshToken);
+          await request.encryptedSession.set(keyRefreshToken, refreshedTokenData.refreshToken);
         } else {
-          request.encryptedSession.delete(keyRefreshToken);
+          await request.encryptedSession.delete(keyRefreshToken);
         }
         if (refreshedTokenData.expiresIn) {
           const newExpiresAt = Date.now() + refreshedTokenData.expiresIn * 1000;
-          request.encryptedSession.set(keyTokenExpiresAt, newExpiresAt);
+          await request.encryptedSession.set(keyTokenExpiresAt, newExpiresAt);
         } else {
-          request.encryptedSession.delete(keyTokenExpiresAt);
+          await request.encryptedSession.delete(keyTokenExpiresAt);
         }
 
         request.log.info('Token refresh successful and session updated; continuing with the HTTP request.');

--- a/server/routes/auth-mcp.js
+++ b/server/routes/auth-mcp.js
@@ -12,7 +12,7 @@ async function authPlugin(fastify) {
   fastify.decorate('mcpIssuerConfiguration', mcpIssuerConfiguration);
 
   fastify.get('/auth/mcp/login', async function (req, reply) {
-    const redirectUri = fastify.prepareOidcLoginRedirect(
+    const redirectUri = await fastify.prepareOidcLoginRedirect(
       req,
       {
         clientId: OIDC_CLIENT_ID_MCP,
@@ -38,13 +38,13 @@ async function authPlugin(fastify) {
         stateSessionKey,
       );
 
-      req.encryptedSession.set('mcp_accessToken', callbackResult.accessToken);
-      req.encryptedSession.set('mcp_refreshToken', callbackResult.refreshToken);
+      await req.encryptedSession.set('mcp_accessToken', callbackResult.accessToken);
+      await req.encryptedSession.set('mcp_refreshToken', callbackResult.refreshToken);
 
       if (callbackResult.expiresAt) {
-        req.encryptedSession.set('mcp_tokenExpiresAt', callbackResult.expiresAt);
+        await req.encryptedSession.set('mcp_tokenExpiresAt', callbackResult.expiresAt);
       } else {
-        req.encryptedSession.delete('mcp_tokenExpiresAt');
+        await req.encryptedSession.delete('mcp_tokenExpiresAt');
       }
 
       return reply.redirect(POST_LOGIN_REDIRECT + callbackResult.postLoginRedirectRoute);
@@ -62,7 +62,7 @@ async function authPlugin(fastify) {
     const accessToken = req.encryptedSession.get('mcp_accessToken');
 
     const isAuthenticated = Boolean(accessToken);
-    reply.send({ isAuthenticated });
+    return reply.send({ isAuthenticated });
   });
 }
 

--- a/server/routes/auth-onboarding.js
+++ b/server/routes/auth-onboarding.js
@@ -11,7 +11,7 @@ async function authPlugin(fastify) {
   fastify.decorate('issuerConfiguration', issuerConfiguration);
 
   fastify.get('/auth/onboarding/login', async function (req, reply) {
-    const redirectUri = fastify.prepareOidcLoginRedirect(
+    const redirectUri = await fastify.prepareOidcLoginRedirect(
       req,
       {
         clientId: OIDC_CLIENT_ID,
@@ -37,14 +37,14 @@ async function authPlugin(fastify) {
         stateSessionKey,
       );
 
-      req.encryptedSession.set('onboarding_accessToken', callbackResult.accessToken);
-      req.encryptedSession.set('onboarding_refreshToken', callbackResult.refreshToken);
-      req.encryptedSession.set('onboarding_userInfo', callbackResult.userInfo);
+      await req.encryptedSession.set('onboarding_accessToken', callbackResult.accessToken);
+      await req.encryptedSession.set('onboarding_refreshToken', callbackResult.refreshToken);
+      await req.encryptedSession.set('onboarding_userInfo', callbackResult.userInfo);
 
       if (callbackResult.expiresAt) {
-        req.encryptedSession.set('onboarding_tokenExpiresAt', callbackResult.expiresAt);
+        await req.encryptedSession.set('onboarding_tokenExpiresAt', callbackResult.expiresAt);
       } else {
-        req.encryptedSession.delete('onboarding_tokenExpiresAt');
+        await req.encryptedSession.delete('onboarding_tokenExpiresAt');
       }
 
       return reply.redirect(POST_LOGIN_REDIRECT + callbackResult.postLoginRedirectRoute);
@@ -64,14 +64,13 @@ async function authPlugin(fastify) {
 
     const isAuthenticated = Boolean(accessToken);
     const user = isAuthenticated ? userInfo : null;
-
-    reply.send({ isAuthenticated, user });
+    return reply.send({ isAuthenticated, user });
   });
 
   fastify.post('/auth/logout', async function (req, reply) {
     // TODO: Idp sign out flow
-    req.encryptedSession.clear();
-    reply.send({ message: 'Logged out' });
+    await req.encryptedSession.clear();
+    return reply.send({ message: 'Logged out' });
   });
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We had a race condition when the session onSend hook was called before the encryptedSession onSend hook, therefore the session data was old and invalid.
This changes the encryptedSession implementation to be called on every save and therefore we dont have this order issue anymore

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

