### PR TITLE
Fixing closing dialog with escape button

### DIFF
--- a/src/components/Members/AddEditMemberDialog.tsx
+++ b/src/components/Members/AddEditMemberDialog.tsx
@@ -123,7 +123,7 @@ export const AddEditMemberDialog: FC<AddEditMemberDialogProps> = ({
   const dialogHeader = memberToEdit ? t('EditMembers.editHeader') : t('EditMembers.addHeader') || 'Add member';
 
   return (
-    <Dialog open={open} headerText={dialogHeader}>
+    <Dialog open={open} headerText={dialogHeader} onClose={onClose}>
       <div className={styles.container}>
         <FlexBox alignItems={'Baseline'} direction={'Column'} className={styles.wrapper}>
           <FlexBox alignItems={'Baseline'} justifyContent={'SpaceBetween'}>


### PR DESCRIPTION
**What this PR does / why we need it**:

There was a bug, when you close edit dialog using ESC button, you cannot use edit again. This small fix is solving issue.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

