### PR TITLE
chore(ci): update Node.js

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm' # Added caching for faster installs
 
       - name: Install dependencies


### PR DESCRIPTION
https://github.com/openmcp-project/ui-frontend/pull/212 upgraded the Node.js version from 22 to 24. This PR adjusts the pipeline.