### PR TITLE
fix: renovate to immediately create PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
     "npm:unpublishSafe",
     ":disableDependencyDashboard"
   ],
-  "prCreation": "not-pending",
+  "prCreation": "immediate",
   "lockFileMaintenance": {
     "enabled": true
   },


### PR DESCRIPTION
#366 introduced `prCreation: "not-pending"` to fix stuck Renovate branches. Since our CI only triggers on `pull_request` events, branches never get a status, causing a permanent deadlock.