### PR TITLE
feat: Add resource health bars to control plane page

### DIFF
--- a/src/components/ControlPlane/ManagedResources.tsx
+++ b/src/components/ControlPlane/ManagedResources.tsx
@@ -44,6 +44,7 @@ import { useHandleResourcePatch as _useHandleResourcePatch } from '../../hooks/u
 import { ApiConfigContext } from '../Shared/k8s';
 import { useHasMcpAdminRights as _useHasMcpAdminRights } from '../../spaces/mcp/auth/useHasMcpAdminRights.ts';
 import { useNavigateToTab } from '../../hooks/useNavigateToTab.ts';
+import { ResourceHealthBar } from './ResourceHealthBar/ResourceHealthBar.tsx';
 
 interface StatusFilterColumn {
   filterValue?: string;
@@ -339,47 +340,44 @@ export function ManagedResources({
       {combinedError && <IllustratedError details={combinedError.message} />}
 
       {!combinedError && (
-        <Panel
-          fixed
-          header={
-            <Toolbar>
-              <Title>{t('common.resourcesCount', { count: rows.length })}</Title>
-              <ToolbarSpacer />
-            </Toolbar>
-          }
-        >
-          <>
-            <AnalyticalTable
-              columns={columns}
-              data={rows}
-              minRows={1}
-              groupBy={['kind']}
-              scaleWidthMode={AnalyticalTableScaleWidthMode.Smart}
-              loading={combinedLoading}
-              filterable
-              retainColumnWidth
-              reactTableOptions={{
-                autoResetHiddenColumns: false,
-                autoResetPage: false,
-                autoResetExpanded: false,
-                autoResetGroupBy: false,
-                autoResetSelectedRows: false,
-                autoResetSortBy: false,
-                autoResetFilters: false,
-                autoResetRowState: false,
-                autoResetResize: false,
-              }}
-            />
+        <>
+          <ResourceHealthBar
+            resources={rows.map((r) => ({
+              ready: r.ready,
+              synced: r.synced,
+            }))}
+            type="ready-synced"
+          />
+          <AnalyticalTable
+            columns={columns}
+            data={rows}
+            minRows={1}
+            groupBy={['kind']}
+            scaleWidthMode={AnalyticalTableScaleWidthMode.Smart}
+            loading={combinedLoading}
+            filterable
+            retainColumnWidth
+            reactTableOptions={{
+              autoResetHiddenColumns: false,
+              autoResetPage: false,
+              autoResetExpanded: false,
+              autoResetGroupBy: false,
+              autoResetSelectedRows: false,
+              autoResetSortBy: false,
+              autoResetFilters: false,
+              autoResetRowState: false,
+              autoResetResize: false,
+            }}
+          />
 
-            <ManagedResourceDeleteDialog
-              open={!!pendingDeleteItem}
-              item={pendingDeleteItem}
-              onClose={() => setPendingDeleteItem(null)}
-              onDeletionConfirmed={handleDeletionConfirmed}
-            />
-            <ErrorDialog ref={errorDialogRef} />
-          </>
-        </Panel>
+          <ManagedResourceDeleteDialog
+            open={!!pendingDeleteItem}
+            item={pendingDeleteItem}
+            onClose={() => setPendingDeleteItem(null)}
+            onDeletionConfirmed={handleDeletionConfirmed}
+          />
+          <ErrorDialog ref={errorDialogRef} />
+        </>
       )}
     </>
   );

--- a/src/components/ControlPlane/ManagedResources.tsx
+++ b/src/components/ControlPlane/ManagedResources.tsx
@@ -306,17 +306,21 @@ export function ManagedResources({
         }),
       ) ?? [];
 
+  const healthStats = useMemo(() => {
+    const readyCount = rows.filter((r) => r.ready).length;
+    const syncedCount = rows.filter((r) => r.synced).length;
+    return { readyCount, syncedCount, total: rows.length };
+  }, [rows.length, managedResources]);
+
   // Notify parent of count changes
   useEffect(() => {
     if (onCountChange) {
-      onCountChange(rows.length);
+      onCountChange(healthStats.total);
     }
     if (onHealthStatsChange) {
-      const readyCount = rows.filter((r) => r.ready).length;
-      const syncedCount = rows.filter((r) => r.synced).length;
-      onHealthStatsChange(readyCount, syncedCount, rows.length);
+      onHealthStatsChange(healthStats.readyCount, healthStats.syncedCount, healthStats.total);
     }
-  }, [rows.length, onCountChange, onHealthStatsChange, rows]);
+  }, [healthStats.total, healthStats.readyCount, healthStats.syncedCount, onCountChange, onHealthStatsChange]);
 
   const handleDeletionConfirmed = async (item: ManagedResourceItem, force: boolean) => {
     toast.show(t('ManagedResources.deleteStarted', { resourceName: item.metadata.name }));

--- a/src/components/ControlPlane/ManagedResources.tsx
+++ b/src/components/ControlPlane/ManagedResources.tsx
@@ -83,12 +83,14 @@ export function ManagedResources({
   useApiResource = _useApiResource,
   useResourcePluralNames = _useResourcePluralNames,
   useHasMcpAdminRights = _useHasMcpAdminRights,
+  onCountChange,
 }: {
   useApiResourceMutation?: typeof _useApiResourceMutation;
   useHandleResourcePatch?: typeof _useHandleResourcePatch;
   useApiResource?: typeof _useApiResource;
   useResourcePluralNames?: typeof _useResourcePluralNames;
   useHasMcpAdminRights?: typeof _useHasMcpAdminRights;
+  onCountChange?: (count: number) => void;
 } = {}) {
   const { t } = useTranslation();
   const toast = useToast();
@@ -306,6 +308,13 @@ export function ManagedResources({
           };
         }),
       ) ?? [];
+
+  // Notify parent of count changes
+  useEffect(() => {
+    if (onCountChange) {
+      onCountChange(rows.length);
+    }
+  }, [rows.length, onCountChange]);
 
   const handleDeletionConfirmed = async (item: ManagedResourceItem, force: boolean) => {
     toast.show(t('ManagedResources.deleteStarted', { resourceName: item.metadata.name }));

--- a/src/components/ControlPlane/ManagedResources.tsx
+++ b/src/components/ControlPlane/ManagedResources.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Fragment, useMemo, useState, useRef, useCallback, useContext } from 'react';
+import { Fragment, useMemo, useState, useRef, useCallback, useContext, useEffect } from 'react';
 import {
   AnalyticalTable,
   AnalyticalTableColumnDefinition,

--- a/src/components/ControlPlane/ManagedResources.tsx
+++ b/src/components/ControlPlane/ManagedResources.tsx
@@ -283,34 +283,37 @@ export function ManagedResources({
     [t, openEditPanel, openDeleteDialog, hasMCPAdminRights, navigateToTab],
   );
 
-  const rows: ResourceRow[] =
-    managedResources
-      ?.filter((managedResource) => managedResource.items)
-      .flatMap((managedResource) =>
-        managedResource.items?.map((item) => {
-          const conditionSynced = item.status?.conditions?.find((condition) => condition.type === 'Synced');
-          const conditionReady = item.status?.conditions?.find((condition) => condition.type === 'Ready');
+  const rows: ResourceRow[] = useMemo(
+    () =>
+      managedResources
+        ?.filter((managedResource) => managedResource.items)
+        .flatMap((managedResource) =>
+          managedResource.items?.map((item) => {
+            const conditionSynced = item.status?.conditions?.find((condition) => condition.type === 'Synced');
+            const conditionReady = item.status?.conditions?.find((condition) => condition.type === 'Ready');
 
-          return {
-            kind: item.kind,
-            name: item.metadata.name,
-            created: formatDateAsTimeAgo(item.metadata.creationTimestamp),
-            synced: conditionSynced?.status === 'True',
-            syncedTransitionTime: conditionSynced?.lastTransitionTime ?? '',
-            ready: conditionReady?.status === 'True',
-            readyTransitionTime: conditionReady?.lastTransitionTime ?? '',
-            item: item,
-            conditionSyncedMessage: conditionSynced?.message ?? conditionSynced?.reason ?? '',
-            conditionReadyMessage: conditionReady?.message ?? conditionReady?.reason ?? '',
-          };
-        }),
-      ) ?? [];
+            return {
+              kind: item.kind,
+              name: item.metadata.name,
+              created: formatDateAsTimeAgo(item.metadata.creationTimestamp),
+              synced: conditionSynced?.status === 'True',
+              syncedTransitionTime: conditionSynced?.lastTransitionTime ?? '',
+              ready: conditionReady?.status === 'True',
+              readyTransitionTime: conditionReady?.lastTransitionTime ?? '',
+              item: item,
+              conditionSyncedMessage: conditionSynced?.message ?? conditionSynced?.reason ?? '',
+              conditionReadyMessage: conditionReady?.message ?? conditionReady?.reason ?? '',
+            };
+          }),
+        ) ?? [],
+    [managedResources],
+  );
 
   const healthStats = useMemo(() => {
     const readyCount = rows.filter((r) => r.ready).length;
     const syncedCount = rows.filter((r) => r.synced).length;
     return { readyCount, syncedCount, total: rows.length };
-  }, [rows.length, managedResources]);
+  }, [rows]);
 
   // Notify parent of count changes
   useEffect(() => {

--- a/src/components/ControlPlane/ManagedResources.tsx
+++ b/src/components/ControlPlane/ManagedResources.tsx
@@ -5,10 +5,6 @@ import {
   AnalyticalTableColumnDefinition,
   AnalyticalTableScaleWidthMode,
   Button,
-  Panel,
-  Title,
-  Toolbar,
-  ToolbarSpacer,
   Link,
 } from '@ui5/webcomponents-react';
 import {
@@ -44,7 +40,6 @@ import { useHandleResourcePatch as _useHandleResourcePatch } from '../../hooks/u
 import { ApiConfigContext } from '../Shared/k8s';
 import { useHasMcpAdminRights as _useHasMcpAdminRights } from '../../spaces/mcp/auth/useHasMcpAdminRights.ts';
 import { useNavigateToTab } from '../../hooks/useNavigateToTab.ts';
-import { ResourceHealthBar } from './ResourceHealthBar/ResourceHealthBar.tsx';
 
 interface StatusFilterColumn {
   filterValue?: string;
@@ -84,6 +79,7 @@ export function ManagedResources({
   useResourcePluralNames = _useResourcePluralNames,
   useHasMcpAdminRights = _useHasMcpAdminRights,
   onCountChange,
+  onHealthStatsChange,
 }: {
   useApiResourceMutation?: typeof _useApiResourceMutation;
   useHandleResourcePatch?: typeof _useHandleResourcePatch;
@@ -91,6 +87,7 @@ export function ManagedResources({
   useResourcePluralNames?: typeof _useResourcePluralNames;
   useHasMcpAdminRights?: typeof _useHasMcpAdminRights;
   onCountChange?: (count: number) => void;
+  onHealthStatsChange?: (ready: number, synced: number, total: number) => void;
 } = {}) {
   const { t } = useTranslation();
   const toast = useToast();
@@ -314,7 +311,12 @@ export function ManagedResources({
     if (onCountChange) {
       onCountChange(rows.length);
     }
-  }, [rows.length, onCountChange]);
+    if (onHealthStatsChange) {
+      const readyCount = rows.filter((r) => r.ready).length;
+      const syncedCount = rows.filter((r) => r.synced).length;
+      onHealthStatsChange(readyCount, syncedCount, rows.length);
+    }
+  }, [rows.length, onCountChange, onHealthStatsChange, rows]);
 
   const handleDeletionConfirmed = async (item: ManagedResourceItem, force: boolean) => {
     toast.show(t('ManagedResources.deleteStarted', { resourceName: item.metadata.name }));
@@ -350,13 +352,6 @@ export function ManagedResources({
 
       {!combinedError && (
         <>
-          <ResourceHealthBar
-            resources={rows.map((r) => ({
-              ready: r.ready,
-              synced: r.synced,
-            }))}
-            type="ready-synced"
-          />
           <AnalyticalTable
             columns={columns}
             data={rows}

--- a/src/components/ControlPlane/Providers.tsx
+++ b/src/components/ControlPlane/Providers.tsx
@@ -134,17 +134,21 @@ export function Providers({ onCountChange, onHealthStatsChange }: ProvidersProps
     [providers?.items],
   );
 
+  const healthStats = useMemo(() => {
+    const installedCount = rows.filter((r) => r.installed === 'true').length;
+    const healthyCount = rows.filter((r) => r.healthy === 'true').length;
+    return { installedCount, healthyCount, total: rows.length };
+  }, [rows]);
+
   // Notify parent of count changes
   useEffect(() => {
     if (onCountChange) {
-      onCountChange(rows.length);
+      onCountChange(healthStats.total);
     }
     if (onHealthStatsChange) {
-      const installedCount = rows.filter((r) => r.installed === 'true').length;
-      const healthyCount = rows.filter((r) => r.healthy === 'true').length;
-      onHealthStatsChange(installedCount, healthyCount, rows.length);
+      onHealthStatsChange(healthStats.installedCount, healthStats.healthyCount, healthStats.total);
     }
-  }, [rows.length, onCountChange, onHealthStatsChange, rows]);
+  }, [healthStats.total, healthStats.installedCount, healthStats.healthyCount, onCountChange, onHealthStatsChange]);
 
   const tableOptions = useMemo(
     () => ({

--- a/src/components/ControlPlane/Providers.tsx
+++ b/src/components/ControlPlane/Providers.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   AnalyticalTable,
@@ -37,7 +37,11 @@ type ProvidersRow = {
   item: unknown;
 };
 
-export function Providers() {
+interface ProvidersProps {
+  onCountChange?: (count: number) => void;
+}
+
+export function Providers({ onCountChange }: ProvidersProps = {}) {
   const { t } = useTranslation();
 
   const {
@@ -132,6 +136,13 @@ export function Providers() {
       }) ?? [],
     [providers?.items],
   );
+
+  // Notify parent of count changes
+  useEffect(() => {
+    if (onCountChange) {
+      onCountChange(rows.length);
+    }
+  }, [rows.length, onCountChange]);
 
   const tableOptions = useMemo(
     () => ({

--- a/src/components/ControlPlane/Providers.tsx
+++ b/src/components/ControlPlane/Providers.tsx
@@ -4,9 +4,6 @@ import {
   AnalyticalTable,
   AnalyticalTableColumnDefinition,
   AnalyticalTableScaleWidthMode,
-  Panel,
-  Toolbar,
-  ToolbarSpacer,
 } from '@ui5/webcomponents-react';
 
 import { useApiResource } from '../../lib/api/useApiResource';
@@ -22,7 +19,6 @@ import '@ui5/webcomponents-icons/dist/sys-cancel-2';
 import StatusFilter from '../Shared/StatusFilter/StatusFilter.tsx';
 import { ResourceStatusCell } from '../Shared/ResourceStatusCell.tsx';
 import { Resource } from '../../utils/removeManagedFieldsAndFilterData.ts';
-import { ResourceHealthBar } from './ResourceHealthBar/ResourceHealthBar.tsx';
 
 type ProvidersRow = {
   name: string;
@@ -39,9 +35,10 @@ type ProvidersRow = {
 
 interface ProvidersProps {
   onCountChange?: (count: number) => void;
+  onHealthStatsChange?: (installed: number, healthy: number, total: number) => void;
 }
 
-export function Providers({ onCountChange }: ProvidersProps = {}) {
+export function Providers({ onCountChange, onHealthStatsChange }: ProvidersProps = {}) {
   const { t } = useTranslation();
 
   const {
@@ -142,7 +139,12 @@ export function Providers({ onCountChange }: ProvidersProps = {}) {
     if (onCountChange) {
       onCountChange(rows.length);
     }
-  }, [rows.length, onCountChange]);
+    if (onHealthStatsChange) {
+      const installedCount = rows.filter((r) => r.installed === 'true').length;
+      const healthyCount = rows.filter((r) => r.healthy === 'true').length;
+      onHealthStatsChange(installedCount, healthyCount, rows.length);
+    }
+  }, [rows.length, onCountChange, onHealthStatsChange, rows]);
 
   const tableOptions = useMemo(
     () => ({
@@ -165,13 +167,6 @@ export function Providers({ onCountChange }: ProvidersProps = {}) {
 
       {!error && (
         <>
-          <ResourceHealthBar
-            resources={rows.map((r) => ({
-              installed: r.installed === 'true',
-              healthy: r.healthy === 'true',
-            }))}
-            type="installed-healthy"
-          />
           <AnalyticalTable
             columns={columns}
             data={rows}

--- a/src/components/ControlPlane/Providers.tsx
+++ b/src/components/ControlPlane/Providers.tsx
@@ -5,7 +5,6 @@ import {
   AnalyticalTableColumnDefinition,
   AnalyticalTableScaleWidthMode,
   Panel,
-  Title,
   Toolbar,
   ToolbarSpacer,
 } from '@ui5/webcomponents-react';
@@ -23,6 +22,7 @@ import '@ui5/webcomponents-icons/dist/sys-cancel-2';
 import StatusFilter from '../Shared/StatusFilter/StatusFilter.tsx';
 import { ResourceStatusCell } from '../Shared/ResourceStatusCell.tsx';
 import { Resource } from '../../utils/removeManagedFieldsAndFilterData.ts';
+import { ResourceHealthBar } from './ResourceHealthBar/ResourceHealthBar.tsx';
 
 type ProvidersRow = {
   name: string;
@@ -153,15 +153,14 @@ export function Providers() {
       {error && <IllustratedError details={error.message} />}
 
       {!error && (
-        <Panel
-          fixed
-          header={
-            <Toolbar>
-              <Title>{t('common.resourcesCount', { count: rows.length })}</Title>
-              <ToolbarSpacer />
-            </Toolbar>
-          }
-        >
+        <>
+          <ResourceHealthBar
+            resources={rows.map((r) => ({
+              installed: r.installed === 'true',
+              healthy: r.healthy === 'true',
+            }))}
+            type="installed-healthy"
+          />
           <AnalyticalTable
             columns={columns}
             data={rows}
@@ -172,7 +171,7 @@ export function Providers() {
             retainColumnWidth
             reactTableOptions={tableOptions}
           />
-        </Panel>
+        </>
       )}
     </>
   );

--- a/src/components/ControlPlane/ProvidersConfig.tsx
+++ b/src/components/ControlPlane/ProvidersConfig.tsx
@@ -4,10 +4,6 @@ import {
   AnalyticalTableColumnDefinition,
   AnalyticalTableScaleWidthMode,
   Button,
-  Panel,
-  Title,
-  Toolbar,
-  ToolbarSpacer,
 } from '@ui5/webcomponents-react';
 import '@ui5/webcomponents-icons/dist/sys-enter-2';
 import '@ui5/webcomponents-icons/dist/sys-cancel-2';
@@ -27,7 +23,6 @@ import { ErrorDialog, ErrorDialogHandle } from '../Shared/ErrorMessageBox.tsx';
 
 import { ApiConfigContext } from '../Shared/k8s';
 import { useHasMcpAdminRights } from '../../spaces/mcp/auth/useHasMcpAdminRights.ts';
-import { ResourceHealthBar } from './ResourceHealthBar/ResourceHealthBar.tsx';
 
 type Rows = {
   parent: string;

--- a/src/components/ControlPlane/ProvidersConfig.tsx
+++ b/src/components/ControlPlane/ProvidersConfig.tsx
@@ -27,6 +27,7 @@ import { ErrorDialog, ErrorDialogHandle } from '../Shared/ErrorMessageBox.tsx';
 
 import { ApiConfigContext } from '../Shared/k8s';
 import { useHasMcpAdminRights } from '../../spaces/mcp/auth/useHasMcpAdminRights.ts';
+import { ResourceHealthBar } from './ResourceHealthBar/ResourceHealthBar.tsx';
 
 type Rows = {
   parent: string;
@@ -154,40 +155,30 @@ export function ProvidersConfig() {
   );
 
   return (
-    <Panel
-      fixed
-      header={
-        <Toolbar>
-          <Title>{t('common.resourcesCount', { count: rows.length })}</Title>
-          <ToolbarSpacer />
-        </Toolbar>
-      }
-    >
-      <>
-        <AnalyticalTable
-          columns={columns}
-          data={rows ?? []}
-          minRows={1}
-          groupBy={['parent']}
-          scaleWidthMode={AnalyticalTableScaleWidthMode.Smart}
-          loading={isLoading}
-          filterable
-          // Prevent the table from resetting when the data changes
-          retainColumnWidth
-          reactTableOptions={{
-            autoResetHiddenColumns: false,
-            autoResetPage: false,
-            autoResetExpanded: false,
-            autoResetGroupBy: false,
-            autoResetSelectedRows: false,
-            autoResetSortBy: false,
-            autoResetFilters: false,
-            autoResetRowState: false,
-            autoResetResize: false,
-          }}
-        />
-        <ErrorDialog ref={errorDialogRef} />
-      </>
-    </Panel>
+    <>
+      <AnalyticalTable
+        columns={columns}
+        data={rows ?? []}
+        minRows={1}
+        groupBy={['parent']}
+        scaleWidthMode={AnalyticalTableScaleWidthMode.Smart}
+        loading={isLoading}
+        filterable
+        // Prevent the table from resetting when the data changes
+        retainColumnWidth
+        reactTableOptions={{
+          autoResetHiddenColumns: false,
+          autoResetPage: false,
+          autoResetExpanded: false,
+          autoResetGroupBy: false,
+          autoResetSelectedRows: false,
+          autoResetSortBy: false,
+          autoResetFilters: false,
+          autoResetRowState: false,
+          autoResetResize: false,
+        }}
+      />
+      <ErrorDialog ref={errorDialogRef} />
+    </>
   );
 }

--- a/src/components/ControlPlane/ProvidersConfig.tsx
+++ b/src/components/ControlPlane/ProvidersConfig.tsx
@@ -16,7 +16,7 @@ import { formatDateAsTimeAgo } from '../../utils/i18n/timeAgo';
 
 import { YamlViewButton } from '../Yaml/YamlViewButton.tsx';
 
-import { Fragment, useCallback, useContext, useMemo, useRef } from 'react';
+import { Fragment, useCallback, useContext, useMemo, useRef, useEffect } from 'react';
 import { Resource } from '../../utils/removeManagedFieldsAndFilterData.ts';
 import { ProviderConfigItem } from '../../lib/shared/types.ts';
 import { ActionsMenu, type ActionItem } from './ActionsMenu';
@@ -37,7 +37,11 @@ type Rows = {
   resource: ProviderConfigItem;
 };
 
-export function ProvidersConfig() {
+interface ProvidersConfigProps {
+  onCountChange?: (count: number) => void;
+}
+
+export function ProvidersConfig({ onCountChange }: ProvidersConfigProps = {}) {
   const { t } = useTranslation();
   const { openInAsideWithApiConfig } = useSplitter();
   const errorDialogRef = useRef<ErrorDialogHandle>(null);
@@ -62,6 +66,13 @@ export function ProvidersConfig() {
       });
     });
   }
+
+  // Notify parent of count changes
+  useEffect(() => {
+    if (onCountChange) {
+      onCountChange(rows.length);
+    }
+  }, [rows.length, onCountChange]);
 
   const openEditPanel = useCallback(
     (item: ProviderConfigItem) => {

--- a/src/components/ControlPlane/ResourceHealthBar/ResourceHealthBar.cy.tsx
+++ b/src/components/ControlPlane/ResourceHealthBar/ResourceHealthBar.cy.tsx
@@ -1,0 +1,142 @@
+import { ResourceHealthBar } from './ResourceHealthBar';
+
+describe('ResourceHealthBar', () => {
+  describe('ready-synced mode', () => {
+    it('renders all resources as ready and synced', () => {
+      const resources = [
+        { ready: true, synced: true },
+        { ready: true, synced: true },
+        { ready: true, synced: true },
+      ];
+
+      cy.mount(<ResourceHealthBar resources={resources} type="ready-synced" />);
+
+      cy.get('[class*="healthBar"]').should('exist');
+      cy.get('[class*="goodSegment"]').should('exist');
+      cy.get('[class*="badSegment"]').should('not.exist');
+      cy.get('[class*="unknownSegment"]').should('not.exist');
+    });
+
+    it('renders mixed resource states', () => {
+      const resources = [
+        { ready: true, synced: true },
+        { ready: false, synced: false },
+        { ready: undefined, synced: undefined },
+      ];
+
+      cy.mount(<ResourceHealthBar resources={resources} type="ready-synced" />);
+
+      cy.get('[class*="healthBar"]').should('exist');
+      cy.get('[class*="goodSegment"]').should('exist');
+      cy.get('[class*="badSegment"]').should('exist');
+      cy.get('[class*="unknownSegment"]').should('exist');
+    });
+
+    it('renders all resources as not ready', () => {
+      const resources = [
+        { ready: false, synced: false },
+        { ready: false, synced: false },
+      ];
+
+      cy.mount(<ResourceHealthBar resources={resources} type="ready-synced" />);
+
+      cy.get('[class*="healthBar"]').should('exist');
+      cy.get('[class*="goodSegment"]').should('not.exist');
+      cy.get('[class*="badSegment"]').should('exist');
+      cy.get('[class*="unknownSegment"]').should('not.exist');
+    });
+
+    it('handles empty resources array', () => {
+      cy.mount(<ResourceHealthBar resources={[]} type="ready-synced" />);
+
+      cy.get('[class*="healthBar"]').should('exist');
+      cy.get('[class*="goodSegment"]').should('not.exist');
+      cy.get('[class*="badSegment"]').should('not.exist');
+      cy.get('[class*="unknownSegment"]').should('not.exist');
+    });
+  });
+
+  describe('installed-healthy mode', () => {
+    it('renders all resources as installed and healthy', () => {
+      const resources = [
+        { installed: true, healthy: true },
+        { installed: true, healthy: true },
+      ];
+
+      cy.mount(<ResourceHealthBar resources={resources} type="installed-healthy" />);
+
+      cy.get('[class*="healthBar"]').should('exist');
+      cy.get('[class*="goodSegment"]').should('exist');
+      cy.get('[class*="badSegment"]').should('not.exist');
+      cy.get('[class*="unknownSegment"]').should('not.exist');
+    });
+
+    it('renders installed but not healthy', () => {
+      const resources = [
+        { installed: true, healthy: false },
+        { installed: true, healthy: false },
+      ];
+
+      cy.mount(<ResourceHealthBar resources={resources} type="installed-healthy" />);
+
+      cy.get('[class*="healthBar"]').should('exist');
+      cy.get('[class*="goodSegment"]').should('not.exist');
+      cy.get('[class*="badSegment"]').should('exist');
+      cy.get('[class*="unknownSegment"]').should('not.exist');
+    });
+
+    it('renders not installed resources', () => {
+      const resources = [
+        { installed: false, healthy: false },
+        { installed: false, healthy: false },
+      ];
+
+      cy.mount(<ResourceHealthBar resources={resources} type="installed-healthy" />);
+
+      cy.get('[class*="healthBar"]').should('exist');
+      cy.get('[class*="goodSegment"]').should('not.exist');
+      cy.get('[class*="badSegment"]').should('not.exist');
+      cy.get('[class*="unknownSegment"]').should('exist');
+    });
+
+    it('renders mixed states correctly', () => {
+      const resources = [
+        { installed: true, healthy: true },
+        { installed: true, healthy: false },
+        { installed: false, healthy: false },
+      ];
+
+      cy.mount(<ResourceHealthBar resources={resources} type="installed-healthy" />);
+
+      cy.get('[class*="healthBar"]').should('exist');
+      cy.get('[class*="goodSegment"]').should('exist');
+      cy.get('[class*="badSegment"]').should('exist');
+      cy.get('[class*="unknownSegment"]').should('exist');
+    });
+  });
+
+  describe('visual properties', () => {
+    it('has correct width proportions for 50/50 split', () => {
+      const resources = [
+        { ready: true, synced: true },
+        { ready: false, synced: false },
+      ];
+
+      cy.mount(<ResourceHealthBar resources={resources} type="ready-synced" />);
+
+      cy.get('[class*="goodSegment"]').should('have.css', 'width').and('match', /40px/); // 50% of 80px
+      cy.get('[class*="badSegment"]').should('have.css', 'width').and('match', /40px/);
+    });
+
+    it('is inline-flex and has correct dimensions', () => {
+      const resources = [{ ready: true, synced: true }];
+
+      cy.mount(<ResourceHealthBar resources={resources} type="ready-synced" />);
+
+      cy.get('[class*="healthBar"]')
+        .should('have.css', 'display', 'inline-flex')
+        .should('have.css', 'height', '6px')
+        .should('have.css', 'width', '80px');
+    });
+  });
+});

--- a/src/components/ControlPlane/ResourceHealthBar/ResourceHealthBar.module.css
+++ b/src/components/ControlPlane/ResourceHealthBar/ResourceHealthBar.module.css
@@ -1,26 +1,46 @@
 .healthBar {
   display: flex;
-  height: 8px;
+  height: 16px;
   width: 100%;
   background: var(--sapGroup_ContentBackground);
-  border-radius: 4px;
+  border-radius: 6px;
   overflow: hidden;
   border: 1px solid var(--sapList_BorderColor);
-  margin-bottom: 1rem;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  margin-bottom: 1.25rem;
+  box-shadow:
+    0 2px 6px rgba(0, 0, 0, 0.12),
+    inset 0 1px 2px rgba(0, 0, 0, 0.05);
+  position: relative;
+}
+
+.healthBar::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 50%;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0.15), transparent);
+  pointer-events: none;
 }
 
 .goodSegment {
   background: var(--sapPositiveColor);
   transition: width 0.3s ease;
+  position: relative;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
 }
 
 .badSegment {
   background: var(--sapNegativeColor);
   transition: width 0.3s ease;
+  position: relative;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
 }
 
 .unknownSegment {
   background: var(--sapNeutralColor);
   transition: width 0.3s ease;
+  position: relative;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
 }

--- a/src/components/ControlPlane/ResourceHealthBar/ResourceHealthBar.module.css
+++ b/src/components/ControlPlane/ResourceHealthBar/ResourceHealthBar.module.css
@@ -1,0 +1,25 @@
+.healthBar {
+  display: flex;
+  height: 6px;
+  width: 100%;
+  background: var(--sapGroup_ContentBackground);
+  border-radius: 3px;
+  overflow: hidden;
+  border: 1px solid var(--sapList_BorderColor);
+  margin-bottom: 1rem;
+}
+
+.goodSegment {
+  background: var(--sapPositiveColor);
+  transition: width 0.3s ease;
+}
+
+.badSegment {
+  background: var(--sapNegativeColor);
+  transition: width 0.3s ease;
+}
+
+.unknownSegment {
+  background: var(--sapNeutralColor);
+  transition: width 0.3s ease;
+}

--- a/src/components/ControlPlane/ResourceHealthBar/ResourceHealthBar.module.css
+++ b/src/components/ControlPlane/ResourceHealthBar/ResourceHealthBar.module.css
@@ -1,12 +1,13 @@
 .healthBar {
   display: flex;
-  height: 6px;
+  height: 8px;
   width: 100%;
   background: var(--sapGroup_ContentBackground);
-  border-radius: 3px;
+  border-radius: 4px;
   overflow: hidden;
   border: 1px solid var(--sapList_BorderColor);
   margin-bottom: 1rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 .goodSegment {

--- a/src/components/ControlPlane/ResourceHealthBar/ResourceHealthBar.module.css
+++ b/src/components/ControlPlane/ResourceHealthBar/ResourceHealthBar.module.css
@@ -1,46 +1,25 @@
 .healthBar {
-  display: flex;
-  height: 16px;
-  width: 100%;
-  background: var(--sapGroup_ContentBackground);
-  border-radius: 6px;
+  display: inline-flex;
+  height: 6px;
+  width: 80px;
+  background: var(--sapField_Background);
+  border-radius: 3px;
   overflow: hidden;
-  border: 1px solid var(--sapList_BorderColor);
-  margin-bottom: 1.25rem;
-  box-shadow:
-    0 2px 6px rgba(0, 0, 0, 0.12),
-    inset 0 1px 2px rgba(0, 0, 0, 0.05);
-  position: relative;
-}
-
-.healthBar::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 50%;
-  background: linear-gradient(to bottom, rgba(255, 255, 255, 0.15), transparent);
-  pointer-events: none;
+  margin-left: 0.5rem;
+  vertical-align: middle;
 }
 
 .goodSegment {
   background: var(--sapPositiveColor);
   transition: width 0.3s ease;
-  position: relative;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
 }
 
 .badSegment {
   background: var(--sapNegativeColor);
   transition: width 0.3s ease;
-  position: relative;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
 }
 
 .unknownSegment {
   background: var(--sapNeutralColor);
   transition: width 0.3s ease;
-  position: relative;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
 }

--- a/src/components/ControlPlane/ResourceHealthBar/ResourceHealthBar.tsx
+++ b/src/components/ControlPlane/ResourceHealthBar/ResourceHealthBar.tsx
@@ -1,0 +1,96 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import styles from './ResourceHealthBar.module.css';
+
+interface ResourceStatus {
+  ready?: boolean;
+  synced?: boolean;
+  installed?: boolean;
+  healthy?: boolean;
+}
+
+interface Props {
+  resources: ResourceStatus[];
+  type?: 'ready-synced' | 'installed-healthy';
+}
+
+interface HealthStats {
+  good: number;
+  bad: number;
+  unknown: number;
+  total: number;
+}
+
+export function ResourceHealthBar({ resources, type = 'ready-synced' }: Props) {
+  const { t } = useTranslation();
+
+  const healthStats = useMemo<HealthStats>(() => {
+    return resources.reduce(
+      (acc, resource) => {
+        if (type === 'installed-healthy') {
+          // For Providers: installed + healthy
+          const isInstalled = resource.installed === true;
+          const isHealthy = resource.healthy === true;
+
+          if (!isInstalled) {
+            acc.unknown++;
+          } else if (isHealthy) {
+            acc.good++;
+          } else {
+            acc.bad++;
+          }
+        } else {
+          // For Managed Resources: ready + synced
+          const isReady = resource.ready === true;
+          const isSynced = resource.synced === true;
+
+          if (isReady && isSynced) {
+            acc.good++;
+          } else if (isReady === false || isSynced === false) {
+            acc.bad++;
+          } else {
+            acc.unknown++;
+          }
+        }
+
+        acc.total++;
+        return acc;
+      },
+      { good: 0, bad: 0, unknown: 0, total: 0 },
+    );
+  }, [resources, type]);
+
+  const goodPercent = healthStats.total > 0 ? (healthStats.good / healthStats.total) * 100 : 0;
+  const badPercent = healthStats.total > 0 ? (healthStats.bad / healthStats.total) * 100 : 0;
+  const unknownPercent = healthStats.total > 0 ? (healthStats.unknown / healthStats.total) * 100 : 0;
+
+  const goodLabel = type === 'installed-healthy' ? t('common.healthy') : t('common.ready');
+  const badLabel = type === 'installed-healthy' ? t('errors.notHealthy') : t('errors.notReady');
+  const unknownLabel = type === 'installed-healthy' ? t('common.notInstalled', 'Not Installed') : t('common.unknown');
+
+  return (
+    <div className={styles.healthBar}>
+      {healthStats.good > 0 && (
+        <div
+          className={styles.goodSegment}
+          style={{ width: `${goodPercent}%` }}
+          title={`${healthStats.good} ${goodLabel}`}
+        />
+      )}
+      {healthStats.bad > 0 && (
+        <div
+          className={styles.badSegment}
+          style={{ width: `${badPercent}%` }}
+          title={`${healthStats.bad} ${badLabel}`}
+        />
+      )}
+      {healthStats.unknown > 0 && (
+        <div
+          className={styles.unknownSegment}
+          style={{ width: `${unknownPercent}%` }}
+          title={`${healthStats.unknown} ${unknownLabel}`}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/spaces/mcp/pages/McpPage.tsx
+++ b/src/spaces/mcp/pages/McpPage.tsx
@@ -33,7 +33,7 @@ import { YamlViewButton } from '../../../components/Yaml/YamlViewButton.tsx';
 import { isNotFoundError } from '../../../lib/api/error.ts';
 import { AuthProviderMcp } from '../auth/AuthContextMcp.tsx';
 
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useCallback } from 'react';
 import { GitRepositories } from '../../../components/ControlPlane/GitRepositories.tsx';
 import { Kustomizations } from '../../../components/ControlPlane/Kustomizations.tsx';
 import { McpConfigMaps } from '../../../components/ControlPlane/McpConfigMaps.tsx';
@@ -72,6 +72,14 @@ export default function McpPage() {
     synced: 0,
     total: 0,
   });
+
+  const handleProvidersHealthStatsChange = useCallback((installed: number, healthy: number, total: number) => {
+    setProvidersHealthStats({ installed, healthy, total });
+  }, []);
+
+  const handleManagedResourcesHealthStatsChange = useCallback((ready: number, synced: number, total: number) => {
+    setManagedResourcesHealthStats({ ready, synced, total });
+  }, []);
 
   const selectedSectionId = useMemo(() => {
     const tab = searchParams.get('tab');
@@ -259,9 +267,7 @@ export default function McpPage() {
                   >
                     <Providers
                       onCountChange={setProvidersCount}
-                      onHealthStatsChange={(installed, healthy, total) =>
-                        setProvidersHealthStats({ installed, healthy, total })
-                      }
+                      onHealthStatsChange={handleProvidersHealthStatsChange}
                     />
                   </ObjectPageSubSection>
                   <ObjectPageSubSection
@@ -289,9 +295,7 @@ export default function McpPage() {
                   >
                     <ManagedResources
                       onCountChange={setManagedResourcesCount}
-                      onHealthStatsChange={(ready, synced, total) =>
-                        setManagedResourcesHealthStats({ ready, synced, total })
-                      }
+                      onHealthStatsChange={handleManagedResourcesHealthStatsChange}
                     />
                   </ObjectPageSubSection>
                 </ObjectPageSection>

--- a/src/spaces/mcp/pages/McpPage.tsx
+++ b/src/spaces/mcp/pages/McpPage.tsx
@@ -62,6 +62,10 @@ export default function McpPage() {
   const [editManagedControlPlaneWizardSection, setEditManagedControlPlaneWizardSection] = useState<
     undefined | WizardStepType
   >(undefined);
+  const [providersCount, setProvidersCount] = useState(0);
+  const [providerConfigsCount, setProviderConfigsCount] = useState(0);
+  const [managedResourcesCount, setManagedResourcesCount] = useState(0);
+
   const selectedSectionId = useMemo(() => {
     const tab = searchParams.get('tab');
     if (tab && MCP_PAGE_SECTIONS.includes(tab as McpPageSectionId)) {
@@ -232,24 +236,24 @@ export default function McpPage() {
                 <ObjectPageSection id="crossplane" titleText={t('McpPage.crossplaneTitle')}>
                   <ObjectPageSubSection
                     id="providers"
-                    titleText={t('McpPage.providersTitle')}
+                    titleText={`${t('McpPage.providersTitle')}${providersCount > 0 ? ` (${providersCount})` : ''}`}
                     className={styles.section}
                   >
-                    <Providers />
+                    <Providers onCountChange={setProvidersCount} />
                   </ObjectPageSubSection>
                   <ObjectPageSubSection
                     id="provider-configs"
-                    titleText={t('McpPage.providerConfigsTitle')}
+                    titleText={`${t('McpPage.providerConfigsTitle')}${providerConfigsCount > 0 ? ` (${providerConfigsCount})` : ''}`}
                     className={styles.section}
                   >
-                    <ProvidersConfig />
+                    <ProvidersConfig onCountChange={setProviderConfigsCount} />
                   </ObjectPageSubSection>
                   <ObjectPageSubSection
                     id="managed-resources"
-                    titleText={t('McpPage.managedResourcesTitle')}
+                    titleText={`${t('McpPage.managedResourcesTitle')}${managedResourcesCount > 0 ? ` (${managedResourcesCount})` : ''}`}
                     className={styles.section}
                   >
-                    <ManagedResources />
+                    <ManagedResources onCountChange={setManagedResourcesCount} />
                   </ObjectPageSubSection>
                 </ObjectPageSection>
               )}

--- a/src/spaces/mcp/pages/McpPage.tsx
+++ b/src/spaces/mcp/pages/McpPage.tsx
@@ -39,6 +39,7 @@ import { Kustomizations } from '../../../components/ControlPlane/Kustomizations.
 import { McpConfigMaps } from '../../../components/ControlPlane/McpConfigMaps.tsx';
 import { McpSecrets } from '../../../components/ControlPlane/McpSecrets.tsx';
 import { McpStatusSection } from '../../../components/ControlPlane/McpStatusSection.tsx';
+import { ResourceHealthBar } from '../../../components/ControlPlane/ResourceHealthBar/ResourceHealthBar.tsx';
 import { ControlPlanePageMenu } from '../../../components/ControlPlanes/ControlPlanePageMenu.tsx';
 import { McpMembersAvatarView } from '../../../components/ControlPlanes/McpMembersAvatarView/McpMembersAvatarView.tsx';
 import { Center } from '../../../components/Ui/Center/Center.tsx';
@@ -65,6 +66,12 @@ export default function McpPage() {
   const [providersCount, setProvidersCount] = useState(0);
   const [providerConfigsCount, setProviderConfigsCount] = useState(0);
   const [managedResourcesCount, setManagedResourcesCount] = useState(0);
+  const [providersHealthStats, setProvidersHealthStats] = useState({ installed: 0, healthy: 0, total: 0 });
+  const [managedResourcesHealthStats, setManagedResourcesHealthStats] = useState({
+    ready: 0,
+    synced: 0,
+    total: 0,
+  });
 
   const selectedSectionId = useMemo(() => {
     const tab = searchParams.get('tab');
@@ -238,8 +245,24 @@ export default function McpPage() {
                     id="providers"
                     titleText={`${t('McpPage.providersTitle')}${providersCount > 0 ? ` (${providersCount})` : ''}`}
                     className={styles.section}
+                    actions={
+                      providersHealthStats.total > 0 ? (
+                        <ResourceHealthBar
+                          resources={Array.from({ length: providersHealthStats.total }, (_, i) => ({
+                            installed: i < providersHealthStats.installed,
+                            healthy: i < providersHealthStats.healthy,
+                          }))}
+                          type="installed-healthy"
+                        />
+                      ) : undefined
+                    }
                   >
-                    <Providers onCountChange={setProvidersCount} />
+                    <Providers
+                      onCountChange={setProvidersCount}
+                      onHealthStatsChange={(installed, healthy, total) =>
+                        setProvidersHealthStats({ installed, healthy, total })
+                      }
+                    />
                   </ObjectPageSubSection>
                   <ObjectPageSubSection
                     id="provider-configs"
@@ -252,8 +275,24 @@ export default function McpPage() {
                     id="managed-resources"
                     titleText={`${t('McpPage.managedResourcesTitle')}${managedResourcesCount > 0 ? ` (${managedResourcesCount})` : ''}`}
                     className={styles.section}
+                    actions={
+                      managedResourcesHealthStats.total > 0 ? (
+                        <ResourceHealthBar
+                          resources={Array.from({ length: managedResourcesHealthStats.total }, (_, i) => ({
+                            ready: i < managedResourcesHealthStats.ready,
+                            synced: i < managedResourcesHealthStats.synced,
+                          }))}
+                          type="ready-synced"
+                        />
+                      ) : undefined
+                    }
                   >
-                    <ManagedResources onCountChange={setManagedResourcesCount} />
+                    <ManagedResources
+                      onCountChange={setManagedResourcesCount}
+                      onHealthStatsChange={(ready, synced, total) =>
+                        setManagedResourcesHealthStats({ ready, synced, total })
+                      }
+                    />
                   </ObjectPageSubSection>
                 </ObjectPageSection>
               )}


### PR DESCRIPTION

<img width="1065" height="650" alt="image" src="https://github.com/user-attachments/assets/b0ee52e8-34af-4e3e-83bc-950e06a79910" />


## Summary
- Adds health status visualization for managed resources
- Shows ready/synced counts with visual indicators
- Includes health stats callback props for parent components

## Test plan
- [ ] Verify health bars display correctly on control plane page
- [ ] Check ready and synced counts are accurate
- [ ] Test with various resource states (ready, not ready, synced, not synced)