### PR TITLE
feat: CSRF protection

### DIFF
--- a/server/plugins/csrf-protection.ts
+++ b/server/plugins/csrf-protection.ts
@@ -1,5 +1,7 @@
 import fp from 'fastify-plugin';
 
+const isLocalDev = process.argv.includes('--local-dev');
+
 // @ts-ignore
 async function csrfProtection(fastify) {
   const { POST_LOGIN_REDIRECT, ALLOWED_CORS_ORIGINS } = fastify.config;
@@ -26,38 +28,53 @@ async function csrfProtection(fastify) {
     }
   }
 
-  if (allowedOrigins.size === 0) {
+  if (!isLocalDev && allowedOrigins.size === 0) {
     throw new Error(
       'CSRF protection: allowedOrigins is empty — all POST requests would be blocked. ' +
-        'Ensure POST_LOGIN_REDIRECT is a valid URL.',
+        `Ensure POST_LOGIN_REDIRECT or ALLOWED_CORS_ORIGINS provides at least one valid URL. ` +
+        `Received POST_LOGIN_REDIRECT=${JSON.stringify(POST_LOGIN_REDIRECT)}, ` +
+        `ALLOWED_CORS_ORIGINS=${JSON.stringify(ALLOWED_CORS_ORIGINS)}.`,
     );
   }
 
-  fastify.log.info({ allowedOrigins: [...allowedOrigins] }, 'CSRF origin validation enabled');
+  if (isLocalDev) {
+    fastify.log.info('CSRF origin validation disabled in local development mode');
+  } else {
+    fastify.log.info({ allowedOrigins: [...allowedOrigins] }, 'CSRF origin validation enabled');
+  }
 
-  // @ts-ignore
-  fastify.addHook('onRequest', async (request, reply) => {
-    if (request.method !== 'POST') return;
+  fastify.decorate('csrfPreHandler', csrfPreHandler.bind(null, allowedOrigins));
+}
 
-    const origin = request.headers['origin'];
-    const referer = request.headers['referer'];
+// @ts-ignore
+function csrfPreHandler(allowedOrigins: Set<string>, request, reply, done) {
+  if (isLocalDev) {
+    return done();
+  }
 
-    let source: string | undefined;
-    if (origin) {
-      source = origin;
-    } else if (referer) {
-      try {
-        source = new URL(referer).origin;
-      } catch {
-        // malformed referer
-      }
+  const rawOrigin = request.headers['origin'];
+  const rawReferer = request.headers['referer'];
+
+  const origin = Array.isArray(rawOrigin) ? rawOrigin[0] : rawOrigin;
+  const referer = Array.isArray(rawReferer) ? rawReferer[0] : rawReferer;
+
+  let source: string | undefined;
+  if (origin) {
+    source = origin;
+  } else if (referer) {
+    try {
+      source = new URL(referer).origin;
+    } catch {
+      // malformed referer
     }
+  }
 
-    if (!source || !allowedOrigins.has(source)) {
-      request.log.warn({ origin, referer, source }, 'CSRF origin validation failed');
-      return reply.code(403).send({ error: 'CSRF origin validation failed' });
-    }
-  });
+  if (!source || !allowedOrigins.has(source)) {
+    request.log.warn({ origin, referer, source }, 'CSRF origin validation failed');
+    return reply.code(403).send({ error: 'CSRF origin validation failed' });
+  }
+
+  done();
 }
 
 export default fp(csrfProtection);

--- a/server/plugins/csrf-protection.ts
+++ b/server/plugins/csrf-protection.ts
@@ -1,0 +1,63 @@
+import fp from 'fastify-plugin';
+
+// @ts-ignore
+async function csrfProtection(fastify) {
+  const { POST_LOGIN_REDIRECT, ALLOWED_CORS_ORIGINS } = fastify.config;
+
+  const allowedOrigins = new Set<string>();
+
+  if (POST_LOGIN_REDIRECT) {
+    try {
+      allowedOrigins.add(new URL(POST_LOGIN_REDIRECT).origin);
+    } catch {
+      fastify.log.warn('POST_LOGIN_REDIRECT is not a valid URL, skipping for CSRF allowlist');
+    }
+  }
+
+  if (ALLOWED_CORS_ORIGINS && ALLOWED_CORS_ORIGINS.trim()) {
+    for (const raw of ALLOWED_CORS_ORIGINS.split(',')) {
+      const trimmed = raw.trim();
+      if (!trimmed) continue;
+      try {
+        allowedOrigins.add(new URL(trimmed).origin);
+      } catch {
+        fastify.log.warn(`ALLOWED_CORS_ORIGINS entry "${trimmed}" is not a valid URL, skipping`);
+      }
+    }
+  }
+
+  if (allowedOrigins.size === 0) {
+    throw new Error(
+      'CSRF protection: allowedOrigins is empty — all POST requests would be blocked. ' +
+        'Ensure POST_LOGIN_REDIRECT is a valid URL.',
+    );
+  }
+
+  fastify.log.info({ allowedOrigins: [...allowedOrigins] }, 'CSRF origin validation enabled');
+
+  // @ts-ignore
+  fastify.addHook('onRequest', async (request, reply) => {
+    if (request.method !== 'POST') return;
+
+    const origin = request.headers['origin'];
+    const referer = request.headers['referer'];
+
+    let source: string | undefined;
+    if (origin) {
+      source = origin;
+    } else if (referer) {
+      try {
+        source = new URL(referer).origin;
+      } catch {
+        // malformed referer
+      }
+    }
+
+    if (!source || !allowedOrigins.has(source)) {
+      request.log.warn({ origin, referer, source }, 'CSRF origin validation failed');
+      return reply.code(403).send({ error: 'CSRF origin validation failed' });
+    }
+  });
+}
+
+export default fp(csrfProtection);

--- a/server/routes/auth-mcp.ts
+++ b/server/routes/auth-mcp.ts
@@ -179,7 +179,7 @@ async function authPlugin(fastify) {
   });
 
   // @ts-expect-error - Fastify plugin route handler typing needs refinement
-  fastify.post('/auth/mcp/refresh', async function (req, reply) {
+  fastify.post('/auth/mcp/refresh', { preHandler: fastify.csrfPreHandler }, async function (req, reply) {
     const { namespace, mcp, idp } = req.query;
 
     const refreshToken = req.encryptedSession.get('mcp_refreshToken');

--- a/server/routes/auth-mcp.ts
+++ b/server/routes/auth-mcp.ts
@@ -191,7 +191,7 @@ async function authPlugin(fastify) {
   });
 
   // @ts-expect-error - Fastify plugin route handler typing needs refinement
-  fastify.post('/auth/mcp/refresh', { config: authRateLimit }, async function (req, reply) {
+  fastify.post('/auth/mcp/refresh', { config: authRateLimit, preHandler: fastify.csrfPreHandler }, async function (req, reply) {
     const { namespace, mcp, idp } = req.query;
 
     const refreshToken = req.encryptedSession.get('mcp_refreshToken');

--- a/server/routes/auth-onboarding.ts
+++ b/server/routes/auth-onboarding.ts
@@ -73,7 +73,7 @@ async function authPlugin(fastify) {
   });
 
   // @ts-expect-error - Fastify plugin route handler typing needs refinement
-  fastify.post('/auth/onboarding/refresh', async function (req, reply) {
+  fastify.post('/auth/onboarding/refresh', { preHandler: fastify.csrfPreHandler }, async function (req, reply) {
     const refreshToken = req.encryptedSession.get('onboarding_refreshToken');
     if (!refreshToken) {
       req.log.error('Missing refresh token; deleting encryptedSession.');
@@ -129,7 +129,7 @@ async function authPlugin(fastify) {
   });
 
   // @ts-ignore
-  fastify.post('/auth/logout', async function (req, reply) {
+  fastify.post('/auth/logout', { preHandler: fastify.csrfPreHandler }, async function (req, reply) {
     // TODO: Idp sign out flow
     await req.encryptedSession.clear();
     return reply.send({ message: 'Logged out' });

--- a/server/routes/auth-onboarding.ts
+++ b/server/routes/auth-onboarding.ts
@@ -82,7 +82,7 @@ async function authPlugin(fastify) {
   });
 
   // @ts-expect-error - Fastify plugin route handler typing needs refinement
-  fastify.post('/auth/onboarding/refresh', { config: authRateLimit }, async function (req, reply) {
+  fastify.post('/auth/onboarding/refresh', { config: authRateLimit, preHandler: fastify.csrfPreHandler }, async function (req, reply) {
     const refreshToken = req.encryptedSession.get('onboarding_refreshToken');
     if (!refreshToken) {
       req.log.error('Missing refresh token; deleting encryptedSession.');
@@ -138,7 +138,7 @@ async function authPlugin(fastify) {
   });
 
   // @ts-ignore
-  fastify.post('/auth/logout', { config: authRateLimit }, async function (req, reply) {
+  fastify.post('/auth/logout', { config: authRateLimit, preHandler: fastify.csrfPreHandler }, async function (req, reply) {
     // TODO: Idp sign out flow
     await req.encryptedSession.clear();
     return reply.send({ message: 'Logged out' });


### PR DESCRIPTION
Adds CSRF protection to the three auth endpoints (logout, onboarding/refresh, mcp/refresh) by validating the request origin against an allowlist.