### PR TITLE
feat: set maxWidth for scaling

### DIFF
--- a/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
@@ -76,7 +76,7 @@ export function ControlPlaneListWorkspaceGridTile({ projectName, workspace }: Pr
       >
         <Panel
           headerLevel="H2"
-          style={{ maxWidth: '1200px', margin: '2px auto 0px auto', width: '100%' }}
+          style={{ maxWidth: '1200px', margin: '0px auto 0px auto', width: '100%' }}
           header={
             <div
               style={{

--- a/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
@@ -76,7 +76,7 @@ export function ControlPlaneListWorkspaceGridTile({ projectName, workspace }: Pr
       >
         <Panel
           headerLevel="H2"
-          style={{ margin: '12px 12px 12px 0' }}
+          style={{ maxWidth: '1200px', margin: '2px auto 0px auto', width: '100%' }}
           header={
             <div
               style={{

--- a/src/components/Projects/ProjectsList.tsx
+++ b/src/components/Projects/ProjectsList.tsx
@@ -133,7 +133,17 @@ export default function ProjectsList() {
 
   return (
     <>
-      <AnalyticalTable style={{ margin: '12px' }} columns={stabilizedColumns} data={stabilizedData} />
+    <AnalyticalTable
+      style={{
+        maxWidth: '1200px',
+        margin: '10px auto -8px auto',
+        width: '100%',
+        borderRadius: '12px', // Add this line
+        overflow: 'hidden',   // Ensures content doesn't overflow rounded corners
+      }}
+      columns={stabilizedColumns}
+      data={stabilizedData}
+    />    
     </>
   );
 }

--- a/src/spaces/mcp/pages/McpPage.tsx
+++ b/src/spaces/mcp/pages/McpPage.tsx
@@ -106,6 +106,7 @@ export default function McpPage() {
               hideTitleText
             >
               <Panel
+                style={{ maxWidth: '1200px', margin: '2px auto -8px auto', width: '100%' }}
                 headerLevel="H2"
                 headerText="Panel"
                 header={<Title level="H3">{t('McpPage.componentsTitle')}</Title>}
@@ -121,6 +122,7 @@ export default function McpPage() {
               hideTitleText
             >
               <Panel
+                style={{ maxWidth: '1200px', margin: '0.1em auto -8px auto', width: '100%' }}
                 headerLevel="H3"
                 headerText="Panel"
                 header={<Title level="H3">{t('McpPage.crossplaneTitle')}</Title>}
@@ -144,6 +146,7 @@ export default function McpPage() {
               hideTitleText
             >
               <Panel
+                style={{ maxWidth: '1200px', margin: '0.1em auto -8px auto', width: '100%' }}
                 headerLevel="H3"
                 headerText="Panel"
                 header={<Title level="H3">{t('McpPage.landscapersTitle')}</Title>}
@@ -159,6 +162,7 @@ export default function McpPage() {
               hideTitleText
             >
               <Panel
+                style={{ maxWidth: '1200px', margin: '0.1em auto -8px auto', width: '100%' }}
                 headerLevel="H3"
                 headerText="Panel"
                 header={<Title level="H3">{t('McpPage.gitOpsTitle')}</Title>}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently opening the UI on an ultra wide screen renders is very hard to dissect for my eyes having to travel a lot. Having an optimized version for standard screen size and only expand the grey part afterwards mitigates this. 

This was done across Projects, Workspaces and MCPs screen for uniformity.

**Before:**
<img width="1711" height="484" alt="image" src="https://github.com/user-attachments/assets/4313c024-43c3-473d-90da-b39eeb5ef7be" />

**After:**

<img width="1719" height="437" alt="image" src="https://github.com/user-attachments/assets/87064666-9562-4f41-90c0-7471496d17f9" />
