### PR TITLE
fix: renovate grouping

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,7 +31,6 @@
       "matchPackageNames": [
         "@opentelemetry/{/,}**"
       ],
-      "matchUpdateTypes": ["major", "minor", "patch", "digest"],
       "separateMajorMinor": false
     }
   ]


### PR DESCRIPTION
Fixes renovate error, seems matchUpdateTypes and separateMajorMinor can't be used together.