### PR TITLE
fix: remove graph background color

### DIFF
--- a/src/components/Graphs/Graph.module.css
+++ b/src/components/Graphs/Graph.module.css
@@ -1,10 +1,7 @@
 .graphContainer {
   display: flex;
   height: 600px;
-  border: 1px solid var(--sapList_BorderColor, #ddd);
-  border-radius: 16px;
   overflow: hidden;
-  background-color: var(--sapBackgroundColor, #fafafa);
   font-family: var(--sapFontFamily);
 }
 


### PR DESCRIPTION
This PR removes the background color of the graph for now.

<img width="1341" height="858" alt="image" src="https://github.com/user-attachments/assets/67164187-bb84-4d24-8e25-8c37a2b8b3e1" />

<img width="1341" height="858" alt="image" src="https://github.com/user-attachments/assets/875e8b09-9598-4ac7-91f4-d6fd0002761a" />
