### PR TITLE
fix: yaml editor rerender issue

### DIFF
--- a/src/components/ControlPlane/MCPHealthPopoverButton.tsx
+++ b/src/components/ControlPlane/MCPHealthPopoverButton.tsx
@@ -121,7 +121,7 @@ const MCPHealthPopoverButton = ({
         open={open}
         onClose={() => setOpen(false)}
       >
-        <ConditionsMessageListView conditions={mcpStatus?.conditions ?? undefined} />
+        {open && <ConditionsMessageListView conditions={mcpStatus?.conditions ?? undefined} />}
       </ResponsivePopover>
     </div>
   );

--- a/src/components/Shared/ConditionsViewButton.tsx
+++ b/src/components/Shared/ConditionsViewButton.tsx
@@ -49,8 +49,8 @@ export const ConditionsViewButton = ({ isOk, conditions }: ConditionsViewButtonP
       </Button>
 
       <ResponsivePopover ref={popoverRef} open={open} placement={PopoverPlacement.Top} onClose={() => setOpen(false)}>
-        {conditions.length > 1 && <ConditionsMessageListView conditions={conditions} />}
-        {conditions.length === 1 && <ConditionMessageItem condition={conditions[0]} />}
+        {open && conditions.length > 1 && <ConditionsMessageListView conditions={conditions} />}
+        {open && conditions.length === 1 && <ConditionMessageItem condition={conditions[0]} />}
       </ResponsivePopover>
     </span>
   );

--- a/src/components/Shared/ResourceStatusCell.tsx
+++ b/src/components/Shared/ResourceStatusCell.tsx
@@ -73,17 +73,19 @@ export const ResourceStatusCell = ({
       )}
 
       <ResponsivePopover ref={popoverRef} open={open} placement={PopoverPlacement.Top} onClose={() => setOpen(false)}>
-        <ConditionMessageItem
-          condition={
-            {
-              type: isOk ? positiveText : negativeText,
-              status: isOk ? 'True' : 'False',
-              reason: '',
-              message: message || '',
-              lastTransitionTime: transitionTime,
-            } as ControlPlaneStatusCondition
-          }
-        />
+        {open && (
+          <ConditionMessageItem
+            condition={
+              {
+                type: isOk ? positiveText : negativeText,
+                status: isOk ? 'True' : 'False',
+                reason: '',
+                message: message || '',
+                lastTransitionTime: transitionTime,
+              } as ControlPlaneStatusCondition
+            }
+          />
+        )}
       </ResponsivePopover>
     </span>
   );


### PR DESCRIPTION
This PR fixes the yaml worker dispatch when the ConditionMessageItem component is rerendered. The YAML editor is now configured only when it is displayed.