### PR TITLE
align graph sizes

### DIFF
--- a/src/components/Graphs/Graph.module.css
+++ b/src/components/Graphs/Graph.module.css
@@ -2,7 +2,7 @@
   display: flex;
   height: 600px;
   border: 1px solid var(--sapList_BorderColor, #ddd);
-  border-radius: 8px;
+  border-radius: 16px;
   overflow: hidden;
   background-color: var(--sapBackgroundColor, #fafafa);
   font-family: var(--sapFontFamily);
@@ -20,6 +20,7 @@
   gap: 1rem;
   align-items: center;
   color: var(--sapTextColor, #222);
+  font-size: var(--sapFontSize);
 }
 
 .graphToolbar {

--- a/src/components/Graphs/Legend.module.css
+++ b/src/components/Graphs/Legend.module.css
@@ -1,6 +1,6 @@
 .legendContainer {
   padding: 1rem;
-  min-width: 240px;
+  min-width: 220px;
   max-width: 300px;
   max-height: 280px;
   border: 1px solid var(--sapList_BorderColor, #ccc);
@@ -11,6 +11,7 @@
   overflow: auto;
   align-self: flex-start;
   color: var(--sapTextColor, #222);
+  font-size: var(--sapFontSize);
 }
 
 .legendTitle {
@@ -21,8 +22,11 @@
 .legendRow {
   display: flex;
   align-items: center;
-  margin-bottom: 8px;
   color: var(--sapTextColor, #222);
+}
+
+.legendRow:not(:last-child) {
+  margin-bottom: 8px;
 }
 
 .legendColorBox {


### PR DESCRIPTION
Minor CSS tweaks to use default font sizes and whitespaces in Graph

# Before
<img width="1798" height="627" alt="image" src="https://github.com/user-attachments/assets/7912a980-ebd7-4112-8325-2677a721de8f" />


# After
<img width="1798" height="627" alt="image" src="https://github.com/user-attachments/assets/0318426c-02bc-44c5-a95b-5a6d687e823c" />
