### PR TITLE
feat: add useMcpComponents hook and WorkspaceHealthIndicator

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -101,8 +101,20 @@
     "deleteConfirmationDialog": "Control plane deletion triggered. The list will refresh automatically once completed.",
     "editMCP": "Edit Control Plane",
     "duplicateMCP": "Duplicate Control Plane",
-    "deleteMCP": "Delete Control Plane"
-
+    "deleteMCP": "Delete Control Plane",
+    "installedComponents_one": "Installed Components ({{count}})",
+    "installedComponents_other": "Installed Components ({{count}})"
+  },
+  "WorkspaceHealthIndicator": {
+    "title": "Workspace Health",
+    "ready": "Ready",
+    "notReady": "Not Ready",
+    "progressing": "Progressing",
+    "deleting": "Deleting",
+    "healthy": "healthy",
+    "unhealthy": "unhealthy",
+    "progressingLabel": "in progress",
+    "unknown": "unknown"
   },
   "ControlPlaneListAllWorkspaces": {
     "emptyListTitleMessage": "No Workspaces created yet",

--- a/src/components/ControlPlanes/ControlPlaneCard/useMcpComponents.spec.tsx
+++ b/src/components/ControlPlanes/ControlPlaneCard/useMcpComponents.spec.tsx
@@ -1,0 +1,235 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useMcpComponents } from './useMcpComponents';
+import * as useApiResourceModule from '../../../lib/api/useApiResource';
+
+// Mock the useApiResource hook
+vi.mock('../../../lib/api/useApiResource');
+
+describe('useMcpComponents', () => {
+  const mockUseApiResource = vi.mocked(useApiResourceModule.useApiResource);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null components when data is loading', () => {
+    mockUseApiResource.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: undefined,
+      isValidating: false,
+    });
+
+    const { result } = renderHook(() => useMcpComponents('project-1', 'workspace-1', 'mcp-1'));
+
+    expect(result.current.components).toBeNull();
+    expect(result.current.roleBindings).toBeUndefined();
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('extracts components from MCP spec', () => {
+    const mockMcp = {
+      spec: {
+        components: {
+          crossplane: { version: '1.14.0' },
+          flux: { version: '2.1.0' },
+          kyverno: { version: '3.0.0' },
+        },
+      },
+    };
+
+    mockUseApiResource.mockReturnValue({
+      data: mockMcp,
+      isLoading: false,
+      error: undefined,
+      isValidating: false,
+    });
+
+    const { result } = renderHook(() => useMcpComponents('project-1', 'workspace-1', 'mcp-1'));
+
+    expect(result.current.components).toEqual({
+      crossplane: { version: '1.14.0' },
+      flux: { version: '2.1.0' },
+      kyverno: { version: '3.0.0' },
+    });
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('extracts roleBindings from MCP authorization spec', () => {
+    const mockMcp = {
+      spec: {
+        authorization: {
+          roleBindings: [
+            {
+              role: 'admin',
+              subjects: [{ kind: 'User', name: 'user@example.com' }],
+            },
+            {
+              role: 'viewer',
+              subjects: [{ kind: 'User', name: 'viewer@example.com' }],
+            },
+          ],
+        },
+      },
+    };
+
+    mockUseApiResource.mockReturnValue({
+      data: mockMcp,
+      isLoading: false,
+      error: undefined,
+      isValidating: false,
+    });
+
+    const { result } = renderHook(() => useMcpComponents('project-1', 'workspace-1', 'mcp-1'));
+
+    expect(result.current.roleBindings).toEqual([
+      {
+        role: 'admin',
+        subjects: [{ kind: 'User', name: 'user@example.com' }],
+      },
+      {
+        role: 'viewer',
+        subjects: [{ kind: 'User', name: 'viewer@example.com' }],
+      },
+    ]);
+  });
+
+  it('handles MCP without components spec', () => {
+    const mockMcp = {
+      spec: {
+        authorization: {
+          roleBindings: [],
+        },
+      },
+    };
+
+    mockUseApiResource.mockReturnValue({
+      data: mockMcp,
+      isLoading: false,
+      error: undefined,
+      isValidating: false,
+    });
+
+    const { result } = renderHook(() => useMcpComponents('project-1', 'workspace-1', 'mcp-1'));
+
+    expect(result.current.components).toBeNull();
+    expect(result.current.roleBindings).toEqual([]);
+  });
+
+  it('handles MCP without authorization spec', () => {
+    const mockMcp = {
+      spec: {
+        components: {
+          crossplane: { version: '1.14.0' },
+        },
+      },
+    };
+
+    mockUseApiResource.mockReturnValue({
+      data: mockMcp,
+      isLoading: false,
+      error: undefined,
+      isValidating: false,
+    });
+
+    const { result } = renderHook(() => useMcpComponents('project-1', 'workspace-1', 'mcp-1'));
+
+    expect(result.current.components).toEqual({
+      crossplane: { version: '1.14.0' },
+    });
+    expect(result.current.roleBindings).toBeUndefined();
+  });
+
+  it('handles completely empty MCP spec', () => {
+    const mockMcp = {
+      spec: {},
+    };
+
+    mockUseApiResource.mockReturnValue({
+      data: mockMcp,
+      isLoading: false,
+      error: undefined,
+      isValidating: false,
+    });
+
+    const { result } = renderHook(() => useMcpComponents('project-1', 'workspace-1', 'mcp-1'));
+
+    expect(result.current.components).toBeNull();
+    expect(result.current.roleBindings).toBeUndefined();
+  });
+
+  it('handles all component types', () => {
+    const mockMcp = {
+      spec: {
+        components: {
+          crossplane: { version: '1.14.0' },
+          flux: { version: '2.1.0' },
+          landscaper: {},
+          kyverno: { version: '3.0.0' },
+          externalSecretsOperator: { version: '0.9.0' },
+        },
+      },
+    };
+
+    mockUseApiResource.mockReturnValue({
+      data: mockMcp,
+      isLoading: false,
+      error: undefined,
+      isValidating: false,
+    });
+
+    const { result } = renderHook(() => useMcpComponents('project-1', 'workspace-1', 'mcp-1'));
+
+    expect(result.current.components).toEqual({
+      crossplane: { version: '1.14.0' },
+      flux: { version: '2.1.0' },
+      landscaper: {},
+      kyverno: { version: '3.0.0' },
+      externalSecretsOperator: { version: '0.9.0' },
+    });
+  });
+
+  it('memoizes components correctly on data change', () => {
+    const mockMcp1 = {
+      spec: {
+        components: {
+          crossplane: { version: '1.14.0' },
+        },
+      },
+    };
+
+    const mockMcp2 = {
+      spec: {
+        components: {
+          crossplane: { version: '1.15.0' },
+        },
+      },
+    };
+
+    mockUseApiResource.mockReturnValue({
+      data: mockMcp1,
+      isLoading: false,
+      error: undefined,
+      isValidating: false,
+    });
+
+    const { result, rerender } = renderHook(() => useMcpComponents('project-1', 'workspace-1', 'mcp-1'));
+
+    const firstComponents = result.current.components;
+    expect(firstComponents).toEqual({ crossplane: { version: '1.14.0' } });
+
+    // Update mock data
+    mockUseApiResource.mockReturnValue({
+      data: mockMcp2,
+      isLoading: false,
+      error: undefined,
+      isValidating: false,
+    });
+
+    rerender();
+
+    expect(result.current.components).toEqual({ crossplane: { version: '1.15.0' } });
+    expect(result.current.components).not.toBe(firstComponents);
+  });
+});

--- a/src/components/ControlPlanes/ControlPlaneCard/useMcpComponents.ts
+++ b/src/components/ControlPlanes/ControlPlaneCard/useMcpComponents.ts
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+import { useApiResource } from '../../../lib/api/useApiResource';
+import { ControlPlane as ControlPlaneResource } from '../../../lib/api/types/crate/controlPlanes';
+
+interface ComponentVersion {
+  version?: string;
+}
+
+interface McpComponents {
+  crossplane?: ComponentVersion;
+  flux?: ComponentVersion;
+  landscaper?: unknown;
+  kyverno?: ComponentVersion;
+  externalSecretsOperator?: ComponentVersion;
+}
+
+interface RoleBinding {
+  role: string;
+  subjects: { kind: string; name: string }[];
+}
+
+export function useMcpComponents(projectName: string, workspaceName: string, controlPlaneName: string) {
+  const { data: mcp, isLoading } = useApiResource(ControlPlaneResource(projectName, workspaceName, controlPlaneName));
+
+  const components = useMemo<McpComponents | null>(() => {
+    if (!mcp?.spec?.components) return null;
+    return mcp.spec.components as McpComponents;
+  }, [mcp]);
+
+  const roleBindings = useMemo<RoleBinding[] | undefined>(() => {
+    return mcp?.spec?.authorization?.roleBindings as RoleBinding[] | undefined;
+  }, [mcp]);
+
+  return { components, roleBindings, isLoading };
+}

--- a/src/components/ControlPlanes/WorkspaceHealthIndicator/WorkspaceHealthIndicator.module.css
+++ b/src/components/ControlPlanes/WorkspaceHealthIndicator/WorkspaceHealthIndicator.module.css
@@ -1,0 +1,127 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  background: var(--sapObjectHeader_Background);
+  border-radius: 0.5rem;
+  border: 1px solid var(--sapList_BorderColor);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.title {
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--sapTextColor);
+}
+
+.healthBadge {
+  padding: 0.25rem 0.75rem;
+  border-radius: 1rem;
+  font-weight: 600;
+  font-size: 0.875rem;
+}
+
+.healthBadge.success {
+  background: var(--sapSuccessBackground);
+  color: var(--sapPositiveColor);
+}
+
+.healthBadge.warning {
+  background: var(--sapWarningBackground);
+  color: var(--sapCriticalColor);
+}
+
+.healthBadge.error {
+  background: var(--sapErrorBackground);
+  color: var(--sapNegativeColor);
+}
+
+.healthValue {
+  font-variant-numeric: tabular-nums;
+}
+
+.statsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 0.75rem;
+}
+
+.statItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.5rem;
+  background: var(--sapTile_Background);
+  border-radius: 0.375rem;
+}
+
+.statValue {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--sapTextColor);
+  font-variant-numeric: tabular-nums;
+}
+
+.statLabel {
+  font-size: 0.75rem;
+  color: var(--sapContent_LabelColor);
+  text-align: center;
+}
+
+.iconReady {
+  color: var(--sapPositiveColor);
+}
+
+.iconProgressing {
+  color: var(--sapCriticalColor);
+}
+
+.iconNotReady {
+  color: var(--sapNegativeColor);
+}
+
+.iconDeleting {
+  color: var(--sapContent_LabelColor);
+}
+
+.compactContainer {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.healthBar {
+  width: 6rem;
+  height: 0.5rem;
+  background: var(--sapGroup_ContentBackground);
+  border-radius: 0.25rem;
+  overflow: hidden;
+  border: 1px solid var(--sapList_BorderColor);
+  display: flex;
+}
+
+.healthBarSegment {
+  height: 100%;
+  transition: width 0.3s ease, background 0.3s ease;
+}
+
+.healthBarFill {
+  height: 100%;
+  transition: width 0.3s ease, background 0.3s ease;
+  border-radius: 0.25rem;
+}
+
+.healthText {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--sapTextColor);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}

--- a/src/components/ControlPlanes/WorkspaceHealthIndicator/WorkspaceHealthIndicator.spec.tsx
+++ b/src/components/ControlPlanes/WorkspaceHealthIndicator/WorkspaceHealthIndicator.spec.tsx
@@ -1,0 +1,279 @@
+import { describe, it, expect } from 'vitest';
+import { ControlPlaneListItem, ReadyStatus } from '../../../spaces/onboarding/types/ControlPlane';
+
+// Pure function tests for WorkspaceHealthIndicator calculation logic
+describe('WorkspaceHealthIndicator utilities', () => {
+  interface HealthStats {
+    ready: number;
+    notReady: number;
+    progressing: number;
+    deleting: number;
+    total: number;
+  }
+
+  // Helper function to calculate health stats (simulating component logic)
+  const calculateHealthStats = (controlPlanes: ControlPlaneListItem[]): HealthStats => {
+    return controlPlanes.reduce(
+      (acc, cp) => {
+        const status = cp.status?.status ?? cp.status?.phase;
+        switch (status) {
+          case ReadyStatus.Ready:
+            acc.ready++;
+            break;
+          case ReadyStatus.NotReady:
+            acc.notReady++;
+            break;
+          case ReadyStatus.Progressing:
+            acc.progressing++;
+            break;
+          case ReadyStatus.InDeletion:
+            acc.deleting++;
+            break;
+        }
+        acc.total++;
+        return acc;
+      },
+      { ready: 0, notReady: 0, progressing: 0, deleting: 0, total: 0 },
+    );
+  };
+
+  // Helper function to calculate health percentage
+  const calculateHealthPercentage = (healthStats: HealthStats): number => {
+    if (healthStats.total === 0) return 0;
+    return Math.round((healthStats.ready / healthStats.total) * 100);
+  };
+
+  // Helper function to determine health color
+  const getHealthColor = (healthPercentage: number, healthStats: HealthStats): string => {
+    if (healthPercentage === 100) return 'positive';
+    if (healthStats.progressing > 0 && healthStats.notReady === 0) return 'informative';
+    if (healthStats.notReady > 0) return 'negative';
+    return 'neutral';
+  };
+
+  // Helper function to determine health label
+  const getHealthLabel = (healthPercentage: number, healthStats: HealthStats): string => {
+    if (healthPercentage === 100) return 'healthy';
+    if (healthStats.progressing > 0 && healthStats.notReady === 0) return 'progressing';
+    if (healthStats.notReady > 0) return 'unhealthy';
+    return 'unknown';
+  };
+
+  describe('calculateHealthStats', () => {
+    it('calculates stats for all ready control planes', () => {
+      const controlPlanes: ControlPlaneListItem[] = [
+        {
+          version: 'v1',
+          metadata: { name: 'mcp-1', namespace: 'ns-1', creationTimestamp: '2024-01-01', annotations: {} },
+          status: { status: ReadyStatus.Ready, conditions: [], access: undefined },
+        },
+        {
+          version: 'v1',
+          metadata: { name: 'mcp-2', namespace: 'ns-1', creationTimestamp: '2024-01-01', annotations: {} },
+          status: { status: ReadyStatus.Ready, conditions: [], access: undefined },
+        },
+      ];
+
+      const result = calculateHealthStats(controlPlanes);
+
+      expect(result.ready).toBe(2);
+      expect(result.notReady).toBe(0);
+      expect(result.progressing).toBe(0);
+      expect(result.deleting).toBe(0);
+      expect(result.total).toBe(2);
+    });
+
+    it('calculates stats for mixed status control planes', () => {
+      const controlPlanes: ControlPlaneListItem[] = [
+        {
+          version: 'v1',
+          metadata: { name: 'mcp-1', namespace: 'ns-1', creationTimestamp: '2024-01-01', annotations: {} },
+          status: { status: ReadyStatus.Ready, conditions: [], access: undefined },
+        },
+        {
+          version: 'v1',
+          metadata: { name: 'mcp-2', namespace: 'ns-1', creationTimestamp: '2024-01-01', annotations: {} },
+          status: { status: ReadyStatus.NotReady, conditions: [], access: undefined },
+        },
+        {
+          version: 'v1',
+          metadata: { name: 'mcp-3', namespace: 'ns-1', creationTimestamp: '2024-01-01', annotations: {} },
+          status: { status: ReadyStatus.Progressing, conditions: [], access: undefined },
+        },
+      ];
+
+      const result = calculateHealthStats(controlPlanes);
+
+      expect(result.ready).toBe(1);
+      expect(result.notReady).toBe(1);
+      expect(result.progressing).toBe(1);
+      expect(result.deleting).toBe(0);
+      expect(result.total).toBe(3);
+    });
+
+    it('handles control planes with null status', () => {
+      const controlPlanes: ControlPlaneListItem[] = [
+        {
+          version: 'v1',
+          metadata: { name: 'mcp-1', namespace: 'ns-1', creationTimestamp: '2024-01-01', annotations: {} },
+          status: null,
+        },
+      ];
+
+      const result = calculateHealthStats(controlPlanes);
+
+      expect(result.ready).toBe(0);
+      expect(result.notReady).toBe(0);
+      expect(result.progressing).toBe(0);
+      expect(result.deleting).toBe(0);
+      expect(result.total).toBe(1);
+    });
+
+    it('handles empty control planes array', () => {
+      const result = calculateHealthStats([]);
+
+      expect(result.ready).toBe(0);
+      expect(result.notReady).toBe(0);
+      expect(result.progressing).toBe(0);
+      expect(result.deleting).toBe(0);
+      expect(result.total).toBe(0);
+    });
+
+    it('counts deleting control planes correctly', () => {
+      const controlPlanes: ControlPlaneListItem[] = [
+        {
+          version: 'v1',
+          metadata: { name: 'mcp-1', namespace: 'ns-1', creationTimestamp: '2024-01-01', annotations: {} },
+          status: { status: ReadyStatus.InDeletion, conditions: [], access: undefined },
+        },
+        {
+          version: 'v1',
+          metadata: { name: 'mcp-2', namespace: 'ns-1', creationTimestamp: '2024-01-01', annotations: {} },
+          status: { status: ReadyStatus.Ready, conditions: [], access: undefined },
+        },
+      ];
+
+      const result = calculateHealthStats(controlPlanes);
+
+      expect(result.deleting).toBe(1);
+      expect(result.ready).toBe(1);
+      expect(result.total).toBe(2);
+    });
+
+    it('uses phase field as fallback when status is not available', () => {
+      const controlPlanes: ControlPlaneListItem[] = [
+        {
+          version: 'v1',
+          metadata: { name: 'mcp-1', namespace: 'ns-1', creationTimestamp: '2024-01-01', annotations: {} },
+          status: {
+            status: ReadyStatus.Ready,
+            phase: ReadyStatus.Ready,
+            conditions: [],
+            access: undefined,
+          },
+        },
+      ];
+
+      const result = calculateHealthStats(controlPlanes);
+
+      expect(result.ready).toBe(1);
+      expect(result.total).toBe(1);
+    });
+  });
+
+  describe('calculateHealthPercentage', () => {
+    it('calculates 100% for all ready control planes', () => {
+      const stats: HealthStats = { ready: 3, notReady: 0, progressing: 0, deleting: 0, total: 3 };
+      expect(calculateHealthPercentage(stats)).toBe(100);
+    });
+
+    it('calculates 0% for no ready control planes', () => {
+      const stats: HealthStats = { ready: 0, notReady: 3, progressing: 0, deleting: 0, total: 3 };
+      expect(calculateHealthPercentage(stats)).toBe(0);
+    });
+
+    it('calculates 50% for half ready control planes', () => {
+      const stats: HealthStats = { ready: 1, notReady: 1, progressing: 0, deleting: 0, total: 2 };
+      expect(calculateHealthPercentage(stats)).toBe(50);
+    });
+
+    it('rounds percentage correctly', () => {
+      const stats: HealthStats = { ready: 2, notReady: 1, progressing: 0, deleting: 0, total: 3 };
+      expect(calculateHealthPercentage(stats)).toBe(67); // 66.666... rounds to 67
+    });
+
+    it('returns 0% for empty control planes', () => {
+      const stats: HealthStats = { ready: 0, notReady: 0, progressing: 0, deleting: 0, total: 0 };
+      expect(calculateHealthPercentage(stats)).toBe(0);
+    });
+
+    it('calculates 33% for one third ready control planes', () => {
+      const stats: HealthStats = { ready: 1, notReady: 2, progressing: 0, deleting: 0, total: 3 };
+      expect(calculateHealthPercentage(stats)).toBe(33); // 33.333... rounds to 33
+    });
+  });
+
+  describe('getHealthColor', () => {
+    it('returns positive for 100% healthy', () => {
+      const stats: HealthStats = { ready: 3, notReady: 0, progressing: 0, deleting: 0, total: 3 };
+      expect(getHealthColor(100, stats)).toBe('positive');
+    });
+
+    it('returns informative for progressing with no errors', () => {
+      const stats: HealthStats = { ready: 2, notReady: 0, progressing: 1, deleting: 0, total: 3 };
+      expect(getHealthColor(67, stats)).toBe('informative');
+    });
+
+    it('returns negative for any not ready control planes', () => {
+      const stats: HealthStats = { ready: 2, notReady: 1, progressing: 0, deleting: 0, total: 3 };
+      expect(getHealthColor(67, stats)).toBe('negative');
+    });
+
+    it('returns negative even with progressing if not ready exists', () => {
+      const stats: HealthStats = { ready: 1, notReady: 1, progressing: 1, deleting: 0, total: 3 };
+      expect(getHealthColor(33, stats)).toBe('negative');
+    });
+
+    it('returns neutral for unknown states', () => {
+      const stats: HealthStats = { ready: 0, notReady: 0, progressing: 0, deleting: 1, total: 1 };
+      expect(getHealthColor(0, stats)).toBe('neutral');
+    });
+
+    it('returns neutral for empty control planes', () => {
+      const stats: HealthStats = { ready: 0, notReady: 0, progressing: 0, deleting: 0, total: 0 };
+      expect(getHealthColor(0, stats)).toBe('neutral');
+    });
+  });
+
+  describe('getHealthLabel', () => {
+    it('returns healthy for 100%', () => {
+      const stats: HealthStats = { ready: 3, notReady: 0, progressing: 0, deleting: 0, total: 3 };
+      expect(getHealthLabel(100, stats)).toBe('healthy');
+    });
+
+    it('returns progressing for progressing with no errors', () => {
+      const stats: HealthStats = { ready: 2, notReady: 0, progressing: 1, deleting: 0, total: 3 };
+      expect(getHealthLabel(67, stats)).toBe('progressing');
+    });
+
+    it('returns unhealthy for any not ready control planes', () => {
+      const stats: HealthStats = { ready: 2, notReady: 1, progressing: 0, deleting: 0, total: 3 };
+      expect(getHealthLabel(67, stats)).toBe('unhealthy');
+    });
+
+    it('returns unhealthy even with progressing if not ready exists', () => {
+      const stats: HealthStats = { ready: 1, notReady: 1, progressing: 1, deleting: 0, total: 3 };
+      expect(getHealthLabel(33, stats)).toBe('unhealthy');
+    });
+
+    it('returns unknown for unknown states', () => {
+      const stats: HealthStats = { ready: 0, notReady: 0, progressing: 0, deleting: 1, total: 1 };
+      expect(getHealthLabel(0, stats)).toBe('unknown');
+    });
+
+    it('returns unknown for empty control planes', () => {
+      const stats: HealthStats = { ready: 0, notReady: 0, progressing: 0, deleting: 0, total: 0 };
+      expect(getHealthLabel(0, stats)).toBe('unknown');
+    });
+  });
+});

--- a/src/components/ControlPlanes/WorkspaceHealthIndicator/WorkspaceHealthIndicator.tsx
+++ b/src/components/ControlPlanes/WorkspaceHealthIndicator/WorkspaceHealthIndicator.tsx
@@ -1,0 +1,150 @@
+import { Icon, Label } from '@ui5/webcomponents-react';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ControlPlaneListItem, ReadyStatus } from '../../../spaces/onboarding/types/ControlPlane';
+import styles from './WorkspaceHealthIndicator.module.css';
+
+interface Props {
+  controlPlanes: ControlPlaneListItem[];
+  compact?: boolean;
+}
+
+interface HealthStats {
+  ready: number;
+  notReady: number;
+  progressing: number;
+  deleting: number;
+  total: number;
+}
+
+export function WorkspaceHealthIndicator({ controlPlanes, compact = false }: Props) {
+  const { t } = useTranslation();
+
+  const healthStats = useMemo<HealthStats>(() => {
+    return controlPlanes.reduce(
+      (acc, cp) => {
+        const status = cp.status?.status ?? cp.status?.phase;
+        switch (status) {
+          case ReadyStatus.Ready:
+            acc.ready++;
+            break;
+          case ReadyStatus.NotReady:
+            acc.notReady++;
+            break;
+          case ReadyStatus.Progressing:
+            acc.progressing++;
+            break;
+          case ReadyStatus.InDeletion:
+            acc.deleting++;
+            break;
+        }
+        acc.total++;
+        return acc;
+      },
+      { ready: 0, notReady: 0, progressing: 0, deleting: 0, total: 0 },
+    );
+  }, [controlPlanes]);
+
+  const healthPercentages = useMemo(() => {
+    if (healthStats.total === 0) return { ready: 0, notReady: 0, progressing: 0 };
+    return {
+      ready: Math.round((healthStats.ready / healthStats.total) * 100),
+      notReady: Math.round((healthStats.notReady / healthStats.total) * 100),
+      progressing: Math.round((healthStats.progressing / healthStats.total) * 100),
+    };
+  }, [healthStats]);
+
+  const getHealthColor = () => {
+    const { ready, notReady, progressing } = healthPercentages;
+    if (ready === 100) return 'var(--sapPositiveColor)';
+    if (progressing > 0 && notReady === 0) return 'var(--sapInformativeColor)';
+    if (notReady > 0) return 'var(--sapNegativeColor)';
+    return 'var(--sapNeutralColor)';
+  };
+
+  const getHealthSummary = () => {
+    if (healthStats.ready === healthStats.total) {
+      return `${healthStats.ready}/${healthStats.total} ${t('WorkspaceHealthIndicator.healthy')}`;
+    }
+    return `${healthStats.ready}/${healthStats.total} ${t('WorkspaceHealthIndicator.healthy')}`;
+  };
+
+  if (compact) {
+    return (
+      <div className={styles.compactContainer}>
+        <div className={styles.healthBar}>
+          {healthPercentages.ready > 0 && (
+            <div
+              className={styles.healthBarSegment}
+              style={{
+                width: `${healthPercentages.ready}%`,
+                background: 'var(--sapPositiveColor)',
+              }}
+            />
+          )}
+          {healthPercentages.notReady > 0 && (
+            <div
+              className={styles.healthBarSegment}
+              style={{
+                width: `${healthPercentages.notReady}%`,
+                background: 'var(--sapNegativeColor)',
+              }}
+            />
+          )}
+          {healthPercentages.progressing > 0 && (
+            <div
+              className={styles.healthBarSegment}
+              style={{
+                width: `${healthPercentages.progressing}%`,
+                background: 'var(--sapNeutralColor)',
+              }}
+            />
+          )}
+        </div>
+        <span className={styles.healthText}>{getHealthSummary()}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <Label className={styles.title}>{t('WorkspaceHealthIndicator.title')}</Label>
+        <div className={`${styles.healthBadge} ${styles[getHealthColor()]}`}>
+          <span className={styles.healthValue}>{healthPercentages.ready}%</span>
+        </div>
+      </div>
+
+      <div className={styles.statsGrid}>
+        {healthStats.ready > 0 && (
+          <div className={styles.statItem}>
+            <Icon name="sap-icon://sys-enter" className={styles.iconReady} />
+            <span className={styles.statValue}>{healthStats.ready}</span>
+            <span className={styles.statLabel}>{t('WorkspaceHealthIndicator.ready')}</span>
+          </div>
+        )}
+        {healthStats.progressing > 0 && (
+          <div className={styles.statItem}>
+            <Icon name="sap-icon://pending" className={styles.iconProgressing} />
+            <span className={styles.statValue}>{healthStats.progressing}</span>
+            <span className={styles.statLabel}>{t('WorkspaceHealthIndicator.progressing')}</span>
+          </div>
+        )}
+        {healthStats.notReady > 0 && (
+          <div className={styles.statItem}>
+            <Icon name="sap-icon://error" className={styles.iconNotReady} />
+            <span className={styles.statValue}>{healthStats.notReady}</span>
+            <span className={styles.statLabel}>{t('WorkspaceHealthIndicator.notReady')}</span>
+          </div>
+        )}
+        {healthStats.deleting > 0 && (
+          <div className={styles.statItem}>
+            <Icon name="sap-icon://delete" className={styles.iconDeleting} />
+            <span className={styles.statValue}>{healthStats.deleting}</span>
+            <span className={styles.statLabel}>{t('WorkspaceHealthIndicator.deleting')}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **`useMcpComponents`** — pure hook that extracts installed component names (Crossplane, Flux, Landscaper, Kyverno, ESO) from an MCP spec
- **`WorkspaceHealthIndicator`** — new component that aggregates per-MCP conditions into a segmented color bar (ready / notReady / progressing / deleting) with a count breakdown
- i18n keys for both additions (`WorkspaceHealthIndicator.*`, `ControlPlaneCard.installedComponents_*`)

## Dependencies

None — this is the foundation PR and can merge independently off `main`.

**Merge order for the full redesign:**
1. ✅ This PR (`feat/workspace-health-indicator`) → `main`
2. `feat/control-plane-card-v2` (depends on this PR)
3. `feat/copy-namespace-button-redesign` (PR #534, independent)
4. `feat/revamped-project-view-integration` (depends on all of the above)

## Test plan

- [ ] `npm run test:vi -- src/components/ControlPlanes/ControlPlaneCard/useMcpComponents.spec.tsx` — 9 tests
- [ ] `npm run test:vi -- src/components/ControlPlanes/WorkspaceHealthIndicator/WorkspaceHealthIndicator.spec.tsx` — 23 tests
- [ ] `npm run lint && npm run type-check` pass