### PR TITLE
make copy namespace button hoverable

### DIFF
--- a/src/components/Projects/ProjectChooser.tsx
+++ b/src/components/Projects/ProjectChooser.tsx
@@ -4,6 +4,7 @@ import useLuigiNavigate from '../Shared/useLuigiNavigate.tsx';
 import IllustratedError from '../Shared/IllustratedError.tsx';
 import { useApiResource } from '../../lib/api/useApiResource';
 import { ListProjectNames } from '../../lib/api/types/crate/listProjectNames';
+import { projectnameToNamespace } from '../../utils';
 
 interface Props {
   currentProjectName: string;
@@ -36,7 +37,7 @@ export default function ProjectChooser({ currentProjectName }: Props) {
           </VariantItem>
         ))}
       </VariantManagement>
-      <CopyButton text={`project-${currentProjectName}`} />
+      <CopyButton collapsible text={projectnameToNamespace(currentProjectName)} />
     </>
   );
 }

--- a/src/components/Shared/CopyButton.cy.tsx
+++ b/src/components/Shared/CopyButton.cy.tsx
@@ -1,0 +1,89 @@
+import { CopyButton } from './CopyButton.tsx';
+import '@ui5/webcomponents-cypress-commands';
+import { CopyButtonProvider } from '../../context/CopyButtonContext.tsx';
+import { ToastProvider } from '../../context/ToastContext.tsx';
+
+describe('CopyButton collapsible', () => {
+  const testText = 'project-test--ws-workspace';
+
+  const mountWithProviders = (component: React.ReactElement) => {
+    return cy.mount(
+      <ToastProvider>
+        <CopyButtonProvider>{component}</CopyButtonProvider>
+      </ToastProvider>,
+    );
+  };
+
+  it('renders with copy icon only when not hovered', () => {
+    mountWithProviders(<CopyButton collapsible text={testText} />);
+
+    cy.get('ui5-button[icon="copy"]').should('exist');
+  });
+
+  it('expands to show text on hover', () => {
+    mountWithProviders(<CopyButton collapsible text={testText} />);
+
+    const button = cy.get('ui5-button[icon="copy"]');
+    button.trigger('mouseenter', { force: true });
+
+    cy.wait(350);
+    button.should('contain.text', testText);
+  });
+
+  it('collapses when mouse leaves', () => {
+    mountWithProviders(<CopyButton collapsible text={testText} />);
+
+    const button = cy.get('ui5-button[icon="copy"]');
+    button.trigger('mouseenter', { force: true });
+    cy.wait(350);
+    button.trigger('mouseleave', { force: true });
+    cy.wait(350);
+
+    button.should('exist');
+  });
+
+  it('shows success state when clicked', () => {
+    cy.window().then((win) => {
+      const writeTextStub = cy.stub().resolves();
+      Object.defineProperty(win.navigator, 'clipboard', {
+        value: { writeText: writeTextStub, readText: cy.stub().resolves('') },
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    mountWithProviders(<CopyButton collapsible text={testText} />);
+
+    const button = cy.get('ui5-button[icon="copy"]');
+    button.trigger('mouseenter', { force: true });
+    cy.wait(350);
+    button.click();
+    cy.wait(500);
+
+    button.should('have.attr', 'design', 'Positive');
+    button.should('contain.text', 'Copied to clipboard');
+  });
+
+  it('displays text as tooltip', () => {
+    mountWithProviders(<CopyButton collapsible text={testText} />);
+
+    cy.get('ui5-button[icon="copy"]').should('have.attr', 'tooltip', testText);
+  });
+
+  it('handles long strings', () => {
+    const longText = 'project-very-long-project-name--ws-very-long-workspace-name';
+    mountWithProviders(<CopyButton collapsible text={longText} />);
+
+    const button = cy.get('ui5-button[icon="copy"]');
+    button.trigger('mouseenter', { force: true });
+    cy.wait(350);
+
+    button.should('contain.text', longText);
+  });
+
+  it('renders non-collapsible variant without container div', () => {
+    mountWithProviders(<CopyButton text={testText} />);
+
+    cy.get('ui5-button[icon="copy"]').should('exist').should('contain.text', testText);
+  });
+});

--- a/src/components/Shared/CopyButton.module.css
+++ b/src/components/Shared/CopyButton.module.css
@@ -1,0 +1,32 @@
+.container {
+  display: inline-flex;
+  align-items: center;
+  overflow: hidden;
+}
+
+.button {
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.button .text {
+  display: inline-block;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.collapsed .text {
+  max-width: 0;
+  opacity: 0;
+  margin-left: 0;
+}
+
+.expanded .text {
+  max-width: 500px;
+  opacity: 1;
+  margin-left: 0.5rem;
+}
+
+.button:hover {
+  background-color: var(--sapButton_Hover_Background);
+}

--- a/src/components/Shared/CopyButton.tsx
+++ b/src/components/Shared/CopyButton.tsx
@@ -1,41 +1,61 @@
 import { Button, ButtonPropTypes } from '@ui5/webcomponents-react';
 import { useCopyToClipboard } from '../../hooks/useCopyToClipboard.ts';
-import { useId, CSSProperties } from 'react';
+import { useId, CSSProperties, useState } from 'react';
 import { useCopyButton } from '../../context/CopyButtonContext.tsx';
 import { ThemingParameters } from '@ui5/webcomponents-react-base';
 import { useTranslation } from 'react-i18next';
+import styles from './CopyButton.module.css';
 
-interface CopyButtonProps extends ButtonPropTypes {
+interface CopyButtonProps extends Omit<ButtonPropTypes, 'children'> {
   text: string;
   style?: CSSProperties;
+  collapsible?: boolean;
 }
 
-export const CopyButton = ({ text, style = {}, ...buttonProps }: CopyButtonProps) => {
+export const CopyButton = ({ text, style = {}, collapsible = false, ...buttonProps }: CopyButtonProps) => {
   const { copyToClipboard } = useCopyToClipboard();
   const { activeCopyId, setActiveCopyId } = useCopyButton();
   const uniqueId = useId();
   const isCopied = activeCopyId === uniqueId;
   const { t } = useTranslation();
+  const [isHovered, setIsHovered] = useState(false);
 
   const handleCopy = async () => {
-    await copyToClipboard(text, { showToastOnSuccess: false });
-    setActiveCopyId(uniqueId);
+    const success = await copyToClipboard(text, { showToastOnSuccess: false });
+    if (success) {
+      setActiveCopyId(uniqueId);
+    }
   };
 
   const defaultStyle: CSSProperties = {
     color: isCopied ? undefined : ThemingParameters.sapContent_LabelColor,
+    ...(collapsible ? { justifyContent: 'start' } : {}),
   };
 
-  return (
+  const showFullText = !collapsible || isHovered || isCopied;
+  const buttonText = isCopied ? t('common.copyToClipboardSuccessToast') : text;
+
+  const button = (
     <Button
       icon="copy"
       design={isCopied ? 'Positive' : 'Transparent'}
-      tooltip="Copy"
+      tooltip={collapsible ? text : 'Copy'}
       style={{ ...defaultStyle, ...style }}
+      className={collapsible ? `${styles.button} ${showFullText ? styles.expanded : styles.collapsed}` : undefined}
       onClick={handleCopy}
+      onMouseEnter={collapsible ? () => setIsHovered(true) : undefined}
+      onMouseLeave={collapsible ? () => setIsHovered(false) : undefined}
+      onFocus={collapsible ? () => setIsHovered(true) : undefined}
+      onBlur={collapsible ? () => setIsHovered(false) : undefined}
       {...buttonProps}
     >
-      {isCopied ? t('common.copyToClipboardSuccessToast') : text}
+      {collapsible ? <span className={styles.text}>{buttonText}</span> : buttonText}
     </Button>
   );
+
+  if (collapsible) {
+    return <div className={styles.container}>{button}</div>;
+  }
+
+  return button;
 };


### PR DESCRIPTION
Make button more calm
regular state
<img width="3378" height="360" alt="image" src="https://github.com/user-attachments/assets/179db7f9-c2b3-412d-a5aa-9e8f60e102a0" />
& expand only on hover

<img width="423" height="205" alt="image" src="https://github.com/user-attachments/assets/444ff446-63eb-4e8e-9fcc-adbaed390c82" />

