### PR TITLE
fix: collaps non permitted workspaces

### DIFF
--- a/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
@@ -49,6 +49,7 @@ export function ControlPlaneListWorkspaceGridTile({ projectName, workspace }: Pr
 
   const { mcpCreationGuide } = useLink();
   const errorView = createErrorView(cpsError);
+  const shouldCollapsePanel = !!errorView;
 
   function createErrorView(error: APIError) {
     if (error) {
@@ -77,6 +78,7 @@ export function ControlPlaneListWorkspaceGridTile({ projectName, workspace }: Pr
         <Panel
           headerLevel="H2"
           style={{ margin: '12px 12px 12px 0' }}
+          collapsed={shouldCollapsePanel}
           header={
             <div
               style={{


### PR DESCRIPTION
**What this PR does / why we need it**:

When opening the workspace section I do not find it nice to be greeted with the things I can not do. Point me to the workspaces I have access to. 

**Before:**

<img width="1703" height="1238" alt="image" src="https://github.com/user-attachments/assets/ec143559-0bc5-4f79-94ff-057b6c837e68" />


**After:**

<img width="1671" height="541" alt="image" src="https://github.com/user-attachments/assets/1eed4fa4-3d74-44eb-920b-212030051c3a" />
