### PR TITLE
fix: renovate group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,7 +31,8 @@
       "matchPackageNames": [
         "@opentelemetry/{/,}**"
       ],
-      "matchUpdateTypes": ["major", "minor", "patch", "digest"]
+      "matchUpdateTypes": ["major", "minor", "patch", "digest"],
+      "separateMajorMinor": false
     }
   ]
 }


### PR DESCRIPTION
With https://github.com/openmcp-project/ui-frontend/pull/508 the otel packages are grouped but separated by minor/major in 2 different PRs. With this change, we should get a single PR across the versions.