### PR TITLE
Fix: Don’t render connect button when there are errors

### DIFF
--- a/src/components/ControlPlanes/ConnectButton.tsx
+++ b/src/components/ControlPlanes/ConnectButton.tsx
@@ -37,7 +37,7 @@ export default function ConnectButton(props: Props) {
   const { t } = useTranslation();
 
   const res = useApiResource(GetKubeconfig(props.secretKey, props.secretName, props.namespace));
-  if (res.isLoading) {
+  if (res.isLoading || res.error) {
     return <></>;
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
This PR resolves an issue where the creation of new MCPs causes the UI to crash.

(follow-up to https://github.com/openmcp-project/ui-frontend/pull/206)