### PR TITLE
fix(sentry): remove sendDefaultPii option to enhance privacy

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,9 +16,6 @@ if (!process.env.BFF_SENTRY_DSN || process.env.BFF_SENTRY_DSN.trim() === '') {
 } else {
   Sentry.init({
     dsn: process.env.BFF_SENTRY_DSN,
-    // Setting this option to true will send default PII data to Sentry.
-    // For example, automatic IP address collection on events
-    sendDefaultPii: true,
     environment: process.env.VITE_SENTRY_ENVIRONMENT,
     beforeSend(event) {
       if (event.request && event.request.cookies) {

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -8,9 +8,6 @@ let sentryRoutes = Routes;
 if (import.meta.env.VITE_SENTRY_DSN && import.meta.env.VITE_SENTRY_DSN.length > 0) {
   Sentry.init({
     dsn: import.meta.env.VITE_SENTRY_DSN,
-    // Setting this option to true will send default PII data to Sentry.
-    // For example, automatic IP address collection on events
-    sendDefaultPii: true,
     environment: import.meta.env.VITE_SENTRY_ENVIRONMENT,
     integrations: [
       Sentry.reactRouterV7BrowserTracingIntegration({


### PR DESCRIPTION
This pull request removes the `sendDefaultPii` option from Sentry initialization in both the server and client codebases, ensuring that default Personally Identifiable Information (PII) is no longer sent to Sentry.

### Changes related to Sentry configuration:

* [`server.js`](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fL19-L21): Removed the `sendDefaultPii` option from the Sentry initialization, which previously allowed automatic PII data collection, such as IP addresses, when enabled.
* [`src/mount.ts`](diffhunk://#diff-10dced802c6852b5a362ffd5970356d2be22d555549040e3533bea567bdc878cL11-L13): Removed the `sendDefaultPii` option from the Sentry initialization in the client-side setup, aligning it with the updated privacy policy.