### PR TITLE
fix: BFF auth guard

### DIFF
--- a/server/plugins/http-proxy.ts
+++ b/server/plugins/http-proxy.ts
@@ -17,11 +17,22 @@ function proxyPlugin(fastify) {
     }
   });
 
-  const requireAuthentication = async (req, reply) => {
-    const accessToken = req.encryptedSession.get('onboarding_accessToken');
-    if (!accessToken) {
-      reply.code(401).send({ statusCode: 401, error: 'Unauthorized', message: 'Authentication required' });
-      return;
+  // @ts-ignore
+  const requireOnboardingAuth = async (req, reply) => {
+    const onboardingToken = req.encryptedSession.get('onboarding_accessToken');
+    if (!onboardingToken) {
+      return reply.unauthorized('Authentication required.');
+    }
+    const useCrate = req.headers['x-use-crate'];
+    if (!useCrate && !req.encryptedSession.get('mcp_accessToken')) {
+      return reply.unauthorized('Authentication required.');
+    }
+  };
+
+  // @ts-ignore
+  const requireGraphqlAuth = async (req, reply) => {
+    if (!req.encryptedSession.get('onboarding_accessToken')) {
+      return reply.unauthorized('Authentication required.');
     }
   };
 
@@ -36,7 +47,7 @@ function proxyPlugin(fastify) {
   fastify.register(httpProxy, {
     prefix: '/onboarding',
     upstream: API_BACKEND_URL,
-    preHandler: requireAuthentication,
+    preHandler: requireOnboardingAuth,
     replyOptions: {
       // @ts-ignore
       rewriteRequestHeaders: (req, headers) => {
@@ -57,7 +68,7 @@ function proxyPlugin(fastify) {
       prefix: '/graphql',
       upstream: graphqlUrl.origin,
       rewritePrefix: graphqlUrl.pathname,
-      preHandler: requireAuthentication,
+      preHandler: requireGraphqlAuth,
       replyOptions: {
         // @ts-ignore
         rewriteRequestHeaders: (req, headers) => {

--- a/server/plugins/http-proxy.ts
+++ b/server/plugins/http-proxy.ts
@@ -17,6 +17,14 @@ function proxyPlugin(fastify) {
     }
   });
 
+  const requireAuthentication = async (req, reply) => {
+    const accessToken = req.encryptedSession.get('onboarding_accessToken');
+    if (!accessToken) {
+      reply.code(401).send({ statusCode: 401, error: 'Unauthorized', message: 'Authentication required' });
+      return;
+    }
+  };
+
   // Remove accept-encoding to prevent backend from compressing
   // This avoids double-compression or encoding issues
   // @ts-ignore
@@ -28,6 +36,7 @@ function proxyPlugin(fastify) {
   fastify.register(httpProxy, {
     prefix: '/onboarding',
     upstream: API_BACKEND_URL,
+    preHandler: requireAuthentication,
     replyOptions: {
       // @ts-ignore
       rewriteRequestHeaders: (req, headers) => {
@@ -48,6 +57,7 @@ function proxyPlugin(fastify) {
       prefix: '/graphql',
       upstream: graphqlUrl.origin,
       rewritePrefix: graphqlUrl.pathname,
+      preHandler: requireAuthentication,
       replyOptions: {
         // @ts-ignore
         rewriteRequestHeaders: (req, headers) => {


### PR DESCRIPTION
Add authentication guard (preHandler) to BFF proxy routes. Unauthenticated requests now receive 401 instead of being forwarded to the backend.