### PR TITLE
fix: breadcrumbs key

### DIFF
--- a/src/components/Core/PathAwareBreadcrumbs/PathAwareBreadcrumbs.tsx
+++ b/src/components/Core/PathAwareBreadcrumbs/PathAwareBreadcrumbs.tsx
@@ -57,8 +57,8 @@ export function PathAwareBreadcrumbs({
         }
       }}
     >
-      {breadcrumbItems.map((item) => (
-        <BreadcrumbsItem key={item.path} data-target={item.path} data-testid="breadcrumb-item">
+      {breadcrumbItems.map((item, index) => (
+        <BreadcrumbsItem key={index} data-target={item.path} data-testid="breadcrumb-item">
           {item.label}
         </BreadcrumbsItem>
       ))}


### PR DESCRIPTION
This PR fixes the console error with duplicate keys in the breadcrumbs.
<img width="494" height="71" alt="image" src="https://github.com/user-attachments/assets/7f2e2b85-bb5f-472a-aea9-0d2dc67e3585" />


Since paths aren’t unique (yet!), I’ve switched the `key` from `path` to `index`. This should be fine for now, as the items are static.