### PR TITLE
refactor: remove redundant Dashboard and Graph section titles

### DIFF
--- a/src/spaces/mcp/pages/McpPage.module.css
+++ b/src/spaces/mcp/pages/McpPage.module.css
@@ -2,6 +2,10 @@
   margin-block: 1.5rem 3rem;
 }
 
+.sectionNoTitle {
+  margin-block: 0 0;
+}
+
 .actionsBar {
   display: flex;
   flex-direction: row;

--- a/src/spaces/mcp/pages/McpPage.tsx
+++ b/src/spaces/mcp/pages/McpPage.tsx
@@ -197,7 +197,7 @@ export default function McpPage() {
               onSelectedSectionChange={handleSectionChange}
             >
               <ObjectPageSection id="overview" titleText={t('McpPage.overviewTitle')}>
-                <ObjectPageSubSection id="dashboard" titleText={t('McpPage.dashboardTitle')} className={styles.section}>
+                <ObjectPageSubSection id="dashboard" className={styles.sectionNoTitle}>
                   <ComponentsDashboard
                     components={mcp.spec?.components}
                     onInstallButtonClick={onEditComponents}
@@ -206,7 +206,7 @@ export default function McpPage() {
                     }}
                   />
                 </ObjectPageSubSection>
-                <ObjectPageSubSection id="graph" titleText={t('McpPage.graphTitle')} className={styles.section}>
+                <ObjectPageSubSection id="graph" className={styles.sectionNoTitle}>
                   <Graph />
                 </ObjectPageSubSection>
                 <ObjectPageSubSection

--- a/src/spaces/mcp/pages/McpPage.tsx
+++ b/src/spaces/mcp/pages/McpPage.tsx
@@ -197,7 +197,7 @@ export default function McpPage() {
               onSelectedSectionChange={handleSectionChange}
             >
               <ObjectPageSection id="overview" titleText={t('McpPage.overviewTitle')}>
-                <ObjectPageSubSection id="dashboard" className={styles.sectionNoTitle}>
+                <ObjectPageSubSection id="dashboard" titleText="" className={styles.sectionNoTitle}>
                   <ComponentsDashboard
                     components={mcp.spec?.components}
                     onInstallButtonClick={onEditComponents}
@@ -206,7 +206,7 @@ export default function McpPage() {
                     }}
                   />
                 </ObjectPageSubSection>
-                <ObjectPageSubSection id="graph" className={styles.sectionNoTitle}>
+                <ObjectPageSubSection id="graph" titleText="" className={styles.sectionNoTitle}>
                   <Graph />
                 </ObjectPageSubSection>
                 <ObjectPageSubSection


### PR DESCRIPTION
These subsection titles are self-explanatory and add visual clutter. The ComponentsDashboard and Graph components speak for themselves.

- Remove titleText from dashboard and graph subsections
- Add sectionNoTitle CSS class with margin-block: 0 0
- Eliminates unnecessary whitespace where titles were removed

This creates a cleaner, more focused UI without redundant labels.
