### PR TITLE
fix: rename Landscapers tab to Landscaper

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -247,7 +247,7 @@
     "fluxTitle": "Flux",
     "gitRepositoriesTitle": "GitRepositories",
     "kustomizationsTitle": "Kustomizations",
-    "landscapersTitle": "Landscaper",
+    "landscaperTitle": "Landscaper",
     "configMapsTitle": "ConfigMaps",
     "secretsTitle": "Secrets",
     "secretTypeHeader": "Type"

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -247,7 +247,7 @@
     "fluxTitle": "Flux",
     "gitRepositoriesTitle": "GitRepositories",
     "kustomizationsTitle": "Kustomizations",
-    "landscapersTitle": "Landscapers",
+    "landscapersTitle": "Landscaper",
     "configMapsTitle": "ConfigMaps",
     "secretsTitle": "Secrets",
     "secretTypeHeader": "Type"

--- a/src/spaces/mcp/components/ComponentsDashboard/ComponentsDashboard.tsx
+++ b/src/spaces/mcp/components/ComponentsDashboard/ComponentsDashboard.tsx
@@ -70,7 +70,7 @@ export function ComponentsDashboard({
           isInstalled={!!components?.landscaper}
           version={undefined} // Landscaper does not have a version
           kpiType="enabled"
-          onNavigateToComponentSection={() => onNavigateToMcpSection('landscapers')}
+          onNavigateToComponentSection={() => onNavigateToMcpSection('landscaper')}
           onInstallButtonClick={undefined}
         />
         <ComponentCard

--- a/src/spaces/mcp/components/ComponentsDashboard/ComponentsDashboardV2.tsx
+++ b/src/spaces/mcp/components/ComponentsDashboard/ComponentsDashboardV2.tsx
@@ -71,7 +71,7 @@ export function ComponentsDashboardV2({
           isInstalled={isLandscaperInstalled}
           version={landscaperVersion}
           kpiType="enabled"
-          onNavigateToComponentSection={() => onNavigateToMcpSection('landscapers')}
+          onNavigateToComponentSection={() => onNavigateToMcpSection('landscaper')}
         />
         <ComponentCard
           name="External Secrets Operator"

--- a/src/spaces/mcp/pages/McpPage.tsx
+++ b/src/spaces/mcp/pages/McpPage.tsx
@@ -51,7 +51,7 @@ import { ManagedControlPlaneAuthorization } from '../authorization/ManagedContro
 import { ComponentsDashboard } from '../components/ComponentsDashboard/ComponentsDashboard.tsx';
 import { McpHeader } from '../components/McpHeader/McpHeader.tsx';
 
-const MCP_PAGE_SECTIONS = ['overview', 'crossplane', 'flux', 'landscapers'] as const;
+const MCP_PAGE_SECTIONS = ['overview', 'crossplane', 'flux', 'landscaper'] as const;
 export type McpPageSectionId = (typeof MCP_PAGE_SECTIONS)[number];
 
 export default function McpPage() {
@@ -274,7 +274,7 @@ export default function McpPage() {
               )}
 
               {isComponentInstalledLandscaper && (
-                <ObjectPageSection id="landscapers" titleText={t('McpPage.landscaperTitle')} className={styles.section}>
+                <ObjectPageSection id="landscaper" titleText={t('McpPage.landscaperTitle')} className={styles.section}>
                   <Landscapers />
                 </ObjectPageSection>
               )}

--- a/src/spaces/mcp/pages/McpPage.tsx
+++ b/src/spaces/mcp/pages/McpPage.tsx
@@ -274,11 +274,7 @@ export default function McpPage() {
               )}
 
               {isComponentInstalledLandscaper && (
-                <ObjectPageSection
-                  id="landscapers"
-                  titleText={t('McpPage.landscaperTitle')}
-                  className={styles.section}
-                >
+                <ObjectPageSection id="landscapers" titleText={t('McpPage.landscaperTitle')} className={styles.section}>
                   <Landscapers />
                 </ObjectPageSection>
               )}

--- a/src/spaces/mcp/pages/McpPage.tsx
+++ b/src/spaces/mcp/pages/McpPage.tsx
@@ -276,7 +276,7 @@ export default function McpPage() {
               {isComponentInstalledLandscaper && (
                 <ObjectPageSection
                   id="landscapers"
-                  titleText={t('McpPage.landscapersTitle')}
+                  titleText={t('McpPage.landscaperTitle')}
                   className={styles.section}
                 >
                   <Landscapers />

--- a/src/spaces/mcp/pages/McpPageV2.tsx
+++ b/src/spaces/mcp/pages/McpPageV2.tsx
@@ -270,7 +270,7 @@ export default function McpPageV2() {
               {isComponentInstalledLandscaper && (
                 <ObjectPageSection
                   id="landscapers"
-                  titleText={t('McpPage.landscapersTitle')}
+                  titleText={t('McpPage.landscaperTitle')}
                   className={styles.section}
                 >
                   <Landscapers />

--- a/src/spaces/mcp/pages/McpPageV2.tsx
+++ b/src/spaces/mcp/pages/McpPageV2.tsx
@@ -268,11 +268,7 @@ export default function McpPageV2() {
               )}
 
               {isComponentInstalledLandscaper && (
-                <ObjectPageSection
-                  id="landscapers"
-                  titleText={t('McpPage.landscaperTitle')}
-                  className={styles.section}
-                >
+                <ObjectPageSection id="landscapers" titleText={t('McpPage.landscaperTitle')} className={styles.section}>
                   <Landscapers />
                 </ObjectPageSection>
               )}

--- a/src/spaces/mcp/pages/McpPageV2.tsx
+++ b/src/spaces/mcp/pages/McpPageV2.tsx
@@ -51,7 +51,7 @@ import { useFluxQuery } from '../components/Kpi/useFluxQuery.ts';
 import { useLandscaperQuery } from '../components/Kpi/useLandscaperQuery.ts';
 import { McpHeader } from '../components/McpHeader/McpHeader.tsx';
 
-const MCP_PAGE_SECTIONS = ['overview', 'crossplane', 'flux', 'landscapers'] as const;
+const MCP_PAGE_SECTIONS = ['overview', 'crossplane', 'flux', 'landscaper'] as const;
 export type McpPageSectionId = (typeof MCP_PAGE_SECTIONS)[number];
 
 export default function McpPageV2() {
@@ -268,7 +268,7 @@ export default function McpPageV2() {
               )}
 
               {isComponentInstalledLandscaper && (
-                <ObjectPageSection id="landscapers" titleText={t('McpPage.landscaperTitle')} className={styles.section}>
+                <ObjectPageSection id="landscaper" titleText={t('McpPage.landscaperTitle')} className={styles.section}>
                   <Landscapers />
                 </ObjectPageSection>
               )}


### PR DESCRIPTION
Renames the tab to "Landscaper" (was "Landscapers")

<img width="1347" height="831" alt="image" src="https://github.com/user-attachments/assets/085eb40f-f884-467f-a885-33ec43ae96a1" />
