### PR TITLE
fix: use numeric UID for non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ WORKDIR /usr/src/app
 COPY --from=build-stage /usr/src/app/dist /usr/src/app/dist
 COPY --from=build-stage /usr/src/app/node_modules /usr/src/app/node_modules
 
-USER nonroot
+USER 65532:65532
 
 CMD ["dist/server.js"]


### PR DESCRIPTION
## Summary
- Change `USER nonroot` to `USER 65532:65532` in the Dockerfile
- Kubernetes cannot verify non-numeric usernames against `runAsNonRoot`, causing: `image has non-numeric user (nonroot), cannot verify user is non-root`
- UID 65532 is the `nonroot` user built into distroless images

## Test plan
- [ ] Verify the image builds successfully
- [ ] Verify the container starts without `runAsNonRoot` errors
- [ ] Verify the app serves correctly on port 5173