### PR TITLE
fix: wrong type in encrypted session

### DIFF
--- a/server/encrypted-session.js
+++ b/server/encrypted-session.js
@@ -66,7 +66,7 @@ function createStore(request) {
   if (!userEncryptionKey) {
     request.log.info({ plugin: 'encrypted-session' }, 'user-side encryption key not found, creating new one');
 
-    userEncryptionKey = generateSecureEncryptionKey();
+    userEncryptionKey = generateSecureEncryptionKey().toString('base64');
     setUserEncryptionKeyIntoUserCookie(request, userEncryptionKey);
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
`generateSecureEncryptionKey()` returns Buffer but is later loaded into `loadedEncryptionKey` from a base64 encoding. To fix this, we convert the generated random buffer to base64 encoded string to have the same control flow.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

