### PR TITLE
fix: run container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,6 @@ WORKDIR /usr/src/app
 COPY --from=build-stage /usr/src/app/dist /usr/src/app/dist
 COPY --from=build-stage /usr/src/app/node_modules /usr/src/app/node_modules
 
-# Run
+USER nonroot
+
 CMD ["dist/server.js"]


### PR DESCRIPTION
## Summary
- Add `USER nonroot` to the production stage of the Dockerfile
- The distroless `nodejs24-debian12` image includes a `nonroot` user (UID 65532)
- Ensures the container does not run as root

## Test plan
- [ ] Verify the image builds successfully
- [ ] Verify the container starts as non-root
- [ ] Verify the app serves correctly on port 5173