### PR TITLE
Activate linter in pipeline

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
       - name: Run Vitest Tests
         run: npm run test:vi
 

--- a/src/components/ComponentsSelection/ComponentsSelection.tsx
+++ b/src/components/ComponentsSelection/ComponentsSelection.tsx
@@ -28,23 +28,15 @@ export interface ComponentsSelectionProps {
   setComponentsList: (components: ComponentsListItem[]) => void;
 }
 
-export const ComponentsSelection: React.FC<ComponentsSelectionProps> = ({
-  componentsList,
-  setComponentsList,
-}) => {
+export const ComponentsSelection: React.FC<ComponentsSelectionProps> = ({ componentsList, setComponentsList }) => {
   const [searchTerm, setSearchTerm] = useState('');
   const { t } = useTranslation();
 
-  const selectedComponents = useMemo(
-    () => getSelectedComponents(componentsList),
-    [componentsList],
-  );
+  const selectedComponents = useMemo(() => getSelectedComponents(componentsList), [componentsList]);
 
   const searchResults = useMemo(() => {
     const lowerSearch = searchTerm.toLowerCase();
-    return componentsList.filter(({ name }) =>
-      name.toLowerCase().includes(lowerSearch),
-    );
+    return componentsList.filter(({ name }) => name.toLowerCase().includes(lowerSearch));
   }, [componentsList, searchTerm]);
 
   const handleSelectionChange = useCallback(
@@ -53,9 +45,7 @@ export const ComponentsSelection: React.FC<ComponentsSelectionProps> = ({
       if (!id) return;
       setComponentsList(
         componentsList.map((component) =>
-          component.name === id
-            ? { ...component, isSelected: !component.isSelected }
-            : component,
+          component.name === id ? { ...component, isSelected: !component.isSelected } : component,
         ),
       );
     },
@@ -74,9 +64,7 @@ export const ComponentsSelection: React.FC<ComponentsSelectionProps> = ({
       if (!name) return;
       setComponentsList(
         componentsList.map((component) =>
-          component.name === name
-            ? { ...component, selectedVersion: version || '' }
-            : component,
+          component.name === name ? { ...component, selectedVersion: version || '' } : component,
         ),
       );
     },
@@ -86,9 +74,7 @@ export const ComponentsSelection: React.FC<ComponentsSelectionProps> = ({
   const isProviderDisabled = useCallback(
     (component: ComponentsListItem) => {
       if (!component.name?.includes('provider')) return false;
-      const crossplane = componentsList.find(
-        ({ name }) => name === 'crossplane',
-      );
+      const crossplane = componentsList.find(({ name }) => name === 'crossplane');
       return crossplane?.isSelected === false;
     },
     [componentsList],
@@ -130,11 +116,7 @@ export const ComponentsSelection: React.FC<ComponentsSelectionProps> = ({
                     aria-label={component.name}
                     onChange={handleSelectionChange}
                   />
-                  <FlexBox
-                    gap={10}
-                    justifyContent="SpaceBetween"
-                    alignItems="Baseline"
-                  >
+                  <FlexBox gap={10} justifyContent="SpaceBetween" alignItems="Baseline">
                     {/* TODO: Add documentation link */}
                     {component.documentationUrl && (
                       <Button

--- a/src/components/ComponentsSelection/ComponentsSelectionContainer.tsx
+++ b/src/components/ComponentsSelection/ComponentsSelectionContainer.tsx
@@ -5,7 +5,7 @@ import IllustratedError from '../Shared/IllustratedError.tsx';
 import { sortVersions } from '../../utils/componentsVersions.ts';
 
 import { ListManagedComponents } from '../../lib/api/types/crate/listManagedComponents.ts';
-import useApiResource from '../../lib/api/useApiResource.ts';
+import { useApiResource } from '../../lib/api/useApiResource.ts';
 import Loading from '../Shared/Loading.tsx';
 import { ComponentsListItem, removeComponents } from '../../lib/api/types/crate/createManagedControlPlane.ts';
 import { useTranslation } from 'react-i18next';

--- a/src/components/ControlPlane/ComponentList.tsx
+++ b/src/components/ControlPlane/ComponentList.tsx
@@ -1,7 +1,4 @@
-import {
-  AnalyticalTable,
-  AnalyticalTableColumnDefinition,
-} from '@ui5/webcomponents-react';
+import { AnalyticalTable, AnalyticalTableColumnDefinition } from '@ui5/webcomponents-react';
 import { ControlPlaneType } from '../../lib/api/types/crate/controlPlanes';
 import { useTranslation } from 'react-i18next';
 

--- a/src/components/ControlPlane/FluxList.tsx
+++ b/src/components/ControlPlane/FluxList.tsx
@@ -1,7 +1,7 @@
 import ConfiguredAnalyticstable from '../Shared/ConfiguredAnalyticsTable.tsx';
 import { AnalyticalTableColumnDefinition, FlexBox, Title } from '@ui5/webcomponents-react';
 import IllustratedError from '../Shared/IllustratedError.tsx';
-import useResource from '../../lib/api/useApiResource';
+import { useApiResource } from '../../lib/api/useApiResource';
 import { FluxRequest } from '../../lib/api/types/flux/listGitRepo';
 import { FluxKustomization, KustomizationsResponse } from '../../lib/api/types/flux/listKustomization';
 import { useTranslation } from 'react-i18next';
@@ -12,12 +12,12 @@ import { useMemo } from 'react';
 import StatusFilter from '../Shared/StatusFilter/StatusFilter.tsx';
 
 export default function FluxList() {
-  const { data: gitReposData, error: repoErr, isLoading: repoIsLoading } = useResource(FluxRequest); //404 if component not enabled
+  const { data: gitReposData, error: repoErr, isLoading: repoIsLoading } = useApiResource(FluxRequest); //404 if component not enabled
   const {
     data: kustmizationData,
     error: kustomizationErr,
     isLoading: kustomizationIsLoading,
-  } = useResource(FluxKustomization); //404 if component not enabled
+  } = useApiResource(FluxKustomization); //404 if component not enabled
 
   const { t } = useTranslation();
 
@@ -80,7 +80,7 @@ export default function FluxList() {
         ),
       },
     ],
-    [],
+    [t],
   );
 
   const kustomizationsColumns: AnalyticalTableColumnDefinition[] = useMemo(
@@ -120,7 +120,7 @@ export default function FluxList() {
         Cell: (cellData: CellData<FluxRow>) => <YamlViewButton resourceObject={cellData.cell.row.original?.item} />,
       },
     ],
-    [],
+    [t],
   );
 
   if (repoErr || kustomizationErr) {

--- a/src/components/ControlPlane/FluxList.tsx
+++ b/src/components/ControlPlane/FluxList.tsx
@@ -1,16 +1,9 @@
 import ConfiguredAnalyticstable from '../Shared/ConfiguredAnalyticsTable.tsx';
-import {
-  AnalyticalTableColumnDefinition,
-  FlexBox,
-  Title,
-} from '@ui5/webcomponents-react';
+import { AnalyticalTableColumnDefinition, FlexBox, Title } from '@ui5/webcomponents-react';
 import IllustratedError from '../Shared/IllustratedError.tsx';
 import useResource from '../../lib/api/useApiResource';
 import { FluxRequest } from '../../lib/api/types/flux/listGitRepo';
-import {
-  FluxKustomization,
-  KustomizationsResponse,
-} from '../../lib/api/types/flux/listKustomization';
+import { FluxKustomization, KustomizationsResponse } from '../../lib/api/types/flux/listKustomization';
 import { useTranslation } from 'react-i18next';
 import { timeAgo } from '../../utils/i18n/timeAgo.ts';
 import { ResourceStatusCell } from '../Shared/ResourceStatusCell.tsx';
@@ -19,11 +12,7 @@ import { useMemo } from 'react';
 import StatusFilter from '../Shared/StatusFilter/StatusFilter.tsx';
 
 export default function FluxList() {
-  const {
-    data: gitReposData,
-    error: repoErr,
-    isLoading: repoIsLoading,
-  } = useResource(FluxRequest); //404 if component not enabled
+  const { data: gitReposData, error: repoErr, isLoading: repoIsLoading } = useResource(FluxRequest); //404 if component not enabled
   const {
     data: kustmizationData,
     error: kustomizationErr,
@@ -75,9 +64,7 @@ export default function FluxList() {
             <ResourceStatusCell
               value={cellData.cell.row.original?.isReady}
               transitionTime={
-                cellData.cell.row.original?.statusUpdateTime
-                  ? cellData.cell.row.original?.statusUpdateTime
-                  : ''
+                cellData.cell.row.original?.statusUpdateTime ? cellData.cell.row.original?.statusUpdateTime : ''
               }
             />
           ) : null,
@@ -118,9 +105,7 @@ export default function FluxList() {
             <ResourceStatusCell
               value={cellData.cell.row.original?.isReady}
               transitionTime={
-                cellData.cell.row.original?.statusUpdateTime
-                  ? cellData.cell.row.original?.statusUpdateTime
-                  : ''
+                cellData.cell.row.original?.statusUpdateTime ? cellData.cell.row.original?.statusUpdateTime : ''
               }
             />
           ) : null,
@@ -132,9 +117,7 @@ export default function FluxList() {
         width: 85,
         accessor: 'yaml',
         disableFilters: true,
-        Cell: (cellData: CellData<FluxRow>) => (
-          <YamlViewButton resourceObject={cellData.cell.row.original?.item} />
-        ),
+        Cell: (cellData: CellData<FluxRow>) => <YamlViewButton resourceObject={cellData.cell.row.original?.item} />,
       },
     ],
     [],
@@ -143,11 +126,7 @@ export default function FluxList() {
   if (repoErr || kustomizationErr) {
     return (
       <IllustratedError
-        details={
-          repoErr?.message ||
-          kustomizationErr?.message ||
-          t('FluxList.undefinedError')
-        }
+        details={repoErr?.message || kustomizationErr?.message || t('FluxList.undefinedError')}
         title={t('FluxList.noFluxError')}
       />
     );
@@ -157,12 +136,8 @@ export default function FluxList() {
     gitReposData?.items?.map((item) => {
       return {
         name: item.metadata.name,
-        isReady:
-          item?.status?.conditions?.find((x) => x.type === 'Ready')?.status ===
-          'True',
-        statusUpdateTime: item.status?.conditions?.find(
-          (x) => x.type === 'Ready',
-        )?.lastTransitionTime,
+        isReady: item?.status?.conditions?.find((x) => x.type === 'Ready')?.status === 'True',
+        statusUpdateTime: item.status?.conditions?.find((x) => x.type === 'Ready')?.lastTransitionTime,
         revision: shortenCommitHash(item.status.artifact?.revision ?? '-'),
         created: timeAgo.format(new Date(item.metadata.creationTimestamp)),
         item: item,
@@ -173,12 +148,8 @@ export default function FluxList() {
     kustmizationData?.items?.map((item) => {
       return {
         name: item.metadata.name,
-        isReady:
-          item.status?.conditions?.find((x) => x.type === 'Ready')?.status ===
-          'True',
-        statusUpdateTime: item.status?.conditions?.find(
-          (x) => x.type === 'Ready',
-        )?.lastTransitionTime,
+        isReady: item.status?.conditions?.find((x) => x.type === 'Ready')?.status === 'True',
+        statusUpdateTime: item.status?.conditions?.find((x) => x.type === 'Ready')?.lastTransitionTime,
         created: timeAgo.format(new Date(item.metadata.creationTimestamp)),
         item: item,
       };
@@ -191,11 +162,7 @@ export default function FluxList() {
           <Title level="H4">{t('FluxList.gitOpsTitle')}</Title>
           <YamlViewButton resourceObject={gitReposData} />
         </FlexBox>
-        <ConfiguredAnalyticstable
-          columns={gitReposColumns}
-          isLoading={repoIsLoading}
-          data={gitReposRows}
-        />
+        <ConfiguredAnalyticstable columns={gitReposColumns} isLoading={repoIsLoading} data={gitReposRows} />
       </div>
       <div className="crossplane-table-element">
         <FlexBox justifyContent={'Start'} alignItems={'Center'} gap={'0.5em'}>

--- a/src/components/ControlPlane/Landscapers.tsx
+++ b/src/components/ControlPlane/Landscapers.tsx
@@ -9,22 +9,11 @@ import {
 } from '@ui5/webcomponents-react';
 import { useState, JSX } from 'react';
 import { resourcesInterval } from '../../lib/shared/constants';
-import useResource, {
-  useMultipleApiResources,
-} from '../../lib/api/useApiResource';
+import useResource, { useMultipleApiResources } from '../../lib/api/useApiResource';
 import { ListNamespaces } from '../../lib/api/types/k8s/listNamespaces';
-import {
-  Installation,
-  InstallationsRequest,
-} from '../../lib/api/types/landscaper/listInstallations';
-import {
-  Execution,
-  ExecutionsRequest,
-} from '../../lib/api/types/landscaper/listExecutions';
-import {
-  DeployItem,
-  DeployItemsRequest,
-} from '../../lib/api/types/landscaper/listDeployItems';
+import { Installation, InstallationsRequest } from '../../lib/api/types/landscaper/listInstallations';
+import { Execution, ExecutionsRequest } from '../../lib/api/types/landscaper/listExecutions';
+import { DeployItem, DeployItemsRequest } from '../../lib/api/types/landscaper/listDeployItems';
 
 import { MultiComboBoxSelectionChangeEventDetail } from '@ui5/webcomponents/dist/MultiComboBox.js';
 
@@ -37,27 +26,13 @@ export function Landscapers() {
 
   const [selectedNamespaces, setSelectedNamespaces] = useState<string[]>([]);
 
-  const { data: installations = [] } = useMultipleApiResources<Installation>(
-    selectedNamespaces,
-    InstallationsRequest,
-  );
+  const { data: installations = [] } = useMultipleApiResources<Installation>(selectedNamespaces, InstallationsRequest);
 
-  const { data: executions = [] } = useMultipleApiResources<Execution>(
-    selectedNamespaces,
-    ExecutionsRequest,
-  );
+  const { data: executions = [] } = useMultipleApiResources<Execution>(selectedNamespaces, ExecutionsRequest);
 
-  const { data: deployItems = [] } = useMultipleApiResources<DeployItem>(
-    selectedNamespaces,
-    DeployItemsRequest,
-  );
+  const { data: deployItems = [] } = useMultipleApiResources<DeployItem>(selectedNamespaces, DeployItemsRequest);
 
-  const handleSelectionChange = (
-    e: Ui5CustomEvent<
-      MultiComboBoxDomRef,
-      MultiComboBoxSelectionChangeEventDetail
-    >,
-  ) => {
+  const handleSelectionChange = (e: Ui5CustomEvent<MultiComboBoxDomRef, MultiComboBoxSelectionChangeEventDetail>) => {
     const selectedItems = Array.from(e.detail.items || []);
     const selectedValues = selectedItems
       .map((item) => item.text)
@@ -85,9 +60,7 @@ export function Landscapers() {
       (installation.status?.subInstCache?.activeSubs
         ?.map((sub) =>
           installations.find(
-            (i) =>
-              i.metadata.name === sub.objectName &&
-              i.metadata.namespace === installation.metadata.namespace,
+            (i) => i.metadata.name === sub.objectName && i.metadata.namespace === installation.metadata.namespace,
           ),
         )
         .filter(Boolean) as Installation[]) || [];
@@ -102,9 +75,7 @@ export function Landscapers() {
       (execution?.status?.deployItemCache?.activeDIs
         ?.map((di) =>
           deployItems.find(
-            (item) =>
-              item.metadata.name === di.objectName &&
-              item.metadata.namespace === execution.metadata.namespace,
+            (item) => item.metadata.name === di.objectName && item.metadata.namespace === execution.metadata.namespace,
           ),
         )
         .filter(Boolean) as DeployItem[]) || [];
@@ -154,8 +125,7 @@ export function Landscapers() {
     return !installations.some((parent) =>
       parent.status?.subInstCache?.activeSubs?.some(
         (sub: { objectName: string }) =>
-          sub.objectName === inst.metadata.name &&
-          parent.metadata.namespace === inst.metadata.namespace,
+          sub.objectName === inst.metadata.name && parent.metadata.namespace === inst.metadata.namespace,
       ),
     );
   });

--- a/src/components/ControlPlane/Landscapers.tsx
+++ b/src/components/ControlPlane/Landscapers.tsx
@@ -9,7 +9,7 @@ import {
 } from '@ui5/webcomponents-react';
 import { useState, JSX } from 'react';
 import { resourcesInterval } from '../../lib/shared/constants';
-import useResource, { useMultipleApiResources } from '../../lib/api/useApiResource';
+import { useApiResource, useMultipleApiResources } from '../../lib/api/useApiResource';
 import { ListNamespaces } from '../../lib/api/types/k8s/listNamespaces';
 import { Installation, InstallationsRequest } from '../../lib/api/types/landscaper/listInstallations';
 import { Execution, ExecutionsRequest } from '../../lib/api/types/landscaper/listExecutions';
@@ -20,7 +20,7 @@ import { MultiComboBoxSelectionChangeEventDetail } from '@ui5/webcomponents/dist
 export function Landscapers() {
   const { t } = useTranslation();
 
-  const { data: namespaces } = useResource(ListNamespaces, {
+  const { data: namespaces } = useApiResource(ListNamespaces, {
     refreshInterval: resourcesInterval,
   });
 

--- a/src/components/ControlPlane/MCPHealthPopoverButton.tsx
+++ b/src/components/ControlPlane/MCPHealthPopoverButton.tsx
@@ -1,19 +1,9 @@
-import {
-  AnalyticalTable,
-  Icon,
-  Popover,
-  FlexBox,
-  FlexBoxJustifyContent,
-  Button,
-} from '@ui5/webcomponents-react';
+import { AnalyticalTable, Icon, Popover, FlexBox, FlexBoxJustifyContent, Button } from '@ui5/webcomponents-react';
 import { AnalyticalTableColumnDefinition } from '@ui5/webcomponents-react/wrappers';
 import PopoverPlacement from '@ui5/webcomponents/dist/types/PopoverPlacement.js';
 import '@ui5/webcomponents-icons/dist/copy';
 import { JSX, useRef, useState } from 'react';
-import {
-  ControlPlaneStatusType,
-  ReadyStatus,
-} from '../../lib/api/types/crate/controlPlanes';
+import { ControlPlaneStatusType, ReadyStatus } from '../../lib/api/types/crate/controlPlanes';
 import ReactTimeAgo from 'react-time-ago';
 import { AnimatedHoverTextButton } from '../Helper/AnimatedHoverTextButton.tsx';
 import { useTranslation } from 'react-i18next';
@@ -67,10 +57,8 @@ export default function MCPHealthPopoverButton({
         mcpStatus?.conditions
           .map((condition) => {
             let text = `- ${condition.type}: ${condition.status}\n`;
-            if (condition.reason)
-              text += `  - ${t('MCPHealthPopoverButton.reasonHeader')}: ${condition.reason}\n`;
-            if (condition.message)
-              text += `  - ${t('MCPHealthPopoverButton.messageHeader')}: ${condition.message}\n`;
+            if (condition.reason) text += `  - ${t('MCPHealthPopoverButton.reasonHeader')}: ${condition.reason}\n`;
+            if (condition.message) text += `  - ${t('MCPHealthPopoverButton.messageHeader')}: ${condition.message}\n`;
             return text;
           })
           .join('')
@@ -189,14 +177,9 @@ function StatusTable({
           }) ?? []
         }
       />
-      <FlexBox
-        justifyContent={FlexBoxJustifyContent.End}
-        style={{ marginTop: '0.5rem' }}
-      >
+      <FlexBox justifyContent={FlexBoxJustifyContent.End} style={{ marginTop: '0.5rem' }}>
         <a href={githubIssuesLink} target="_blank" rel="noreferrer">
-          <Button>
-            {t('MCPHealthPopoverButton.createSupportTicketButton')}
-          </Button>
+          <Button>{t('MCPHealthPopoverButton.createSupportTicketButton')}</Button>
         </a>
       </FlexBox>
     </div>

--- a/src/components/ControlPlane/ManagedResources.tsx
+++ b/src/components/ControlPlane/ManagedResources.tsx
@@ -110,12 +110,8 @@ export function ManagedResources() {
       ?.filter((managedResource) => managedResource.items)
       .flatMap((managedResource) =>
         managedResource.items?.map((item) => {
-          const conditionSynced = item.status?.conditions?.find(
-            (condition) => condition.type === 'Synced',
-          );
-          const conditionReady = item.status?.conditions?.find(
-            (condition) => condition.type === 'Ready',
-          );
+          const conditionSynced = item.status?.conditions?.find((condition) => condition.type === 'Synced');
+          const conditionReady = item.status?.conditions?.find((condition) => condition.type === 'Ready');
 
           return {
             kind: item.kind,

--- a/src/components/ControlPlane/ManagedResources.tsx
+++ b/src/components/ControlPlane/ManagedResources.tsx
@@ -5,7 +5,7 @@ import {
   AnalyticalTableScaleWidthMode,
   Title,
 } from '@ui5/webcomponents-react';
-import useResource from '../../lib/api/useApiResource';
+import { useApiResource } from '../../lib/api/useApiResource';
 import { ManagedResourcesRequest } from '../../lib/api/types/crossplane/listManagedResources';
 import { timeAgo } from '../../utils/i18n/timeAgo';
 import IllustratedError from '../Shared/IllustratedError';
@@ -44,7 +44,7 @@ export function ManagedResources() {
     data: managedResources,
     error,
     isLoading,
-  } = useResource(ManagedResourcesRequest, {
+  } = useApiResource(ManagedResourcesRequest, {
     refreshInterval: resourcesInterval, // Resources are quite expensive to fetch, so we refresh every 30 seconds
   });
 
@@ -102,7 +102,7 @@ export function ManagedResources() {
           ) : undefined,
       },
     ],
-    [],
+    [t],
   );
 
   const rows: ResourceRow[] =

--- a/src/components/ControlPlane/Providers.tsx
+++ b/src/components/ControlPlane/Providers.tsx
@@ -75,9 +75,7 @@ export function Providers() {
           cellData.cell.row.original?.installed != null ? (
             <ResourceStatusCell
               value={cellData.cell.row.original?.installed === 'true'}
-              transitionTime={
-                cellData.cell.row.original?.installedTransitionTime
-              }
+              transitionTime={cellData.cell.row.original?.installedTransitionTime}
             />
           ) : null,
       },
@@ -112,12 +110,8 @@ export function Providers() {
 
   const rows: ProvidersRow[] =
     providers?.items?.map((item) => {
-      const installed = item.status?.conditions?.find(
-        (condition) => condition.type === 'Installed',
-      );
-      const healthy = item.status?.conditions?.find(
-        (condition) => condition.type === 'Healthy',
-      );
+      const installed = item.status?.conditions?.find((condition) => condition.type === 'Installed');
+      const healthy = item.status?.conditions?.find((condition) => condition.type === 'Healthy');
       return {
         name: item.metadata.name,
         created: timeAgo.format(new Date(item.metadata.creationTimestamp)),

--- a/src/components/ControlPlane/Providers.tsx
+++ b/src/components/ControlPlane/Providers.tsx
@@ -7,7 +7,7 @@ import {
   Title,
 } from '@ui5/webcomponents-react';
 
-import useResource from '../../lib/api/useApiResource';
+import { useApiResource } from '../../lib/api/useApiResource';
 import IllustratedError from '../Shared/IllustratedError';
 import { ProvidersListRequest } from '../../lib/api/types/crossplane/listProviders';
 import { resourcesInterval } from '../../lib/shared/constants';
@@ -46,7 +46,7 @@ export function Providers() {
     data: providers,
     error,
     isLoading,
-  } = useResource(ProvidersListRequest, {
+  } = useApiResource(ProvidersListRequest, {
     refreshInterval: resourcesInterval,
   });
 

--- a/src/components/ControlPlane/ProvidersConfig.tsx
+++ b/src/components/ControlPlane/ProvidersConfig.tsx
@@ -83,7 +83,7 @@ export function ProvidersConfig() {
           ) : undefined,
       },
     ],
-    [],
+    [t],
   );
 
   return (

--- a/src/components/ControlPlane/ProvidersConfig.tsx
+++ b/src/components/ControlPlane/ProvidersConfig.tsx
@@ -79,9 +79,7 @@ export function ProvidersConfig() {
         disableFilters: true,
         Cell: (cellData: CellData<Rows>) =>
           cellData.cell.row.original?.resource ? (
-            <YamlViewButton
-              resourceObject={cellData.cell.row.original?.resource}
-            />
+            <YamlViewButton resourceObject={cellData.cell.row.original?.resource} />
           ) : undefined,
       },
     ],

--- a/src/components/ControlPlanes/ConnectButton.tsx
+++ b/src/components/ControlPlanes/ConnectButton.tsx
@@ -36,9 +36,7 @@ export default function ConnectButton(props: Props) {
 
   const { t } = useTranslation();
 
-  const res = useResource(
-    GetKubeconfig(props.secretKey, props.secretName, props.namespace),
-  );
+  const res = useResource(GetKubeconfig(props.secretKey, props.secretName, props.namespace));
   if (res.isLoading) {
     return <></>;
   }
@@ -72,12 +70,7 @@ export default function ConnectButton(props: Props) {
 
   return (
     <div>
-      <Button
-        disabled={props.disabled}
-        icon="slim-arrow-down"
-        icon-end
-        onClick={handleOpenerClick}
-      >
+      <Button disabled={props.disabled} icon="slim-arrow-down" icon-end onClick={handleOpenerClick}>
         {t('ConnectButton.buttonText')}
       </Button>
       <Menu
@@ -103,18 +96,12 @@ export default function ConnectButton(props: Props) {
               props.workspaceName,
             )}/mcps/${props.controlPlaneName}/context/${context.name}`}
             additionalText={`(${
-              context.context.user === 'openmcp'
-                ? t('ConnectButton.defaultIdP')
-                : t('ConnectButton.unsupportedIdP')
+              context.context.user === 'openmcp' ? t('ConnectButton.defaultIdP') : t('ConnectButton.unsupportedIdP')
             })`}
             disabled={context.context.user !== 'openmcp'}
           />
         ))}
-        <MenuItem
-          key={'download'}
-          text={'Download Kubeconfig'}
-          data-action="download"
-        />
+        <MenuItem key={'download'} text={'Download Kubeconfig'} data-action="download" />
       </Menu>
     </div>
   );

--- a/src/components/ControlPlanes/ConnectButton.tsx
+++ b/src/components/ControlPlanes/ConnectButton.tsx
@@ -6,7 +6,7 @@ import { GetKubeconfig } from '../../lib/api/types/crate/getKubeconfig.ts';
 import yaml from 'js-yaml';
 import { useRef, useState } from 'react';
 import { DownloadKubeconfig } from './CopyKubeconfigButton.tsx';
-import useResource from '../../lib/api/useApiResource.ts';
+import { useApiResource } from '../../lib/api/useApiResource.ts';
 import { extractWorkspaceNameFromNamespace } from '../../utils/index.ts';
 import { useTranslation } from 'react-i18next';
 
@@ -36,7 +36,7 @@ export default function ConnectButton(props: Props) {
 
   const { t } = useTranslation();
 
-  const res = useResource(GetKubeconfig(props.secretKey, props.secretName, props.namespace));
+  const res = useApiResource(GetKubeconfig(props.secretKey, props.secretName, props.namespace));
   if (res.isLoading) {
     return <></>;
   }

--- a/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCard.tsx
+++ b/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCard.tsx
@@ -12,14 +12,9 @@ import { DeleteConfirmationDialog } from '../../Dialogs/DeleteConfirmationDialog
 import MCPHealthPopoverButton from '../../ControlPlane/MCPHealthPopoverButton.tsx';
 import styles from './ControlPlaneCard.module.css';
 import { KubectlDeleteMcp } from '../../Dialogs/KubectlCommandInfo/Controllers/KubectlDeleteMcp.tsx';
-import {
-  ListControlPlanesType,
-  ReadyStatus,
-} from '../../../lib/api/types/crate/controlPlanes.ts';
+import { ListControlPlanesType, ReadyStatus } from '../../../lib/api/types/crate/controlPlanes.ts';
 import { ListWorkspacesType } from '../../../lib/api/types/crate/listWorkspaces.ts';
-import {
-  useApiResourceMutation,
-} from '../../../lib/api/useApiResource.ts';
+import { useApiResourceMutation } from '../../../lib/api/useApiResource.ts';
 import {
   DeleteMCPResource,
   DeleteMCPType,
@@ -38,40 +33,26 @@ interface Props {
   projectName: string;
 }
 
-export function ControlPlaneCard({
-  controlPlane,
-  workspace,
-  projectName,
-}: Props) {
+export function ControlPlaneCard({ controlPlane, workspace, projectName }: Props) {
   const [dialogDeleteMcpIsOpen, setDialogDeleteMcpIsOpen] = useState(false);
   const toast = useToast();
   const { t } = useTranslation();
 
   const { trigger: patchTrigger } = useApiResourceMutation<DeleteMCPType>(
-    PatchMCPResourceForDeletion(
-      controlPlane.metadata.namespace,
-      controlPlane.metadata.name,
-    ),
+    PatchMCPResourceForDeletion(controlPlane.metadata.namespace, controlPlane.metadata.name),
   );
   const { trigger: deleteTrigger } = useApiResourceMutation<DeleteMCPType>(
-    DeleteMCPResource(
-      controlPlane.metadata.namespace,
-      controlPlane.metadata.name,
-    ),
+    DeleteMCPResource(controlPlane.metadata.namespace, controlPlane.metadata.name),
   );
 
   const name = controlPlane.metadata.name;
   const namespace = controlPlane.metadata.namespace;
 
-  const isSystemIdentityProviderEnabled =
-    Boolean(controlPlane.spec?.authentication?.enableSystemIdentityProvider);
+  const isSystemIdentityProviderEnabled = Boolean(controlPlane.spec?.authentication?.enableSystemIdentityProvider);
 
-  const isConnectButtonEnabled =
-    canConnectToMCP(controlPlane) &&
-    isSystemIdentityProviderEnabled
+  const isConnectButtonEnabled = canConnectToMCP(controlPlane) && isSystemIdentityProviderEnabled;
 
-  const showWarningBecauseOfDisabledSystemIdentityProvider =
-    !isSystemIdentityProviderEnabled;
+  const showWarningBecauseOfDisabledSystemIdentityProvider = !isSystemIdentityProviderEnabled;
 
   return (
     <>
@@ -92,28 +73,16 @@ export function ControlPlaneCard({
                 />
               </div>
             </FlexBox>
-            <FlexBox
-              direction="Row"
-              justifyContent="SpaceBetween"
-              alignItems="Center"
-              className={styles.row}
-            >
+            <FlexBox direction="Row" justifyContent="SpaceBetween" alignItems="Center" className={styles.row}>
               <Button
                 design={'Transparent'}
                 icon="delete"
-                disabled={
-                  controlPlane.status?.status === ReadyStatus.InDeletion
-                }
+                disabled={controlPlane.status?.status === ReadyStatus.InDeletion}
                 onClick={() => {
                   setDialogDeleteMcpIsOpen(true);
                 }}
               />
-              <FlexBox
-                direction="Row"
-                justifyContent="SpaceBetween"
-                alignItems="Center"
-                gap={10}
-              >
+              <FlexBox direction="Row" justifyContent="SpaceBetween" alignItems="Center" gap={10}>
                 <YamlViewButtonWithLoader
                   workspaceName={controlPlane.metadata.namespace}
                   resourceName={controlPlane.metadata.name}

--- a/src/components/ControlPlanes/ControlPlanesListMenu.tsx
+++ b/src/components/ControlPlanes/ControlPlanesListMenu.tsx
@@ -1,11 +1,4 @@
-import {
-  Button,
-  ButtonDomRef,
-  Menu,
-  MenuItem,
-  Ui5CustomEvent,
-  MenuDomRef,
-} from '@ui5/webcomponents-react';
+import { Button, ButtonDomRef, Menu, MenuItem, Ui5CustomEvent, MenuDomRef } from '@ui5/webcomponents-react';
 import type { ButtonClickEventDetail } from '@ui5/webcomponents/dist/Button.js';
 import { Dispatch, FC, SetStateAction, useRef, useState } from 'react';
 import '@ui5/webcomponents-icons/dist/copy';
@@ -27,9 +20,7 @@ export const ControlPlanesListMenu: FC<ControlPlanesListMenuProps> = ({
 
   const { t } = useTranslation();
 
-  const handleOpenerClick = (
-    e: Ui5CustomEvent<ButtonDomRef, ButtonClickEventDetail>,
-  ) => {
+  const handleOpenerClick = (e: Ui5CustomEvent<ButtonDomRef, ButtonClickEventDetail>) => {
     if (popoverRef.current && e.currentTarget) {
       popoverRef.current.opener = e.currentTarget as HTMLElement;
       setOpen((prev) => !prev);

--- a/src/components/ControlPlanes/CopyKubeconfigButton.tsx
+++ b/src/components/ControlPlanes/CopyKubeconfigButton.tsx
@@ -56,12 +56,7 @@ export default function CopyKubeconfigButton() {
           data-action="download"
           icon="download"
         />
-        <MenuItem
-          key={'copy'}
-          text={t('CopyKubeconfigButton.menuCopy')}
-          data-action="copy"
-          icon="copy"
-        />
+        <MenuItem key={'copy'} text={t('CopyKubeconfigButton.menuCopy')} data-action="copy" icon="copy" />
       </Menu>
     </>
   );

--- a/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.tsx
@@ -17,9 +17,7 @@ interface Props {
 
 export default function ControlPlaneListAllWorkspaces({ projectName }: Props) {
   const { workspaceCreationGuide } = useLink();
-  const { data: allWorkspaces, error } = useApiResource(
-    ListWorkspaces(projectName),
-  );
+  const { data: allWorkspaces, error } = useApiResource(ListWorkspaces(projectName));
 
   const { t } = useTranslation();
 
@@ -37,9 +35,7 @@ export default function ControlPlaneListAllWorkspaces({ projectName }: Props) {
           <IllustratedMessage
             name="EmptyList"
             titleText={t('ControlPlaneListAllWorkspaces.emptyListTitleMessage')}
-            subtitleText={t(
-              'ControlPlaneListAllWorkspaces.emptyListSubtitleMessage',
-            )}
+            subtitleText={t('ControlPlaneListAllWorkspaces.emptyListSubtitleMessage')}
           />
           <Button
             design={ButtonDesign.Emphasized}

--- a/src/components/ControlPlanes/List/ControlPlaneListToolbar.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListToolbar.tsx
@@ -3,11 +3,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CreateWorkspaceDialogContainer } from '../../Dialogs/CreateWorkspaceDialogContainer.tsx';
 
-export function ControlPlaneListToolbar({
-  projectName,
-}: {
-  projectName: string;
-}) {
+export function ControlPlaneListToolbar({ projectName }: { projectName: string }) {
   const [dialogCreateProjectIsOpen, setDialogIsOpen] = useState(false);
   const { t } = useTranslation();
 

--- a/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
@@ -1,30 +1,14 @@
-import {
-  Button,
-  FlexBox,
-  Grid,
-  ObjectPageSection,
-  Panel,
-  Title,
-} from '@ui5/webcomponents-react';
+import { Button, FlexBox, Grid, ObjectPageSection, Panel, Title } from '@ui5/webcomponents-react';
 import '@ui5/webcomponents-fiori/dist/illustrations/NoData.js';
 import '@ui5/webcomponents-fiori/dist/illustrations/EmptyList.js';
 import '@ui5/webcomponents-icons/dist/delete';
 import { CopyButton } from '../../Shared/CopyButton.tsx';
 import { ControlPlaneCard } from '../ControlPlaneCard/ControlPlaneCard.tsx';
-import {
-  ListWorkspacesType,
-  isWorkspaceReady,
-} from '../../../lib/api/types/crate/listWorkspaces.ts';
+import { ListWorkspacesType, isWorkspaceReady } from '../../../lib/api/types/crate/listWorkspaces.ts';
 import { useState } from 'react';
 import { MembersAvatarView } from './MembersAvatarView.tsx';
-import {
-  DeleteWorkspaceResource,
-  DeleteWorkspaceType,
-} from '../../../lib/api/types/crate/deleteWorkspace.ts';
-import {
-  useApiResourceMutation,
-  useApiResource,
-} from '../../../lib/api/useApiResource.ts';
+import { DeleteWorkspaceResource, DeleteWorkspaceType } from '../../../lib/api/types/crate/deleteWorkspace.ts';
+import { useApiResourceMutation, useApiResource } from '../../../lib/api/useApiResource.ts';
 import { DISPLAY_NAME_ANNOTATION } from '../../../lib/api/types/shared/keyNames.ts';
 import { DeleteConfirmationDialog } from '../../Dialogs/DeleteConfirmationDialog.tsx';
 import { KubectlDeleteWorkspace } from '../../Dialogs/KubectlCommandInfo/Controllers/KubectlDeleteWorkspace.tsx';
@@ -46,17 +30,10 @@ interface Props {
   workspace: ListWorkspacesType;
 }
 
-export function ControlPlaneListWorkspaceGridTile({
-  projectName,
-  workspace,
-}: Props) {
-  const [
-    isCreateManagedControlPlaneWizardOpen,
-    setIsCreateManagedControlPlaneWizardOpen,
-  ] = useState(false);
+export function ControlPlaneListWorkspaceGridTile({ projectName, workspace }: Props) {
+  const [isCreateManagedControlPlaneWizardOpen, setIsCreateManagedControlPlaneWizardOpen] = useState(false);
   const workspaceName = workspace.metadata.name;
-  const workspaceDisplayName =
-    workspace.metadata.annotations?.[DISPLAY_NAME_ANNOTATION] || '';
+  const workspaceDisplayName = workspace.metadata.annotations?.[DISPLAY_NAME_ANNOTATION] || '';
   const showDisplayName = workspaceDisplayName.length > 0;
   const projectNamespace = workspace.metadata.namespace;
 
@@ -65,9 +42,7 @@ export function ControlPlaneListWorkspaceGridTile({
   const toast = useToast();
   const [dialogDeleteWsIsOpen, setDialogDeleteWsIsOpen] = useState(false);
 
-  const { data: controlplanes, error: cpsError } = useApiResource(
-    ListControlPlanes(projectName, workspaceName),
-  );
+  const { data: controlplanes, error: cpsError } = useApiResource(ListControlPlanes(projectName, workspaceName));
   const { trigger } = useApiResourceMutation<DeleteWorkspaceType>(
     DeleteWorkspaceResource(projectNamespace, workspaceName),
   );
@@ -80,20 +55,12 @@ export function ControlPlaneListWorkspaceGridTile({
       if (error.status === 403) {
         return (
           <IllustratedError
-            title={t(
-              'ControlPlaneListWorkspaceGridTile.permissionErrorMessage',
-            )}
-            details={t(
-              'ControlPlaneListWorkspaceGridTile.permissionErrorMessageSubtitle',
-            )}
+            title={t('ControlPlaneListWorkspaceGridTile.permissionErrorMessage')}
+            details={t('ControlPlaneListWorkspaceGridTile.permissionErrorMessageSubtitle')}
           />
         );
       } else {
-        return (
-          <IllustratedError
-            title={t('ControlPlaneListWorkspaceGridTile.loadingErrorMessage')}
-          />
-        );
+        return <IllustratedError title={t('ControlPlaneListWorkspaceGridTile.loadingErrorMessage')} />;
       }
     }
     return null;
@@ -126,16 +93,9 @@ export function ControlPlaneListWorkspaceGridTile({
                 {!isWorkspaceReady(workspace) ? '(Loading)' : ''}
               </Title>
 
-              <CopyButton
-                text={workspace.status?.namespace || '-'}
-                style={{ justifyContent: 'start' }}
-              />
+              <CopyButton text={workspace.status?.namespace || '-'} style={{ justifyContent: 'start' }} />
 
-              <MembersAvatarView
-                members={workspace.spec.members}
-                project={projectName}
-                workspace={workspaceName}
-              />
+              <MembersAvatarView members={workspace.spec.members} project={projectName} workspace={workspaceName} />
               <FlexBox justifyContent={'SpaceBetween'} gap={10}>
                 <YamlViewButtonWithLoader
                   workspaceName={workspace.metadata.namespace}
@@ -144,9 +104,7 @@ export function ControlPlaneListWorkspaceGridTile({
                 />
                 <ControlPlanesListMenu
                   setDialogDeleteWsIsOpen={setDialogDeleteWsIsOpen}
-                  setIsCreateManagedControlPlaneWizardOpen={
-                    setIsCreateManagedControlPlaneWizardOpen
-                  }
+                  setIsCreateManagedControlPlaneWizardOpen={setIsCreateManagedControlPlaneWizardOpen}
                 />
               </FlexBox>
             </div>
@@ -193,19 +151,12 @@ export function ControlPlaneListWorkspaceGridTile({
       </ObjectPageSection>
       <DeleteConfirmationDialog
         resourceName={workspaceName}
-        kubectl={
-          <KubectlDeleteWorkspace
-            projectName={projectName}
-            resourceName={workspaceName}
-          />
-        }
+        kubectl={<KubectlDeleteWorkspace projectName={projectName} resourceName={workspaceName} />}
         isOpen={dialogDeleteWsIsOpen}
         setIsOpen={setDialogDeleteWsIsOpen}
         onDeletionConfirmed={async () => {
           await trigger();
-          toast.show(
-            t('ControlPlaneListWorkspaceGridTile.deleteConfirmationDialog'),
-          );
+          toast.show(t('ControlPlaneListWorkspaceGridTile.deleteConfirmationDialog'));
         }}
       />
       <CreateManagedControlPlaneWizardContainer

--- a/src/components/ControlPlanes/List/MembersAvatarView.tsx
+++ b/src/components/ControlPlanes/List/MembersAvatarView.tsx
@@ -33,12 +33,7 @@ export function MembersAvatarView({ members, project, workspace }: Props) {
 
   return (
     <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-      <AvatarGroup
-        ref={openerRef}
-        style={{ maxWidth: '200px' }}
-        type={AvatarGroupType.Group}
-        onClick={handleOnClick}
-      >
+      <AvatarGroup ref={openerRef} style={{ maxWidth: '200px' }} type={AvatarGroupType.Group} onClick={handleOnClick}>
         {avatars}
       </AvatarGroup>
       <Popover

--- a/src/components/ControlPlanes/controlPlanes.ts
+++ b/src/components/ControlPlanes/controlPlanes.ts
@@ -3,15 +3,7 @@ import { ControlPlaneType } from '../../lib/api/types/crate/controlPlanes';
 export const canConnectToMCP = (controlPlane: ControlPlaneType): boolean => {
   const conditions = controlPlane.status?.conditions ?? [];
 
-  return [
-    'APIServerHealthy',
-    'AuthenticationHealthy',
-    'AuthorizationHealthy',
-  ].every((type) =>
-    conditions.some(
-      (condition) =>
-        condition.type === type &&
-        String(condition.status).toLowerCase() === 'true',
-    ),
+  return ['APIServerHealthy', 'AuthenticationHealthy', 'AuthorizationHealthy'].every((type) =>
+    conditions.some((condition) => condition.type === type && String(condition.status).toLowerCase() === 'true'),
   );
 };

--- a/src/components/Core/DarkModeSystemSwitcher.tsx
+++ b/src/components/Core/DarkModeSystemSwitcher.tsx
@@ -4,9 +4,7 @@ import { setTheme } from '@ui5/webcomponents-base/dist/config/Theme.js';
 export function DarkModeSystemSwitcher() {
   useEffect(() => {
     if (!window.matchMedia) {
-      console.warn(
-        'Dark mode system switcher is not supported in this browser',
-      );
+      console.warn('Dark mode system switcher is not supported in this browser');
       return;
     }
 

--- a/src/components/Core/IntelligentBreadcrumbs.tsx
+++ b/src/components/Core/IntelligentBreadcrumbs.tsx
@@ -1,8 +1,4 @@
-import {
-  Breadcrumbs,
-  BreadcrumbsDomRef,
-  Ui5CustomEvent,
-} from '@ui5/webcomponents-react';
+import { Breadcrumbs, BreadcrumbsDomRef, Ui5CustomEvent } from '@ui5/webcomponents-react';
 import { BreadcrumbsItem } from '@ui5/webcomponents-react/wrappers';
 import { NavigateOptions, useParams } from 'react-router-dom';
 import useLuigiNavigate from '../Shared/useLuigiNavigate.tsx';
@@ -11,9 +7,7 @@ import { useTranslation } from 'react-i18next';
 
 const PREFIX = '/mcp';
 
-function navigateFromBreadcrumbs(
-  navigate: (to: string, options?: NavigateOptions) => void,
-) {
+function navigateFromBreadcrumbs(navigate: (to: string, options?: NavigateOptions) => void) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (event: Ui5CustomEvent<BreadcrumbsDomRef, any>) => {
     event.preventDefault();
@@ -36,25 +30,15 @@ export default function IntelligentBreadcrumbs() {
         </BreadcrumbsItem>
         {projectName && (
           <>
-            <BreadcrumbsItem href={`${PREFIX}/projects`}>
-              Projects
-            </BreadcrumbsItem>
-            <BreadcrumbsItem href={`${PREFIX}/projects/${projectName}`}>
-              {projectName}
-            </BreadcrumbsItem>
+            <BreadcrumbsItem href={`${PREFIX}/projects`}>Projects</BreadcrumbsItem>
+            <BreadcrumbsItem href={`${PREFIX}/projects/${projectName}`}>{projectName}</BreadcrumbsItem>
             {workspaceName && (
               <>
-                <BreadcrumbsItem href={`${PREFIX}/projects/${projectName}`}>
-                  Workspaces
-                </BreadcrumbsItem>
-                <BreadcrumbsItem href={`${PREFIX}/projects/${projectName}`}>
-                  {workspaceName}
-                </BreadcrumbsItem>
+                <BreadcrumbsItem href={`${PREFIX}/projects/${projectName}`}>Workspaces</BreadcrumbsItem>
+                <BreadcrumbsItem href={`${PREFIX}/projects/${projectName}`}>{workspaceName}</BreadcrumbsItem>
                 {controlPlaneName && (
                   <>
-                    <BreadcrumbsItem href={`${PREFIX}/projects/${projectName}`}>
-                      MCPs
-                    </BreadcrumbsItem>
+                    <BreadcrumbsItem href={`${PREFIX}/projects/${projectName}`}>MCPs</BreadcrumbsItem>
                     <BreadcrumbsItem
                       href={`${PREFIX}/projects/${projectName}/workspaces/${workspaceName}/mcps/${controlPlaneName}`}
                     >

--- a/src/components/Core/ShellBar.tsx
+++ b/src/components/Core/ShellBar.tsx
@@ -22,14 +22,7 @@ import {
   Ui5CustomEvent,
 } from '@ui5/webcomponents-react';
 import { useAuthOnboarding } from '../../spaces/onboarding/auth/AuthContextOnboarding.tsx';
-import {
-  Dispatch,
-  RefObject,
-  SetStateAction,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { Dispatch, RefObject, SetStateAction, useEffect, useRef, useState } from 'react';
 import { ShellBarProfileClickEventDetail } from '@ui5/webcomponents-fiori/dist/ShellBar.js';
 import PopoverPlacement from '@ui5/webcomponents/dist/types/PopoverPlacement.js';
 import { useTranslation } from 'react-i18next';
@@ -55,9 +48,7 @@ export function ShellBarComponent() {
 
   const { user } = useAuthOnboarding();
 
-  const onProfileClick = (
-    e: Ui5CustomEvent<ShellBarDomRef, ShellBarProfileClickEventDetail>,
-  ) => {
+  const onProfileClick = (e: Ui5CustomEvent<ShellBarDomRef, ShellBarProfileClickEventDetail>) => {
     profilePopoverRef.current!.opener = e.detail.targetRef;
     setProfilePopoverOpen(!profilePopoverOpen);
   };
@@ -69,19 +60,12 @@ export function ShellBarComponent() {
     }
   };
 
-  const onFeedbackClick = (
-    e: Ui5CustomEvent<ShellBarItemDomRef, ShellBarItemClickEventDetail>,
-  ) => {
+  const onFeedbackClick = (e: Ui5CustomEvent<ShellBarItemDomRef, ShellBarItemClickEventDetail>) => {
     feedbackPopoverRef.current!.opener = e.detail.targetRef;
     setFeedbackPopoverOpen(!feedbackPopoverOpen);
   };
 
-  const onFeedbackMessageChange = (
-    event: Ui5CustomEvent<
-      TextAreaDomRef,
-      { value: string; previousValue: string }
-    >,
-  ) => {
+  const onFeedbackMessageChange = (event: Ui5CustomEvent<TextAreaDomRef, { value: string; previousValue: string }>) => {
     const newValue = event.target.value;
     setFeedbackMessage(newValue);
   };
@@ -110,9 +94,7 @@ export function ShellBarComponent() {
 
   useEffect(() => {
     const shellbar = document.querySelector('ui5-shellbar');
-    const el = shellbar?.shadowRoot?.querySelector(
-      '.ui5-shellbar-overflow-container-left',
-    );
+    const el = shellbar?.shadowRoot?.querySelector('.ui5-shellbar-overflow-container-left');
 
     if (el) {
       (el as HTMLElement).style.backgroundColor = 'red';
@@ -123,23 +105,14 @@ export function ShellBarComponent() {
     <>
       <ShellBar
         className={styles.TestShellbar}
-        profile={
-          <Avatar
-            initials={generateInitialsForEmail(auth.user?.email)}
-            size="XS"
-          />
-        }
+        profile={<Avatar initials={generateInitialsForEmail(auth.user?.email)} size="XS" />}
         startButton={
           <div className={styles.container}>
             <div className={styles.logoWrapper}>
               <img src="/logo.png" alt="MCP" className={styles.logo} />
               <span className={styles.logoText}>MCP</span>
             </div>
-            <Button
-              ref={betaButtonRef}
-              className={styles.betaButton}
-              onClick={onBetaClick}
-            >
+            <Button ref={betaButtonRef} className={styles.betaButton} onClick={onBetaClick}>
               <span className={styles.betaContent}>
                 <Icon name="information" className={styles.betaIcon} />
                 <span className={styles.betaText}>Beta</span>
@@ -152,16 +125,8 @@ export function ShellBarComponent() {
         <ShellBarItem icon="feedback" onClick={onFeedbackClick} />
       </ShellBar>
 
-      <ProfilePopover
-        open={profilePopoverOpen}
-        setOpen={setProfilePopoverOpen}
-        popoverRef={profilePopoverRef}
-      />
-      <BetaPopover
-        open={betaPopoverOpen}
-        setOpen={setBetaPopoverOpen}
-        popoverRef={betaPopoverRef}
-      />
+      <ProfilePopover open={profilePopoverOpen} setOpen={setProfilePopoverOpen} popoverRef={profilePopoverRef} />
+      <BetaPopover open={betaPopoverOpen} setOpen={setBetaPopoverOpen} popoverRef={betaPopoverRef} />
       <FeedbackPopover
         open={feedbackPopoverOpen}
         setOpen={setFeedbackPopoverOpen}
@@ -224,12 +189,7 @@ const BetaPopover = ({
   const { t } = useTranslation();
 
   return (
-    <Popover
-      ref={popoverRef}
-      placement={PopoverPlacement.Bottom}
-      open={open}
-      onClose={() => setOpen(false)}
-    >
+    <Popover ref={popoverRef} placement={PopoverPlacement.Bottom} open={open} onClose={() => setOpen(false)}>
       <div
         style={{
           padding: '1rem',
@@ -274,20 +234,13 @@ const FeedbackPopover = ({
 }) => {
   const { t } = useTranslation();
 
-  const onRatingChange = (
-    event: Event & { target: UI5RatingIndicatorElement },
-  ) => {
+  const onRatingChange = (event: Event & { target: UI5RatingIndicatorElement }) => {
     setRating(event.target.value);
   };
 
   return (
     <>
-      <Popover
-        ref={popoverRef}
-        placement={PopoverPlacement.Bottom}
-        open={open}
-        onClose={() => setOpen(false)}
-      >
+      <Popover ref={popoverRef} placement={PopoverPlacement.Bottom} open={open} onClose={() => setOpen(false)}>
         <div
           style={{
             padding: '1rem',
@@ -297,26 +250,12 @@ const FeedbackPopover = ({
           {!feedbackSent ? (
             <Form headerText={t('ShellBar.feedbackHeader')}>
               <FormGroup>
-                <FormItem
-                  labelContent={
-                    <Label style={{ color: 'black' }}>
-                      {t('ShellBar.feedbackRatingLabel')}
-                    </Label>
-                  }
-                >
-                  <RatingIndicator
-                    value={rating}
-                    max={5}
-                    onChange={onRatingChange}
-                  />
+                <FormItem labelContent={<Label style={{ color: 'black' }}>{t('ShellBar.feedbackRatingLabel')}</Label>}>
+                  <RatingIndicator value={rating} max={5} onChange={onRatingChange} />
                 </FormItem>
                 <FormItem
                   className="formAlignLabelStart"
-                  labelContent={
-                    <Label style={{ color: 'black' }}>
-                      {t('ShellBar.feedbackMessageLabel')}
-                    </Label>
-                  }
+                  labelContent={<Label style={{ color: 'black' }}>{t('ShellBar.feedbackMessageLabel')}</Label>}
                 >
                   <TextArea
                     value={feedbackMessage}

--- a/src/components/Dialogs/KubectlCommandInfo/Controllers/KubectlDeleteMcp.tsx
+++ b/src/components/Dialogs/KubectlCommandInfo/Controllers/KubectlDeleteMcp.tsx
@@ -8,11 +8,7 @@ interface KubectlDeleteMcpProps {
   resourceName: string;
 }
 
-export const KubectlDeleteMcp = ({
-  projectName,
-  workspaceName,
-  resourceName,
-}: KubectlDeleteMcpProps) => {
+export const KubectlDeleteMcp = ({ projectName, workspaceName, resourceName }: KubectlDeleteMcpProps) => {
   const [isInfoDialogOpen, setIsInfoDialogOpen] = useState(false);
 
   const openInfoDialog = () => setIsInfoDialogOpen(true);

--- a/src/components/Dialogs/KubectlCommandInfo/Controllers/KubectlDeleteWorkspace.tsx
+++ b/src/components/Dialogs/KubectlCommandInfo/Controllers/KubectlDeleteWorkspace.tsx
@@ -7,10 +7,7 @@ interface KubectlDeleteWorkspaceProps {
   resourceName: string;
 }
 
-export const KubectlDeleteWorkspace = ({
-  projectName,
-  resourceName,
-}: KubectlDeleteWorkspaceProps) => {
+export const KubectlDeleteWorkspace = ({ projectName, resourceName }: KubectlDeleteWorkspaceProps) => {
   const [isInfoDialogOpen, setIsInfoDialogOpen] = useState(false);
 
   const openInfoDialog = () => setIsInfoDialogOpen(true);

--- a/src/components/Dialogs/KubectlCommandInfo/KubectlBaseDialog.tsx
+++ b/src/components/Dialogs/KubectlCommandInfo/KubectlBaseDialog.tsx
@@ -56,6 +56,7 @@ export const KubectlBaseDialog = ({
       initialValues[field.id] = field.defaultValue;
     });
     setFormValues(initialValues);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleFieldChange = (fieldId: string) => (event: Ui5CustomEvent<InputDomRef>) => {

--- a/src/components/Dialogs/KubectlCommandInfo/KubectlBaseDialog.tsx
+++ b/src/components/Dialogs/KubectlCommandInfo/KubectlBaseDialog.tsx
@@ -58,13 +58,12 @@ export const KubectlBaseDialog = ({
     setFormValues(initialValues);
   }, []);
 
-  const handleFieldChange =
-    (fieldId: string) => (event: Ui5CustomEvent<InputDomRef>) => {
-      setFormValues((prev) => ({
-        ...prev,
-        [fieldId]: event.target.value,
-      }));
-    };
+  const handleFieldChange = (fieldId: string) => (event: Ui5CustomEvent<InputDomRef>) => {
+    setFormValues((prev) => ({
+      ...prev,
+      [fieldId]: event.target.value,
+    }));
+  };
 
   const getFormattedCommand = (template: string) => {
     let result = template;
@@ -108,9 +107,7 @@ export const KubectlBaseDialog = ({
           .map((template, index) => (
             <div key={`main-command-${index}`}>
               <Text>{template.description}</Text>
-              <KubectlTerminal
-                command={getFormattedCommand(template.command)}
-              />
+              <KubectlTerminal command={getFormattedCommand(template.command)} />
             </div>
           ))}
 
@@ -134,9 +131,7 @@ export const KubectlBaseDialog = ({
             >
               {formFields.map((field) => (
                 <div key={field.id}>
-                  <Text style={{ fontWeight: 'bold', marginBottom: '8px' }}>
-                    {field.label}
-                  </Text>
+                  <Text style={{ fontWeight: 'bold', marginBottom: '8px' }}>{field.label}</Text>
                   <Input
                     placeholder={field.placeholder}
                     value={formValues[field.id] || ''}
@@ -155,9 +150,7 @@ export const KubectlBaseDialog = ({
           .map((template, index) => (
             <div key={`additional-command-${index}`}>
               <Text>{template.description}</Text>
-              <KubectlTerminal
-                command={getFormattedCommand(template.command)}
-              />
+              <KubectlTerminal command={getFormattedCommand(template.command)} />
             </div>
           ))}
 

--- a/src/components/Dialogs/KubectlCommandInfo/KubectlCreateProjectDialog.tsx
+++ b/src/components/Dialogs/KubectlCommandInfo/KubectlCreateProjectDialog.tsx
@@ -1,8 +1,4 @@
-import {
-  KubectlBaseDialog,
-  FormField,
-  CustomCommand,
-} from './KubectlBaseDialog';
+import { KubectlBaseDialog, FormField, CustomCommand } from './KubectlBaseDialog';
 import { useTranslation } from 'react-i18next';
 
 interface KubectlCreateProjectDialogProps {
@@ -10,10 +6,7 @@ interface KubectlCreateProjectDialogProps {
   isOpen: boolean;
 }
 
-export const KubectlCreateProjectDialog = ({
-  onClose,
-  isOpen,
-}: KubectlCreateProjectDialogProps) => {
+export const KubectlCreateProjectDialog = ({ onClose, isOpen }: KubectlCreateProjectDialogProps) => {
   const { t } = useTranslation();
   const randomProjectName = Math.random().toString(36).substring(2, 8);
 
@@ -21,30 +14,20 @@ export const KubectlCreateProjectDialog = ({
     {
       id: 'projectName',
       label: t('KubectlCreateProjectDialog.formFields.projectName.label'),
-      placeholder: t(
-        'KubectlCreateProjectDialog.formFields.projectName.placeholder',
-      ),
+      placeholder: t('KubectlCreateProjectDialog.formFields.projectName.placeholder'),
       defaultValue: randomProjectName,
     },
     {
       id: 'chargingTargetId',
       label: t('KubectlCreateProjectDialog.formFields.chargingTargetId.label'),
-      placeholder: t(
-        'KubectlCreateProjectDialog.formFields.chargingTargetId.placeholder',
-      ),
-      defaultValue: t(
-        'KubectlCreateProjectDialog.formFields.chargingTargetId.defaultValue',
-      ),
+      placeholder: t('KubectlCreateProjectDialog.formFields.chargingTargetId.placeholder'),
+      defaultValue: t('KubectlCreateProjectDialog.formFields.chargingTargetId.defaultValue'),
     },
     {
       id: 'userEmail',
       label: t('KubectlCreateProjectDialog.formFields.userEmail.label'),
-      placeholder: t(
-        'KubectlCreateProjectDialog.formFields.userEmail.placeholder',
-      ),
-      defaultValue: t(
-        'KubectlCreateProjectDialog.formFields.userEmail.defaultValue',
-      ),
+      placeholder: t('KubectlCreateProjectDialog.formFields.userEmail.placeholder'),
+      defaultValue: t('KubectlCreateProjectDialog.formFields.userEmail.defaultValue'),
     },
   ];
 

--- a/src/components/Dialogs/KubectlCommandInfo/KubectlCreateWorkspaceDialog.tsx
+++ b/src/components/Dialogs/KubectlCommandInfo/KubectlCreateWorkspaceDialog.tsx
@@ -1,8 +1,4 @@
-import {
-  KubectlBaseDialog,
-  FormField,
-  CustomCommand,
-} from './KubectlBaseDialog';
+import { KubectlBaseDialog, FormField, CustomCommand } from './KubectlBaseDialog';
 import { useTranslation } from 'react-i18next';
 
 interface KubectlCreateWorkspaceDialogProps {
@@ -11,11 +7,7 @@ interface KubectlCreateWorkspaceDialogProps {
   project?: string;
 }
 
-export const KubectlCreateWorkspaceDialog = ({
-  onClose,
-  isOpen,
-  project,
-}: KubectlCreateWorkspaceDialogProps) => {
+export const KubectlCreateWorkspaceDialog = ({ onClose, isOpen, project }: KubectlCreateWorkspaceDialogProps) => {
   const { t } = useTranslation();
   const randomWorkspaceName = Math.random().toString(36).substring(2, 8);
   const projectName = project || '<Project Namespace>';
@@ -25,32 +17,20 @@ export const KubectlCreateWorkspaceDialog = ({
     {
       id: 'workspaceName',
       label: t('KubectlCreateWorkspaceDialog.formFields.workspaceName.label'),
-      placeholder: t(
-        'KubectlCreateWorkspaceDialog.formFields.workspaceName.placeholder',
-      ),
+      placeholder: t('KubectlCreateWorkspaceDialog.formFields.workspaceName.placeholder'),
       defaultValue: randomWorkspaceName,
     },
     {
       id: 'chargingTargetId',
-      label: t(
-        'KubectlCreateWorkspaceDialog.formFields.chargingTargetId.label',
-      ),
-      placeholder: t(
-        'KubectlCreateWorkspaceDialog.formFields.chargingTargetId.placeholder',
-      ),
-      defaultValue: t(
-        'KubectlCreateWorkspaceDialog.formFields.chargingTargetId.defaultValue',
-      ),
+      label: t('KubectlCreateWorkspaceDialog.formFields.chargingTargetId.label'),
+      placeholder: t('KubectlCreateWorkspaceDialog.formFields.chargingTargetId.placeholder'),
+      defaultValue: t('KubectlCreateWorkspaceDialog.formFields.chargingTargetId.defaultValue'),
     },
     {
       id: 'userEmail',
       label: t('KubectlCreateWorkspaceDialog.formFields.userEmail.label'),
-      placeholder: t(
-        'KubectlCreateWorkspaceDialog.formFields.userEmail.placeholder',
-      ),
-      defaultValue: t(
-        'KubectlCreateWorkspaceDialog.formFields.userEmail.defaultValue',
-      ),
+      placeholder: t('KubectlCreateWorkspaceDialog.formFields.userEmail.placeholder'),
+      defaultValue: t('KubectlCreateWorkspaceDialog.formFields.userEmail.defaultValue'),
     },
   ];
 

--- a/src/components/Dialogs/KubectlCommandInfo/KubectlDeleteMcpDialog.tsx
+++ b/src/components/Dialogs/KubectlCommandInfo/KubectlDeleteMcpDialog.tsx
@@ -19,9 +19,7 @@ export const KubectlDeleteMcpDialog = ({
   isOpen,
 }: KubectlDeleteMcpDialogProps) => {
   const { t } = useTranslation();
-  const workspaceNamespace = projectName
-    ? `project-${projectName}--ws-${workspaceName}`
-    : '<project-namespace>';
+  const workspaceNamespace = projectName ? `project-${projectName}--ws-${workspaceName}` : '<project-namespace>';
   const mcpName = resourceName || '<mcp-name>';
 
   const customCommands: CustomCommand[] = [

--- a/src/components/Dialogs/KubectlCommandInfo/KubectlInfoButton.tsx
+++ b/src/components/Dialogs/KubectlCommandInfo/KubectlInfoButton.tsx
@@ -5,19 +5,11 @@ import '@ui5/webcomponents-icons/dist/command-line-interfaces.js';
 
 interface KubectlInfoButtonProps extends Omit<ButtonPropTypes, 'children'> {}
 
-export const KubectlInfoButton = ({
-  onClick,
-  ...buttonProps
-}: KubectlInfoButtonProps) => {
+export const KubectlInfoButton = ({ onClick, ...buttonProps }: KubectlInfoButtonProps) => {
   const { t } = useTranslation();
 
   return (
-    <Button
-      design={ButtonDesign.Transparent}
-      icon="command-line-interfaces"
-      onClick={onClick}
-      {...buttonProps}
-    >
+    <Button design={ButtonDesign.Transparent} icon="command-line-interfaces" onClick={onClick} {...buttonProps}>
       {t('CommonKubectl.learnButton')}
     </Button>
   );

--- a/src/components/Dialogs/KubectlCommandInfo/KubectlTerminal.tsx
+++ b/src/components/Dialogs/KubectlCommandInfo/KubectlTerminal.tsx
@@ -28,10 +28,7 @@ export const KubectlTerminal = ({ command }: KubeCtlTerminalProps) => {
       const kubectlPart = 'kubectl' + afterYaml;
 
       const yamlLines = yamlContent.split('\n').map((line, index) => (
-        <div
-          key={index}
-          style={{ marginLeft: line.startsWith(' ') ? '16px' : '0' }}
-        >
+        <div key={index} style={{ marginLeft: line.startsWith(' ') ? '16px' : '0' }}>
           {line}
         </div>
       ));
@@ -93,12 +90,7 @@ export const KubectlTerminal = ({ command }: KubeCtlTerminalProps) => {
             }}
           />
         </FlexBox>
-        <Button
-          icon="copy"
-          design="Transparent"
-          tooltip="Copy to clipboard"
-          onClick={handleCopy}
-        />
+        <Button icon="copy" design="Transparent" tooltip="Copy to clipboard" onClick={handleCopy} />
       </FlexBox>
 
       <div style={{ padding: '12px 16px', overflowX: 'auto' }}>

--- a/src/components/Helper/AnimatedHoverTextButton.tsx
+++ b/src/components/Helper/AnimatedHoverTextButton.tsx
@@ -1,9 +1,4 @@
-import {
-  Button,
-  FlexBox,
-  FlexBoxAlignItems,
-  Text,
-} from '@ui5/webcomponents-react';
+import { Button, FlexBox, FlexBoxAlignItems, Text } from '@ui5/webcomponents-react';
 import '@ui5/webcomponents-icons/dist/copy';
 import { JSX, useState } from 'react';
 import ButtonDesign from '@ui5/webcomponents/dist/types/ButtonDesign.js';

--- a/src/components/Helper/Tooltip.tsx
+++ b/src/components/Helper/Tooltip.tsx
@@ -21,11 +21,7 @@ export function Tooltip(props: TooltipProps) {
 
   return (
     <>
-      <div
-        ref={openerRef}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-      >
+      <div ref={openerRef} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
         {props.children}
         <Popover
           opener={openerRef.current!}

--- a/src/components/Helper/generateInitialsForEmail.spec.ts
+++ b/src/components/Helper/generateInitialsForEmail.spec.ts
@@ -11,15 +11,11 @@ describe('generateInitialsForEmail', () => {
   });
 
   it('should generate initials from an email with multiple name parts', () => {
-    expect(generateInitialsForEmail('first.middle.last@example.com')).toBe(
-      'FML',
-    );
+    expect(generateInitialsForEmail('first.middle.last@example.com')).toBe('FML');
   });
 
   it('should truncate to 3 initials if more than 3 name parts exist', () => {
-    expect(
-      generateInitialsForEmail('first.second.third.extra@example.com'),
-    ).toBe('FST');
+    expect(generateInitialsForEmail('first.second.third.extra@example.com')).toBe('FST');
   });
 
   it('should handle emails where the name part is short', () => {

--- a/src/components/Members/EditMembers.cy.tsx
+++ b/src/components/Members/EditMembers.cy.tsx
@@ -5,12 +5,7 @@ const email1 = 'test1@test.com';
 const email2 = 'test2@test.com';
 
 function mountContainer(members: Member[] = []) {
-  cy.mount(
-    <EditMembers
-      members={members}
-      onMemberChanged={cy.spy().as('onChangeSpy')}
-    />,
-  );
+  cy.mount(<EditMembers members={members} onMemberChanged={cy.spy().as('onChangeSpy')} />);
 }
 
 describe('<EditMembers />', () => {
@@ -35,9 +30,7 @@ describe('<EditMembers />', () => {
     });
     cy.get('[data-testid="add-member-button"]').click();
     cy.get('@onChangeSpy').should('have.been.calledOnce');
-    cy.get('@onChangeSpy').should('have.been.calledWith', [
-      { name: email2, roles: [MemberRoles.admin], kind: 'User' },
-    ]);
+    cy.get('@onChangeSpy').should('have.been.calledWith', [{ name: email2, roles: [MemberRoles.admin], kind: 'User' }]);
   });
 
   it('Should remove selected member', () => {
@@ -45,9 +38,7 @@ describe('<EditMembers />', () => {
       { name: email1, roles: [MemberRoles.admin], kind: 'User' },
       { name: email2, roles: [MemberRoles.viewer], kind: 'User' },
     ]);
-    cy.get(
-      '[aria-rowindex="1"] > [data-column-id-cell="."] > ui5-button',
-    ).click();
+    cy.get('[aria-rowindex="1"] > [data-column-id-cell="."] > ui5-button').click();
     cy.get('@onChangeSpy').should('have.been.calledOnce');
     cy.get('@onChangeSpy').should('have.been.calledWith', [
       { name: email2, roles: [MemberRoles.viewer], kind: 'User' },

--- a/src/components/Members/EditMembers.tsx
+++ b/src/components/Members/EditMembers.tsx
@@ -1,11 +1,5 @@
 import { FC, useRef, useState, useCallback } from 'react';
-import {
-  Button,
-  FlexBox,
-  Input,
-  InputDomRef,
-  Label,
-} from '@ui5/webcomponents-react';
+import { Button, FlexBox, Input, InputDomRef, Label } from '@ui5/webcomponents-react';
 import { MemberTable } from './MemberTable.tsx';
 import { MemberRoleSelect } from './MemberRoleSelect.tsx';
 import { ValueState } from '../Shared/Ui5ValieState.tsx';
@@ -46,10 +40,7 @@ export const EditMembers: FC<EditMembersProps> = ({
       setEmailMessage(t('validationErrors.userExists'));
       return;
     }
-    onMemberChanged([
-      ...members,
-      { name: email, roles: [selectedRole], kind: 'User' },
-    ]);
+    onMemberChanged([...members, { name: email, roles: [selectedRole], kind: 'User' }]);
     if (input) input.value = '';
   }, [members, onMemberChanged, selectedRole, t]);
 

--- a/src/components/Members/MemberRoleSelect.tsx
+++ b/src/components/Members/MemberRoleSelect.tsx
@@ -1,15 +1,5 @@
-import {
-  MemberRoles,
-  MemberRolesDetailed,
-} from '../../lib/api/types/shared/members';
-import {
-  FlexBox,
-  Label,
-  Option,
-  Select,
-  SelectDomRef,
-  Ui5CustomEvent,
-} from '@ui5/webcomponents-react';
+import { MemberRoles, MemberRolesDetailed } from '../../lib/api/types/shared/members';
+import { FlexBox, Label, Option, Select, SelectDomRef, Ui5CustomEvent } from '@ui5/webcomponents-react';
 import { SelectChangeEventDetail } from '@ui5/webcomponents/dist/Select.js';
 import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -18,15 +8,10 @@ interface MemberRoleSelectProps {
   value: MemberRoles;
   onChange: (value: MemberRoles) => void;
 }
-export function MemberRoleSelect({
-  value,
-  onChange: fireOnChangeEventToParent,
-}: MemberRoleSelectProps) {
+export function MemberRoleSelect({ value, onChange: fireOnChangeEventToParent }: MemberRoleSelectProps) {
   const ref = useRef<SelectDomRef>(null);
 
-  const handleChange = (
-    event: Ui5CustomEvent<SelectDomRef, SelectChangeEventDetail>,
-  ) => {
+  const handleChange = (event: Ui5CustomEvent<SelectDomRef, SelectChangeEventDetail>) => {
     const newValue = event.detail.selectedOption.dataset.value as MemberRoles;
     fireOnChangeEventToParent(newValue);
   };
@@ -40,15 +25,8 @@ export function MemberRoleSelect({
   const { t } = useTranslation();
   return (
     <FlexBox direction={'Column'}>
-      <Label for={'member-role-select'}>
-        {t('MemberTable.columnRoleHeader')}
-      </Label>
-      <Select
-        ref={ref}
-        id="member-role-select"
-        value={value}
-        onChange={handleChange}
-      >
+      <Label for={'member-role-select'}>{t('MemberTable.columnRoleHeader')}</Label>
+      <Select ref={ref} id="member-role-select" value={value} onChange={handleChange}>
         {Object.values(MemberRoles)
           .map((r) => MemberRolesDetailed[r])
           .map((role) => (

--- a/src/components/Members/MemberTable.tsx
+++ b/src/components/Members/MemberTable.tsx
@@ -1,8 +1,5 @@
 import { AnalyticalTable, Button } from '@ui5/webcomponents-react';
-import {
-  Member,
-  MemberRolesDetailed,
-} from '../../lib/api/types/shared/members';
+import { Member, MemberRolesDetailed } from '../../lib/api/types/shared/members';
 import { AnalyticalTableColumnDefinition } from '@ui5/webcomponents-react/wrappers';
 import { useTranslation } from 'react-i18next';
 import { FC } from 'react';
@@ -66,11 +63,7 @@ export const MemberTable: FC<MemberTableProps> = ({
 
   if (requireAtLeastOneMember && members.length === 0) {
     return (
-      <Infobox
-        size="sm"
-        variant={isValidationError ? 'danger' : 'normal'}
-        id="members-error"
-      >
+      <Infobox size="sm" variant={isValidationError ? 'danger' : 'normal'} id="members-error">
         {t('validationErrors.atLeastOneUser')}
       </Infobox>
     );
@@ -81,7 +74,5 @@ export const MemberTable: FC<MemberTableProps> = ({
     role: m.roles.map((r) => MemberRolesDetailed[r].displayValue).join(', '),
   }));
 
-  return (
-    <AnalyticalTable scaleWidthMode="Smart" columns={columns} data={data} />
-  );
+  return <AnalyticalTable scaleWidthMode="Smart" columns={columns} data={data} />;
 };

--- a/src/components/Projects/ProjectChooser.tsx
+++ b/src/components/Projects/ProjectChooser.tsx
@@ -2,7 +2,7 @@ import { VariantItem, VariantManagement } from '@ui5/webcomponents-react';
 import { CopyButton } from '../Shared/CopyButton.tsx';
 import useLuigiNavigate from '../Shared/useLuigiNavigate.tsx';
 import IllustratedError from '../Shared/IllustratedError.tsx';
-import useResource from '../../lib/api/useApiResource';
+import { useApiResource } from '../../lib/api/useApiResource';
 import { ListProjectNames } from '../../lib/api/types/crate/listProjectNames';
 
 interface Props {
@@ -10,7 +10,7 @@ interface Props {
 }
 
 export default function ProjectChooser({ currentProjectName }: Props) {
-  const { data, error } = useResource(ListProjectNames);
+  const { data, error } = useApiResource(ListProjectNames);
   const navigate = useLuigiNavigate();
 
   if (error) {

--- a/src/components/Projects/ProjectListToolbar.tsx
+++ b/src/components/Projects/ProjectListToolbar.tsx
@@ -7,16 +7,9 @@ export function ProjectListToolbar() {
   return (
     <>
       <Toolbar>
-        <ToolbarButton
-          icon="add"
-          text="Project"
-          onClick={() => setDialogIsOpen(true)}
-        />
+        <ToolbarButton icon="add" text="Project" onClick={() => setDialogIsOpen(true)} />
       </Toolbar>
-      <CreateProjectDialogContainer
-        isOpen={dialogCreateProjectIsOpen}
-        setIsOpen={setDialogIsOpen}
-      />
+      <CreateProjectDialogContainer isOpen={dialogCreateProjectIsOpen} setIsOpen={setDialogIsOpen} />
     </>
   );
 }

--- a/src/components/Projects/ProjectsList.tsx
+++ b/src/components/Projects/ProjectsList.tsx
@@ -3,7 +3,7 @@ import { AnalyticalTable, AnalyticalTableColumnDefinition, Link } from '@ui5/web
 import { CopyButton } from '../Shared/CopyButton.tsx';
 import useLuigiNavigate from '../Shared/useLuigiNavigate.tsx';
 import IllustratedError from '../Shared/IllustratedError.tsx';
-import useResource from '../../lib/api/useApiResource';
+import { useApiResource } from '../../lib/api/useApiResource';
 import { projectnameToNamespace } from '../../utils';
 import '@ui5/webcomponents-icons/dist/copy';
 import '@ui5/webcomponents-icons/dist/arrow-right';
@@ -15,7 +15,7 @@ import { ProjectsListItemMenu } from './ProjectsListItemMenu.tsx';
 
 export default function ProjectsList() {
   const navigate = useLuigiNavigate();
-  const { data, error } = useResource(ListProjectNames, {
+  const { data, error } = useApiResource(ListProjectNames, {
     refreshInterval: 3000,
   });
   const stabilizedData = useMemo(
@@ -116,7 +116,7 @@ export default function ProjectsList() {
         ),
       },
     ],
-    [],
+    [navigate],
   );
   if (error) {
     return <IllustratedError details={error.message} />;

--- a/src/components/Shared/ConfiguredAnalyticsTable.tsx
+++ b/src/components/Shared/ConfiguredAnalyticsTable.tsx
@@ -14,9 +14,7 @@ interface Props {
 export default function ConfiguredAnalyticsTable(props: Props) {
   return (
     <AnalyticalTable
-      columns={props.columns.map((c) =>
-        typeof c === 'string' ? { Header: c, accessor: c } : c,
-      )}
+      columns={props.columns.map((c) => (typeof c === 'string' ? { Header: c, accessor: c } : c))}
       data={props.data}
       minRows={1}
       visibleRows={props.visibleRows ?? 12}

--- a/src/components/Shared/CopyButton.tsx
+++ b/src/components/Shared/CopyButton.tsx
@@ -10,11 +10,7 @@ interface CopyButtonProps extends ButtonPropTypes {
   style?: CSSProperties;
 }
 
-export const CopyButton = ({
-  text,
-  style = {},
-  ...buttonProps
-}: CopyButtonProps) => {
+export const CopyButton = ({ text, style = {}, ...buttonProps }: CopyButtonProps) => {
   const { show } = useToast();
   const { activeCopyId, setActiveCopyId } = useCopyButton();
   const uniqueId = useId();

--- a/src/components/Shared/ErrorMessageBox.tsx
+++ b/src/components/Shared/ErrorMessageBox.tsx
@@ -17,11 +17,7 @@ export const ErrorDialog = forwardRef<ErrorDialogHandle>((_, ref) => {
   }));
   return (
     <>
-      <MessageBox
-        open={open}
-        type={MessageBoxType.Error}
-        onClose={() => setOpen(false)}
-      >
+      <MessageBox open={open} type={MessageBoxType.Error} onClose={() => setOpen(false)}>
         {message}
       </MessageBox>
     </>

--- a/src/components/Shared/Loading.tsx
+++ b/src/components/Shared/Loading.tsx
@@ -7,11 +7,7 @@ export default function Loading() {
 
   return (
     <>
-      <IllustratedMessage
-        name="ReloadScreen"
-        titleText={t('Loading.title')}
-        subtitleText={t('Loading.subtitle')}
-      />
+      <IllustratedMessage name="ReloadScreen" titleText={t('Loading.title')} subtitleText={t('Loading.subtitle')} />
     </>
   );
 }

--- a/src/components/Shared/ResourceStatusCell.tsx
+++ b/src/components/Shared/ResourceStatusCell.tsx
@@ -8,9 +8,7 @@ export function ResourceStatusCell({ value, transitionTime }: StatusCellProps) {
       design={value ? 'Positive' : 'Negative'}
       name={value ? 'sys-enter-2' : 'sys-cancel-2'}
       showTooltip={true}
-      accessibleName={
-        transitionTime ? timeAgo.format(new Date(transitionTime)) : '-'
-      }
+      accessibleName={transitionTime ? timeAgo.format(new Date(transitionTime)) : '-'}
     />
   );
 }

--- a/src/components/Shared/StatusFilter/StatusFilter.tsx
+++ b/src/components/Shared/StatusFilter/StatusFilter.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Select } from '@ui5/webcomponents-react';
-import StatusFilterOption, {
-  StatusFilterOptionProps,
-} from './StatusFilterOption';
+import StatusFilterOption, { StatusFilterOptionProps } from './StatusFilterOption';
 
 interface StatusFilterProps {
   column: {
@@ -12,10 +10,7 @@ interface StatusFilterProps {
   };
 }
 
-const options: Pick<
-  StatusFilterOptionProps,
-  'value' | 'iconName' | 'color' | 'labelKey'
->[] = [
+const options: Pick<StatusFilterOptionProps, 'value' | 'iconName' | 'color' | 'labelKey'>[] = [
   { value: 'all', iconName: 'filter', color: 'gray', labelKey: 'All' },
   {
     value: 'true',
@@ -34,9 +29,7 @@ const options: Pick<
 const StatusFilter: React.FC<StatusFilterProps> = ({ column }) => {
   const { t } = useTranslation();
 
-  const handleChange = (
-    e: CustomEvent<{ selectedOption: { dataset?: { value?: string } } }>,
-  ) => {
+  const handleChange = (e: CustomEvent<{ selectedOption: { dataset?: { value?: string } } }>) => {
     const value = e.detail.selectedOption.dataset?.value;
     column.setFilter?.(value === 'all' ? undefined : value);
   };
@@ -48,10 +41,7 @@ const StatusFilter: React.FC<StatusFilterProps> = ({ column }) => {
           key={option.value}
           {...option}
           t={t}
-          isSelected={
-            column.filterValue === option.value ||
-            (option.value === 'all' && !column.filterValue)
-          }
+          isSelected={column.filterValue === option.value || (option.value === 'all' && !column.filterValue)}
         />
       ))}
     </Select>

--- a/src/components/Shared/StatusFilter/StatusFilterOption.tsx
+++ b/src/components/Shared/StatusFilter/StatusFilterOption.tsx
@@ -11,20 +11,8 @@ export interface StatusFilterOptionProps {
   isSelected: boolean;
 }
 
-const RenderOption: React.FC<StatusFilterOptionProps> = ({
-  value,
-  iconName,
-  color,
-  labelKey,
-  t,
-  isSelected,
-}) => (
-  <Option
-    key={value}
-    data-value={value}
-    selected={isSelected}
-    className={styles.option}
-  >
+const RenderOption: React.FC<StatusFilterOptionProps> = ({ value, iconName, color, labelKey, t, isSelected }) => (
+  <Option key={value} data-value={value} selected={isSelected} className={styles.option}>
     <div className={styles.container}>
       <Icon name={iconName} style={{ color }} className={styles.icon} />
       <span className={styles.label}>{t(labelKey)}</span>

--- a/src/components/Shared/TooltipCell.tsx
+++ b/src/components/Shared/TooltipCell.tsx
@@ -6,10 +6,7 @@ interface TooltipCellProps {
 }
 
 const TooltipCell: React.FC<TooltipCellProps> = ({ children, title }) => {
-  const resolvedTitle =
-    typeof children === 'string' || typeof children === 'number'
-      ? String(children)
-      : (title ?? '');
+  const resolvedTitle = typeof children === 'string' || typeof children === 'number' ? String(children) : (title ?? '');
 
   return (
     <div

--- a/src/components/Shared/Ui5ValieState.tsx
+++ b/src/components/Shared/Ui5ValieState.tsx
@@ -1,8 +1,2 @@
 // Definition of the ValueState type used for the highlighting of input elements in UI5
-export type ValueState =
-  | 'Information'
-  | 'None'
-  | 'Positive'
-  | 'Critical'
-  | 'Negative'
-  | undefined;
+export type ValueState = 'Information' | 'None' | 'Positive' | 'Critical' | 'Negative' | undefined;

--- a/src/components/Shared/k8s/ApiConfigProvider.tsx
+++ b/src/components/Shared/k8s/ApiConfigProvider.tsx
@@ -9,9 +9,5 @@ interface Props {
 export const ApiConfigContext = createContext({} as ApiConfig);
 
 export const ApiConfigProvider = ({ children, apiConfig }: Props) => {
-  return (
-    <ApiConfigContext.Provider value={apiConfig}>
-      {children}
-    </ApiConfigContext.Provider>
-  );
+  return <ApiConfigContext.Provider value={apiConfig}>{children}</ApiConfigContext.Provider>;
 };

--- a/src/components/Ui/IllustratedBanner/IllustratedBanner.cy.tsx
+++ b/src/components/Ui/IllustratedBanner/IllustratedBanner.cy.tsx
@@ -30,11 +30,7 @@ describe('<IllustratedBanner />', () => {
     );
 
     cy.get('ui5-button').contains('Need Help?').should('be.visible');
-    cy.get('ui5-button').should(
-      'have.attr',
-      'icon',
-      'sap-icon://question-mark',
-    );
+    cy.get('ui5-button').should('have.attr', 'icon', 'sap-icon://question-mark');
   });
 
   it('renders a link with correct attributes', () => {

--- a/src/components/Ui/IllustratedBanner/IllustratedBanner.tsx
+++ b/src/components/Ui/IllustratedBanner/IllustratedBanner.tsx
@@ -16,13 +16,7 @@ type InfoBannerProps = {
   button?: React.ReactElement;
 };
 
-export const IllustratedBanner = ({
-  title,
-  subtitle,
-  illustrationName,
-  help,
-  button,
-}: InfoBannerProps) => {
+export const IllustratedBanner = ({ title, subtitle, illustrationName, help, button }: InfoBannerProps) => {
   return (
     <FlexBox direction="Column" alignItems="Center">
       <IllustratedMessage
@@ -35,9 +29,7 @@ export const IllustratedBanner = ({
         <a href={help.link} target="_blank" rel="noreferrer">
           <Button
             design={ButtonDesign.Transparent}
-            icon={
-              help.buttonIcon ? help.buttonIcon : 'sap-icon://question-mark'
-            }
+            icon={help.buttonIcon ? help.buttonIcon : 'sap-icon://question-mark'}
           >
             {help.buttonText}
           </Button>

--- a/src/components/Yaml/YamlLoader.tsx
+++ b/src/components/Yaml/YamlLoader.tsx
@@ -9,16 +9,9 @@ import Loading from '../Shared/Loading.tsx';
 import IllustratedError from '../Shared/IllustratedError.tsx';
 import YamlViewer from './YamlViewer.tsx';
 import useResource from '../../lib/api/useApiResource';
-import {
-  removeManagedFieldsProperty,
-  Resource,
-} from '../../utils/removeManagedFieldsProperty.ts';
+import { removeManagedFieldsProperty, Resource } from '../../utils/removeManagedFieldsProperty.ts';
 
-export const YamlLoader: FC<YamlViewButtonProps> = ({
-  workspaceName,
-  resourceType,
-  resourceName,
-}) => {
+export const YamlLoader: FC<YamlViewButtonProps> = ({ workspaceName, resourceType, resourceName }) => {
   const { isLoading, data, error } = useResource(
     ResourceObject(workspaceName ?? '', resourceType, resourceName),
     undefined,

--- a/src/components/Yaml/YamlLoader.tsx
+++ b/src/components/Yaml/YamlLoader.tsx
@@ -8,11 +8,11 @@ import { ResourceObject } from '../../lib/api/types/crate/resourceObject.ts';
 import Loading from '../Shared/Loading.tsx';
 import IllustratedError from '../Shared/IllustratedError.tsx';
 import YamlViewer from './YamlViewer.tsx';
-import useResource from '../../lib/api/useApiResource';
+import { useApiResource } from '../../lib/api/useApiResource';
 import { removeManagedFieldsProperty, Resource } from '../../utils/removeManagedFieldsProperty.ts';
 
 export const YamlLoader: FC<YamlViewButtonProps> = ({ workspaceName, resourceType, resourceName }) => {
-  const { isLoading, data, error } = useResource(
+  const { isLoading, data, error } = useApiResource(
     ResourceObject(workspaceName ?? '', resourceType, resourceName),
     undefined,
     true,

--- a/src/components/Yaml/YamlViewButton.tsx
+++ b/src/components/Yaml/YamlViewButton.tsx
@@ -4,10 +4,7 @@ import styles from './YamlViewer.module.css';
 import { useTranslation } from 'react-i18next';
 import YamlViewer from './YamlViewer.tsx';
 import { stringify } from 'yaml';
-import {
-  removeManagedFieldsProperty,
-  Resource,
-} from '../../utils/removeManagedFieldsProperty.ts';
+import { removeManagedFieldsProperty, Resource } from '../../utils/removeManagedFieldsProperty.ts';
 import { YamlIcon } from './YamlIcon.tsx';
 import { YamlViewDialog } from './YamlViewDialog.tsx';
 

--- a/src/components/Yaml/YamlViewDialog.tsx
+++ b/src/components/Yaml/YamlViewDialog.tsx
@@ -9,17 +9,12 @@ export type YamlViewDialogProps = {
   dialogContent: ReactNode;
 };
 
-export const YamlViewDialog: FC<YamlViewDialogProps> = ({
-  isOpen,
-  setIsOpen,
-  dialogContent,
-}) => {
+export const YamlViewDialog: FC<YamlViewDialogProps> = ({ isOpen, setIsOpen, dialogContent }) => {
   const { t } = useTranslation();
   return (
     <Dialog
       open={isOpen}
       stretch
-      onClick={(e) => e.stopPropagation()}
       footer={
         <Bar
           design="Footer"
@@ -30,6 +25,7 @@ export const YamlViewDialog: FC<YamlViewDialogProps> = ({
           }
         />
       }
+      onClick={(e) => e.stopPropagation()}
       onClose={() => {
         setIsOpen(false);
       }}

--- a/src/components/Yaml/YamlViewer.tsx
+++ b/src/components/Yaml/YamlViewer.tsx
@@ -1,9 +1,6 @@
 import { FC } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import {
-  materialLight,
-  materialDark,
-} from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { materialLight, materialDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
 import { Button, FlexBox } from '@ui5/webcomponents-react';
 import styles from './YamlViewer.module.css';
@@ -33,13 +30,7 @@ const YamlViewer: FC<YamlViewerProps> = ({ yamlString, filename }) => {
 
   return (
     <div className={styles.container}>
-      <FlexBox
-        className={styles.buttons}
-        direction="Row"
-        justifyContent="End"
-        alignItems="Baseline"
-        gap={16}
-      >
+      <FlexBox className={styles.buttons} direction="Row" justifyContent="End" alignItems="Baseline" gap={16}>
         <Button icon="copy" onClick={copyToClipboard}>
           {t('buttons.copy')}
         </Button>

--- a/src/context/CopyButtonContext.tsx
+++ b/src/context/CopyButtonContext.tsx
@@ -1,11 +1,4 @@
-import {
-  createContext,
-  useContext,
-  useState,
-  useRef,
-  FC,
-  ReactNode,
-} from 'react';
+import { createContext, useContext, useState, useRef, FC, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 const DURATION = 2000; //ms
@@ -20,9 +13,7 @@ const CopyButtonContext = createContext<CopyButtonContextType>({
   setActiveCopyId: () => {},
 });
 
-export const CopyButtonProvider: FC<{ children: ReactNode }> = ({
-  children,
-}) => {
+export const CopyButtonProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [activeCopyId, setActiveCopyId] = useState<string | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
 
@@ -43,9 +34,7 @@ export const CopyButtonProvider: FC<{ children: ReactNode }> = ({
   };
 
   return (
-    <CopyButtonContext.Provider
-      value={{ activeCopyId, setActiveCopyId: handleSetActiveCopyId }}
-    >
+    <CopyButtonContext.Provider value={{ activeCopyId, setActiveCopyId: handleSetActiveCopyId }}>
       {children}
     </CopyButtonContext.Provider>
   );

--- a/src/context/FrontendConfigContext.tsx
+++ b/src/context/FrontendConfigContext.tsx
@@ -19,24 +19,16 @@ interface FrontendConfigProviderProps {
   children: ReactNode;
 }
 
-export function FrontendConfigProvider({
-  children,
-}: FrontendConfigProviderProps) {
+export function FrontendConfigProvider({ children }: FrontendConfigProviderProps) {
   const config = use(fetchPromise);
-  return (
-    <FrontendConfigContext.Provider value={config}>
-      {children}
-    </FrontendConfigContext.Provider>
-  );
+  return <FrontendConfigContext.Provider value={config}>{children}</FrontendConfigContext.Provider>;
 }
 
 export const useFrontendConfig = () => {
   const context = use(FrontendConfigContext);
 
   if (!context) {
-    throw new Error(
-      'useFrontendConfig must be used within a FrontendConfigProvider.',
-    );
+    throw new Error('useFrontendConfig must be used within a FrontendConfigProvider.');
   }
   return context;
 };

--- a/src/lib/api/fetch.ts
+++ b/src/lib/api/fetch.ts
@@ -51,10 +51,7 @@ export const fetchApiServer = async (
       // Unauthorized, redirect to the login page
       window.location.replace('/api/auth/onboarding/login');
     }
-    const error = new APIError(
-      'An error occurred while fetching the data.',
-      res.status,
-    );
+    const error = new APIError('An error occurred while fetching the data.', res.status);
     error.info = await res.json();
     throw error;
   }
@@ -75,9 +72,7 @@ export const fetchApiServerJson = async <T>(
 };
 
 // request is of [path, config, jq]
-export const fetchApiServerJsonMultiple = (
-  requests: [string | null, ApiConfig, string | undefined][],
-) => {
+export const fetchApiServerJsonMultiple = (requests: [string | null, ApiConfig, string | undefined][]) => {
   return Promise.all(
     requests
       .filter((r) => r[0] !== null)

--- a/src/lib/api/types/crate/controlPlanes.ts
+++ b/src/lib/api/types/crate/controlPlanes.ts
@@ -10,13 +10,13 @@ export interface Metadata {
 export interface ControlPlaneType {
   metadata: Metadata;
   spec:
-  | {
-    authentication: {
-      enableSystemIdentityProvider?: boolean;
-    };
-    components: ControlPlaneComponentsType;
-  }
-  | undefined;
+    | {
+        authentication: {
+          enableSystemIdentityProvider?: boolean;
+        };
+        components: ControlPlaneComponentsType;
+      }
+    | undefined;
   status: ControlPlaneStatusType | undefined;
 }
 
@@ -36,13 +36,13 @@ export interface ControlPlaneStatusType {
   status: ReadyStatus;
   conditions: ControlPlaneStatusCondition[];
   access:
-  | {
-    key: string | undefined;
-    name: string | undefined;
-    namespace: string | undefined;
-    kubeconfig: string | undefined;
-  }
-  | undefined;
+    | {
+        key: string | undefined;
+        name: string | undefined;
+        namespace: string | undefined;
+        kubeconfig: string | undefined;
+      }
+    | undefined;
 }
 
 export interface ControlPlaneStatusCondition {

--- a/src/lib/api/types/crate/createProject.ts
+++ b/src/lib/api/types/crate/createProject.ts
@@ -1,9 +1,5 @@
 import { Resource } from '../resource';
-import {
-  CHARGING_TARGET_LABEL,
-  CHARGING_TARGET_TYPE_LABEL,
-  DISPLAY_NAME_ANNOTATION,
-} from '../shared/keyNames';
+import { CHARGING_TARGET_LABEL, CHARGING_TARGET_TYPE_LABEL, DISPLAY_NAME_ANNOTATION } from '../shared/keyNames';
 import { Member } from '../shared/members';
 
 export interface CreateProjectType {

--- a/src/lib/api/types/crate/createWorkspace.ts
+++ b/src/lib/api/types/crate/createWorkspace.ts
@@ -1,9 +1,5 @@
 import { Resource } from '../resource';
-import {
-  CHARGING_TARGET_LABEL,
-  CHARGING_TARGET_TYPE_LABEL,
-  DISPLAY_NAME_ANNOTATION,
-} from '../shared/keyNames';
+import { CHARGING_TARGET_LABEL, CHARGING_TARGET_TYPE_LABEL, DISPLAY_NAME_ANNOTATION } from '../shared/keyNames';
 import { Member } from '../shared/members';
 
 export interface CreateWorkspaceType {
@@ -56,9 +52,7 @@ export const CreateWorkspace = (
   };
 };
 
-export const CreateWorkspaceResource = (
-  namespace: string,
-): Resource<undefined> => {
+export const CreateWorkspaceResource = (namespace: string): Resource<undefined> => {
   return {
     path: `/apis/core.openmcp.cloud/v1alpha1/namespaces/${namespace}/workspaces`,
     method: 'POST',

--- a/src/lib/api/types/crate/deleteMCP.ts
+++ b/src/lib/api/types/crate/deleteMCP.ts
@@ -13,10 +13,7 @@ export const PatchMCPResourceForDeletionBody = {
   },
 };
 
-export const PatchMCPResourceForDeletion = (
-  namespace: string,
-  mcpName: string,
-): Resource<undefined> => {
+export const PatchMCPResourceForDeletion = (namespace: string, mcpName: string): Resource<undefined> => {
   return {
     path: `/apis/core.openmcp.cloud/v1alpha1/namespaces/${namespace}/managedcontrolplanes/${mcpName}?fieldManager=kubectl-annotate`,
     method: 'PATCH',
@@ -25,10 +22,7 @@ export const PatchMCPResourceForDeletion = (
   };
 };
 
-export const DeleteMCPResource = (
-  namespace: string,
-  mcpName: string,
-): Resource<undefined> => {
+export const DeleteMCPResource = (namespace: string, mcpName: string): Resource<undefined> => {
   return {
     path: `/apis/core.openmcp.cloud/v1alpha1/namespaces/${namespace}/managedcontrolplanes/${mcpName}/`,
     method: 'DELETE',

--- a/src/lib/api/types/crate/deleteWorkspace.ts
+++ b/src/lib/api/types/crate/deleteWorkspace.ts
@@ -5,10 +5,7 @@ export interface DeleteWorkspaceType {
   namespace: string;
 }
 
-export const DeleteWorkspaceResource = (
-  namespace: string,
-  workspaceName: string,
-): Resource<undefined> => {
+export const DeleteWorkspaceResource = (namespace: string, workspaceName: string): Resource<undefined> => {
   return {
     path: `/apis/core.openmcp.cloud/v1alpha1/namespaces/${namespace}/workspaces/${workspaceName}`,
     method: 'DELETE',

--- a/src/lib/api/types/crate/getKubeconfig.ts
+++ b/src/lib/api/types/crate/getKubeconfig.ts
@@ -1,10 +1,6 @@
 import { Resource } from '../resource';
 
-export const GetKubeconfig = (
-  secretKey: string,
-  secretName: string,
-  secretNamespace: string,
-): Resource<string> => {
+export const GetKubeconfig = (secretKey: string, secretName: string, secretNamespace: string): Resource<string> => {
   return {
     path: `/api/v1/namespaces/${secretNamespace}/secrets/${secretName}`,
     jq: `.data.${secretKey} | @base64d `,

--- a/src/lib/api/types/crate/listWorkspaces.ts
+++ b/src/lib/api/types/crate/listWorkspaces.ts
@@ -19,9 +19,7 @@ export function isWorkspaceReady(workspace: ListWorkspacesType): boolean {
   return workspace.status != null && workspace.status.namespace != null;
 }
 
-export const ListWorkspaces = (
-  projectName: string,
-): Resource<ListWorkspacesType[]> => {
+export const ListWorkspaces = (projectName: string): Resource<ListWorkspacesType[]> => {
   return {
     path: `/apis/core.openmcp.cloud/v1alpha1/namespaces/project-${projectName}/workspaces`,
     jq: '[.items[] | {metadata: .metadata | {name, namespace, annotations, deletionTimestamp}, status: .status, spec: .spec | {members: [.members[] | {name, roles}]}}]',

--- a/src/lib/api/types/landscaper/listDeployItems.ts
+++ b/src/lib/api/types/landscaper/listDeployItems.ts
@@ -17,8 +17,6 @@ export interface DeployItemsListResponse {
   items: DeployItem[];
 }
 
-export const DeployItemsRequest = (
-  namespace: string,
-): Resource<DeployItemsListResponse> => ({
+export const DeployItemsRequest = (namespace: string): Resource<DeployItemsListResponse> => ({
   path: `/apis/landscaper.gardener.cloud/v1alpha1/namespaces/${namespace}/deployitems`,
 });

--- a/src/lib/api/types/landscaper/listExecutions.ts
+++ b/src/lib/api/types/landscaper/listExecutions.ts
@@ -21,8 +21,6 @@ export interface ExecutionsListResponse {
   items: Execution[];
 }
 
-export const ExecutionsRequest = (
-  namespace: string,
-): Resource<ExecutionsListResponse> => ({
+export const ExecutionsRequest = (namespace: string): Resource<ExecutionsListResponse> => ({
   path: `/apis/landscaper.gardener.cloud/v1alpha1/namespaces/${namespace}/executions`,
 });

--- a/src/lib/api/types/landscaper/listInstallations.ts
+++ b/src/lib/api/types/landscaper/listInstallations.ts
@@ -25,8 +25,6 @@ export interface InstallationsListResponse {
   items: Installation[];
 }
 
-export const InstallationsRequest = (
-  namespace: string,
-): Resource<InstallationsListResponse> => ({
+export const InstallationsRequest = (namespace: string): Resource<InstallationsListResponse> => ({
   path: `/apis/landscaper.gardener.cloud/v1alpha1/namespaces/${namespace}/installations`,
 });

--- a/src/lib/api/types/shared/components.ts
+++ b/src/lib/api/types/shared/components.ts
@@ -1,9 +1,4 @@
-export type ComponentType =
-  | 'crossplane'
-  | 'btpServiceOperator'
-  | 'externalSecretsOperator'
-  | 'flux'
-  | 'kyverno';
+export type ComponentType = 'crossplane' | 'btpServiceOperator' | 'externalSecretsOperator' | 'flux' | 'kyverno';
 
 export const possibleComponents: Component[] = [
   { name: 'crossplane', version: '1.17.1' },

--- a/src/lib/api/types/shared/keyNames.ts
+++ b/src/lib/api/types/shared/keyNames.ts
@@ -1,5 +1,3 @@
 export const DISPLAY_NAME_ANNOTATION: string = 'openmcp.cloud/display-name';
-export const CHARGING_TARGET_LABEL: string =
-  'openmcp.cloud.sap/charging-target';
-export const CHARGING_TARGET_TYPE_LABEL: string =
-  'openmcp.cloud.sap/charging-target-type';
+export const CHARGING_TARGET_LABEL: string = 'openmcp.cloud.sap/charging-target';
+export const CHARGING_TARGET_TYPE_LABEL: string = 'openmcp.cloud.sap/charging-target-type';

--- a/src/lib/api/useApiResource.ts
+++ b/src/lib/api/useApiResource.ts
@@ -10,8 +10,6 @@ import { MutatorOptions } from 'swr/_internal';
 import { CRDRequest, CRDResponse } from './types/crossplane/CRDList';
 import { ProviderConfigs, ProviderConfigsData, ProviderConfigsDataForRequest } from '../shared/types';
 
-export { useApiResource as default };
-
 export const useApiResource = <T>(resource: Resource<T>, config?: SWRConfiguration, excludeMcpConfig?: boolean) => {
   const apiConfig = useContext(ApiConfigContext);
 
@@ -134,12 +132,13 @@ export const useProvidersConfigResource = (config?: SWRConfiguration) => {
         if (finalData.length > 0) {
           setIsLoading(false);
         }
-      } catch (err) {
+      } catch (_) {
         setIsLoading(false);
       }
     };
 
     fetchDataAndUpdateState();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
 
   return {

--- a/src/lib/api/validations/regex.spec.ts
+++ b/src/lib/api/validations/regex.spec.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  projectWorkspaceNameRegex,
-  managedControlPlaneNameRegex,
-} from './regex';
+import { projectWorkspaceNameRegex, managedControlPlaneNameRegex } from './regex';
 
 describe('projectWorkspaceNameRegex', () => {
   const valid = [
@@ -54,18 +51,7 @@ describe('managedControlPlaneNameRegex', () => {
     'abc1-2.def3',
     'abc.def.ghi',
   ];
-  const invalid = [
-    'My-MCP',
-    'ABC',
-    '-mcp',
-    'mcp-',
-    '.mcp',
-    'mcp.',
-    'a'.repeat(64),
-    'abc..def',
-    'abc-.def',
-    'abc.-def',
-  ];
+  const invalid = ['My-MCP', 'ABC', '-mcp', 'mcp-', '.mcp', 'mcp.', 'a'.repeat(64), 'abc..def', 'abc-.def', 'abc.-def'];
 
   it('matches valid managed control plane names', () => {
     for (const name of valid) {

--- a/src/lib/api/validations/regex.ts
+++ b/src/lib/api/validations/regex.ts
@@ -1,10 +1,7 @@
 // Matches project or workspace names: 1-63 chars per segment, alphanum/dash, dot-separated, no leading/trailing dash, allows uppercase.
-export const projectWorkspaceNameRegex =
-  /^(?!-)[a-zA-Z0-9-]{1,63}(?<!-)(?:\.(?!-)[a-zA-Z0-9-]{1,63}(?<!-))*$/;
+export const projectWorkspaceNameRegex = /^(?!-)[a-zA-Z0-9-]{1,63}(?<!-)(?:\.(?!-)[a-zA-Z0-9-]{1,63}(?<!-))*$/;
 
 // Matches managed control plane names: 1-63 chars per segment, lowercase alphanum/dash, dot-separated, no leading/trailing dash.
-export const managedControlPlaneNameRegex =
-  /^(?!-)[a-z0-9-]{1,63}(?<!-)(?:\.(?!-)[a-z0-9-]{1,63}(?<!-))*$/;
+export const managedControlPlaneNameRegex = /^(?!-)[a-z0-9-]{1,63}(?<!-)(?:\.(?!-)[a-z0-9-]{1,63}(?<!-))*$/;
 
-export const btpChargingTargetRegex =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+export const btpChargingTargetRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;

--- a/src/lib/shared/McpContext.tsx
+++ b/src/lib/shared/McpContext.tsx
@@ -1,12 +1,12 @@
 import { createContext, ReactNode, useContext } from 'react';
 import { ControlPlane as ManagedControlPlaneResource } from '../api/types/crate/controlPlanes.ts';
 import { ApiConfigProvider } from '../../components/Shared/k8s';
-import useResource from '../api/useApiResource.ts';
+import { useApiResource } from '../api/useApiResource.ts';
 import { GetKubeconfig } from '../api/types/crate/getKubeconfig.ts';
 import { useAuthMcp } from '../../spaces/mcp/auth/AuthContextMcp.tsx';
 import { BusyIndicator } from '@ui5/webcomponents-react';
 
-interface McpContext {
+interface Mcp {
   project: string;
   workspace: string;
   name: string;
@@ -19,24 +19,24 @@ interface McpContext {
 }
 
 interface Props {
-  context: McpContext;
+  context: Mcp;
   children?: ReactNode;
 }
 
-export const McpContext = createContext({} as McpContext);
+export const McpContext = createContext({} as Mcp);
 
 export const useMcp = () => {
   return useContext(McpContext);
 };
 
 export const McpContextProvider = ({ children, context }: Props) => {
-  const mcp = useResource(ManagedControlPlaneResource(context.project, context.workspace, context.name));
+  const mcp = useApiResource(ManagedControlPlaneResource(context.project, context.workspace, context.name));
 
   const secretNamespace = mcp.data?.status?.access?.namespace;
   const secretName = mcp.data?.status?.access?.name;
   const secretKey = mcp.data?.status?.access?.key;
 
-  const kubeconfig = useResource(GetKubeconfig(secretKey ?? '', secretName ?? '', secretNamespace ?? ''));
+  const kubeconfig = useApiResource(GetKubeconfig(secretKey ?? '', secretName ?? '', secretNamespace ?? ''));
 
   if (mcp.isLoading || mcp.error) {
     return <></>;

--- a/src/lib/shared/McpContext.tsx
+++ b/src/lib/shared/McpContext.tsx
@@ -30,21 +30,13 @@ export const useMcp = () => {
 };
 
 export const McpContextProvider = ({ children, context }: Props) => {
-  const mcp = useResource(
-    ManagedControlPlaneResource(
-      context.project,
-      context.workspace,
-      context.name,
-    ),
-  );
+  const mcp = useResource(ManagedControlPlaneResource(context.project, context.workspace, context.name));
 
   const secretNamespace = mcp.data?.status?.access?.namespace;
   const secretName = mcp.data?.status?.access?.name;
   const secretKey = mcp.data?.status?.access?.key;
 
-  const kubeconfig = useResource(
-    GetKubeconfig(secretKey ?? '', secretName ?? '', secretNamespace ?? ''),
-  );
+  const kubeconfig = useResource(GetKubeconfig(secretKey ?? '', secretName ?? '', secretNamespace ?? ''));
 
   if (mcp.isLoading || mcp.error) {
     return <></>;
@@ -77,11 +69,7 @@ function RequireDownstreamLogin(props: { children?: ReactNode }) {
   );
 }
 
-export function WithinManagedControlPlane({
-  children,
-}: {
-  children?: ReactNode;
-}) {
+export function WithinManagedControlPlane({ children }: { children?: ReactNode }) {
   const auth = useAuthMcp();
 
   if (auth.isLoading) {

--- a/src/lib/shared/useLink.ts
+++ b/src/lib/shared/useLink.ts
@@ -8,12 +8,8 @@ export function useLink() {
 
   return {
     documentationHomepage: createLink('/'),
-    gettingStartedGuide: createLink(
-      '/docs/managed-control-planes/get-started/get-started-mcp',
-    ),
-    workspaceCreationGuide: createLink(
-      '/docs/managed-control-planes/get-started/get-started-mcp#4-create-workspace',
-    ),
+    gettingStartedGuide: createLink('/docs/managed-control-planes/get-started/get-started-mcp'),
+    workspaceCreationGuide: createLink('/docs/managed-control-planes/get-started/get-started-mcp#4-create-workspace'),
     mcpCreationGuide: createLink(
       '/docs/managed-control-planes/get-started/get-started-mcp#5-create-managedcontrolplane',
     ),

--- a/src/spaces/mcp/auth/AuthContextMcp.tsx
+++ b/src/spaces/mcp/auth/AuthContextMcp.tsx
@@ -34,18 +34,13 @@ export function AuthProviderMcp({ children }: { children: ReactNode }) {
         } catch (_) {
           /* safe to ignore */
         }
-        throw new Error(
-          errorBody?.message ||
-            `Authentication check failed with status: ${response.status}`,
-        );
+        throw new Error(errorBody?.message || `Authentication check failed with status: ${response.status}`);
       }
 
       const body = await response.json();
       const validationResult = MeResponseSchema.safeParse(body);
       if (!validationResult.success) {
-        throw new Error(
-          `Auth API response validation failed: ${validationResult.error.flatten()}`,
-        );
+        throw new Error(`Auth API response validation failed: ${validationResult.error.flatten()}`);
       }
 
       const { isAuthenticated: apiIsAuthenticated } = validationResult.data;
@@ -61,16 +56,10 @@ export function AuthProviderMcp({ children }: { children: ReactNode }) {
   const login = () => {
     sessionStorage.setItem(AUTH_FLOW_SESSION_KEY, 'mcp');
 
-    window.location.replace(
-      `/api/auth/mcp/login?redirectTo=${encodeURIComponent(window.location.hash)}`,
-    );
+    window.location.replace(`/api/auth/mcp/login?redirectTo=${encodeURIComponent(window.location.hash)}`);
   };
 
-  return (
-    <AuthContextMcp value={{ isLoading, isAuthenticated, error, login }}>
-      {children}
-    </AuthContextMcp>
-  );
+  return <AuthContextMcp value={{ isLoading, isAuthenticated, error, login }}>{children}</AuthContextMcp>;
 }
 
 export const useAuthMcp = () => {

--- a/src/spaces/onboarding/auth/AuthContextOnboarding.tsx
+++ b/src/spaces/onboarding/auth/AuthContextOnboarding.tsx
@@ -12,9 +12,7 @@ interface AuthContextOnboardingType {
   logout: () => Promise<void>;
 }
 
-const AuthContextOnboarding = createContext<AuthContextOnboardingType | null>(
-  null,
-);
+const AuthContextOnboarding = createContext<AuthContextOnboardingType | null>(null);
 
 export function AuthProviderOnboarding({ children }: { children: ReactNode }) {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
@@ -40,22 +38,16 @@ export function AuthProviderOnboarding({ children }: { children: ReactNode }) {
         } catch (_) {
           /* safe to ignore */
         }
-        throw new Error(
-          errorBody?.message ||
-            `Authentication check failed with status: ${response.status}`,
-        );
+        throw new Error(errorBody?.message || `Authentication check failed with status: ${response.status}`);
       }
 
       const body = await response.json();
       const validationResult = MeResponseSchema.safeParse(body);
       if (!validationResult.success) {
-        throw new Error(
-          `Auth API response validation failed: ${validationResult.error.flatten()}`,
-        );
+        throw new Error(`Auth API response validation failed: ${validationResult.error.flatten()}`);
       }
 
-      const { isAuthenticated: apiIsAuthenticated, user: apiUser } =
-        validationResult.data;
+      const { isAuthenticated: apiIsAuthenticated, user: apiUser } = validationResult.data;
       setUser(apiUser);
       setIsAuthenticated(apiIsAuthenticated);
 
@@ -76,9 +68,7 @@ export function AuthProviderOnboarding({ children }: { children: ReactNode }) {
   const login = () => {
     sessionStorage.setItem(AUTH_FLOW_SESSION_KEY, 'onboarding');
 
-    window.location.replace(
-      `/api/auth/onboarding/login?redirectTo=${encodeURIComponent(window.location.hash)}`,
-    );
+    window.location.replace(`/api/auth/onboarding/login?redirectTo=${encodeURIComponent(window.location.hash)}`);
   };
 
   const logout = async () => {
@@ -94,9 +84,7 @@ export function AuthProviderOnboarding({ children }: { children: ReactNode }) {
         } catch (_) {
           /* safe to ignore */
         }
-        throw new Error(
-          errorBody?.message || `Logout failed with status: ${response.status}`,
-        );
+        throw new Error(errorBody?.message || `Logout failed with status: ${response.status}`);
       }
 
       await refreshAuthStatus();
@@ -106,9 +94,7 @@ export function AuthProviderOnboarding({ children }: { children: ReactNode }) {
   };
 
   return (
-    <AuthContextOnboarding
-      value={{ isLoading, isAuthenticated, user, error, login, logout }}
-    >
+    <AuthContextOnboarding value={{ isLoading, isAuthenticated, user, error, login, logout }}>
       {children}
     </AuthContextOnboarding>
   );
@@ -117,9 +103,7 @@ export function AuthProviderOnboarding({ children }: { children: ReactNode }) {
 export const useAuthOnboarding = () => {
   const context = use(AuthContextOnboarding);
   if (!context) {
-    throw new Error(
-      'useAuthOnboarding must be used within an AuthProviderOnboarding.',
-    );
+    throw new Error('useAuthOnboarding must be used within an AuthProviderOnboarding.');
   }
   return context;
 };

--- a/src/spaces/onboarding/services/ApolloClientProvider/ApolloClientProvider.tsx
+++ b/src/spaces/onboarding/services/ApolloClientProvider/ApolloClientProvider.tsx
@@ -1,9 +1,4 @@
-import {
-  ApolloClient,
-  ApolloProvider,
-  createHttpLink,
-  InMemoryCache,
-} from '@apollo/client';
+import { ApolloClient, ApolloProvider, createHttpLink, InMemoryCache } from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
 import { ReactNode } from 'react';
 import { useFrontendConfig } from '../../../../context/FrontendConfigContext.tsx';

--- a/src/spaces/onboarding/services/WorkspaceService/WorkspaceService.ts
+++ b/src/spaces/onboarding/services/WorkspaceService/WorkspaceService.ts
@@ -19,9 +19,7 @@ export function useWorkspacesQuery(projectNamespace: string) {
   });
 
   const workspaceNames = (
-    query.data?.core_openmcp_cloud?.Workspaces.map(
-      (workspace) => workspace.metadata?.name,
-    ) ?? []
+    query.data?.core_openmcp_cloud?.Workspaces.map((workspace) => workspace.metadata?.name) ?? []
   ).filter((workspaceName) => workspaceName != null);
 
   return {

--- a/src/views/ControlPlanes/ControlPlaneListView.tsx
+++ b/src/views/ControlPlanes/ControlPlaneListView.tsx
@@ -18,10 +18,7 @@ export default function ControlPlaneListView() {
           <ObjectPageTitle
             header={
               <Title>
-                <Trans
-                  i18nKey="ControlPlaneListView.header"
-                  components={{ span: <span className="mono-font" /> }}
-                />
+                <Trans i18nKey="ControlPlaneListView.header" components={{ span: <span className="mono-font" /> }} />
               </Title>
             }
             subHeader={
@@ -32,16 +29,12 @@ export default function ControlPlaneListView() {
                   alignItems: 'center',
                 }}
               >
-                <p style={{ marginRight: '0.5rem' }}>
-                  {t('ControlPlaneListView.projectHeader')}
-                </p>
+                <p style={{ marginRight: '0.5rem' }}>{t('ControlPlaneListView.projectHeader')}</p>
                 <ProjectChooser currentProjectName={projectName ?? ''} />
               </div>
             }
             breadcrumbs={<IntelligentBreadcrumbs />}
-            actionsBar={
-              <ControlPlaneListToolbar projectName={projectName ?? ''} />
-            }
+            actionsBar={<ControlPlaneListToolbar projectName={projectName ?? ''} />}
           />
         }
         //TODO: project chooser should be part of the breadcrumb section if possible?

--- a/src/views/ControlPlanes/ControlPlaneView.tsx
+++ b/src/views/ControlPlanes/ControlPlaneView.tsx
@@ -17,7 +17,7 @@ import { ProvidersConfig } from '../../components/ControlPlane/ProvidersConfig.t
 import { Providers } from '../../components/ControlPlane/Providers.tsx';
 import ComponentList from '../../components/ControlPlane/ComponentList.tsx';
 import MCPHealthPopoverButton from '../../components/ControlPlane/MCPHealthPopoverButton.tsx';
-import useResource from '../../lib/api/useApiResource';
+import { useApiResource } from '../../lib/api/useApiResource';
 
 import { YamlViewButtonWithLoader } from '../../components/Yaml/YamlViewButtonWithLoader.tsx';
 import { Landscapers } from '../../components/ControlPlane/Landscapers.tsx';
@@ -27,7 +27,7 @@ export default function ControlPlaneView() {
   const { projectName, workspaceName, controlPlaneName, contextName } = useParams();
   const { t } = useTranslation();
 
-  const { data: mcp, error } = useResource(
+  const { data: mcp, error } = useApiResource(
     ControlPlaneResource(projectName ?? '', workspaceName ?? '', controlPlaneName ?? ''),
   );
 

--- a/src/views/ControlPlanes/ControlPlaneView.tsx
+++ b/src/views/ControlPlanes/ControlPlaneView.tsx
@@ -1,10 +1,4 @@
-import {
-  ObjectPage,
-  ObjectPageSection,
-  ObjectPageTitle,
-  Panel,
-  Title,
-} from '@ui5/webcomponents-react';
+import { ObjectPage, ObjectPageSection, ObjectPageTitle, Panel, Title } from '@ui5/webcomponents-react';
 import { useParams } from 'react-router-dom';
 import CopyKubeconfigButton from '../../components/ControlPlanes/CopyKubeconfigButton.tsx';
 import '@ui5/webcomponents-fiori/dist/illustrations/SimpleBalloon';
@@ -17,10 +11,7 @@ import IntelligentBreadcrumbs from '../../components/Core/IntelligentBreadcrumbs
 import FluxList from '../../components/ControlPlane/FluxList.tsx';
 import { ControlPlane as ControlPlaneResource } from '../../lib/api/types/crate/controlPlanes.ts';
 import { useTranslation } from 'react-i18next';
-import {
-  McpContextProvider,
-  WithinManagedControlPlane,
-} from '../../lib/shared/McpContext.tsx';
+import { McpContextProvider, WithinManagedControlPlane } from '../../lib/shared/McpContext.tsx';
 import { ManagedResources } from '../../components/ControlPlane/ManagedResources.tsx';
 import { ProvidersConfig } from '../../components/ControlPlane/ProvidersConfig.tsx';
 import { Providers } from '../../components/ControlPlane/Providers.tsx';
@@ -33,16 +24,11 @@ import { Landscapers } from '../../components/ControlPlane/Landscapers.tsx';
 import { AuthProviderMcp } from '../../spaces/mcp/auth/AuthContextMcp.tsx';
 
 export default function ControlPlaneView() {
-  const { projectName, workspaceName, controlPlaneName, contextName } =
-    useParams();
+  const { projectName, workspaceName, controlPlaneName, contextName } = useParams();
   const { t } = useTranslation();
 
   const { data: mcp, error } = useResource(
-    ControlPlaneResource(
-      projectName ?? '',
-      workspaceName ?? '',
-      controlPlaneName ?? '',
-    ),
+    ControlPlaneResource(projectName ?? '', workspaceName ?? '', controlPlaneName ?? ''),
   );
 
   if (!projectName || !workspaceName || !controlPlaneName) {
@@ -52,11 +38,7 @@ export default function ControlPlaneView() {
   if (error) {
     return <IllustratedError details={error.message} />;
   }
-  if (
-    !mcp?.status?.access?.key ||
-    !mcp?.status?.access?.name ||
-    !mcp?.status?.access?.namespace
-  ) {
+  if (!mcp?.status?.access?.key || !mcp?.status?.access?.name || !mcp?.status?.access?.namespace) {
     return <IllustratedError details={t('ControlPlaneView.accessError')} />;
   }
 
@@ -113,11 +95,7 @@ export default function ControlPlaneView() {
               <Panel
                 headerLevel="H2"
                 headerText="Panel"
-                header={
-                  <Title level="H3">
-                    {t('ControlPlaneView.componentsTitle')}
-                  </Title>
-                }
+                header={<Title level="H3">{t('ControlPlaneView.componentsTitle')}</Title>}
                 noAnimation
               >
                 <ComponentList mcp={mcp} />
@@ -132,11 +110,7 @@ export default function ControlPlaneView() {
               <Panel
                 headerLevel="H3"
                 headerText="Panel"
-                header={
-                  <Title level="H3">
-                    {t('ControlPlaneView.crossplaneTitle')}
-                  </Title>
-                }
+                header={<Title level="H3">{t('ControlPlaneView.crossplaneTitle')}</Title>}
                 noAnimation
               >
                 <div className="crossplane-table-element">
@@ -159,11 +133,7 @@ export default function ControlPlaneView() {
               <Panel
                 headerLevel="H3"
                 headerText="Panel"
-                header={
-                  <Title level="H3">
-                    {t('ControlPlaneView.landscapersTitle')}
-                  </Title>
-                }
+                header={<Title level="H3">{t('ControlPlaneView.landscapersTitle')}</Title>}
                 noAnimation
               >
                 <Landscapers />
@@ -178,9 +148,7 @@ export default function ControlPlaneView() {
               <Panel
                 headerLevel="H3"
                 headerText="Panel"
-                header={
-                  <Title level="H3">{t('ControlPlaneView.gitOpsTitle')}</Title>
-                }
+                header={<Title level="H3">{t('ControlPlaneView.gitOpsTitle')}</Title>}
                 noAnimation
               >
                 <FluxList />

--- a/src/views/Login.tsx
+++ b/src/views/Login.tsx
@@ -40,10 +40,7 @@ export default function LoginView() {
             </p>
           </Text>
           <div>
-            <Button
-              design={ButtonDesign.Emphasized}
-              onClick={() => void auth.login()}
-            >
+            <Button design={ButtonDesign.Emphasized} onClick={() => void auth.login()}>
               {t('Login.signInButton')}
             </Button>
           </div>


### PR DESCRIPTION
Since we updated the Prettier rules to allow more characters per line, I ran Prettier across the codebase to clean things up. Most of the changes happened automatically with `--fix` (`eslint ./src --report-unused-disable-directives --max-warnings 0 --fix`).

The only “real” (non-automatic) changes are in the last commit to fix the remaining linter warnings ([4ab9ac5](https://github.com/openmcp-project/ui-frontend/pull/202/commits/4ab9ac58f40289d4e0c36985e849e27de8d55504)).

The PR also enables the linter in GH actions.