### PR TITLE
chore: group vite packages in Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,13 @@
   },
   "packageRules": [
     {
+      "groupName": "vite",
+      "matchPackageNames": [
+        "vite",
+        "@vitejs/{/,}**"
+      ]
+    },
+    {
       "groupName": "@ui5/webcomponents packages",
       "matchPackageNames": [
         "@ui5/webcomponents{/,}**"


### PR DESCRIPTION
⁠vite and ⁠@vitejs/plugin-react need to be updated together to avoid compatibility issues. Grouping them ensures both stay in sync.