### PR TITLE
fix: Link for connect button

### DIFF
--- a/src/components/ControlPlanes/ConnectButton.tsx
+++ b/src/components/ControlPlanes/ConnectButton.tsx
@@ -88,7 +88,7 @@ export default function ConnectButton(props: Props) {
             text={context.context.user}
             data-target={`/mcp/projects/${props.projectName}/workspaces/${extractWorkspaceNameFromNamespace(
               props.workspaceName,
-            )}/mcps/${props.controlPlaneName}/context/${context.name}`}
+            )}/mcps/${props.controlPlaneName}`}
             additionalText={`(${
               context.context.user === 'openmcp' ? t('ConnectButton.defaultIdP') : t('ConnectButton.unsupportedIdP')
             })`}


### PR DESCRIPTION
This PR fixes the link used by the Connect button when multiple contexts are present.

We previously removed the context from the URL (see https://github.com/openmcp-project/ui-frontend/pull/206), but this instance was missed.