### PR TITLE
feat: add ControlPlaneCardV2 with status bar, component icons and metadata

### DIFF
--- a/src/components/ControlPlanes/ConnectButton/ConnectButton.tsx
+++ b/src/components/ControlPlanes/ConnectButton/ConnectButton.tsx
@@ -1,4 +1,5 @@
 import { Button, Menu, MenuItem, MenuSeparator } from '@ui5/webcomponents-react';
+import ButtonDesign from '@ui5/webcomponents/dist/types/ButtonDesign.js';
 import { useId, useState } from 'react';
 import { DownloadKubeconfig } from '../CopyKubeconfigButton.tsx';
 import { useTranslation } from 'react-i18next';
@@ -61,7 +62,7 @@ export default function ConnectButton({
 
   if (isLoading || error || connectionTargets.length === 0) {
     return (
-      <Button endIcon="navigation-right-arrow" disabled={true}>
+      <Button design={ButtonDesign.Emphasized} endIcon="navigation-right-arrow" disabled={true}>
         {t('ConnectButton.buttonText')}
       </Button>
     );
@@ -70,7 +71,12 @@ export default function ConnectButton({
   if (connectionTargets.length === 1) {
     const directTarget = connectionTargets[0];
     return (
-      <Button endIcon="navigation-right-arrow" disabled={disabled} onClick={() => navigate(directTarget.url)}>
+      <Button
+        design={ButtonDesign.Emphasized}
+        endIcon="navigation-right-arrow"
+        disabled={disabled}
+        onClick={() => navigate(directTarget.url)}
+      >
         {t('ConnectButton.buttonText')}
       </Button>
     );
@@ -79,6 +85,7 @@ export default function ConnectButton({
   return (
     <div>
       <Button
+        design={ButtonDesign.Emphasized}
         id={buttonId}
         disabled={disabled}
         endIcon="slim-arrow-down"

--- a/src/components/ControlPlanes/ConnectButton/ConnectButtonV2.tsx
+++ b/src/components/ControlPlanes/ConnectButton/ConnectButtonV2.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@ui5/webcomponents-react';
+import ButtonDesign from '@ui5/webcomponents/dist/types/ButtonDesign.js';
 
 import { useTranslation } from 'react-i18next';
 import { useNavigate as _useNavigate } from 'react-router-dom';
@@ -24,6 +25,7 @@ export default function ConnectButtonV2({
 
   return (
     <Button
+      design={ButtonDesign.Emphasized}
       endIcon="navigation-right-arrow"
       onClick={() => navigate(`/mcp/projects/${projectName}/workspaces/${workspaceName}/mcpsv2/${controlPlaneName}`)}
     >

--- a/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCardMenu.tsx
+++ b/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCardMenu.tsx
@@ -31,6 +31,7 @@ export const ControlPlaneCardMenu: FC<ControlPlanesListMenuProps> = ({
         id={openerId}
         icon="overflow"
         icon-end
+        design="Transparent"
         data-testid="ControlPlaneCardMenu-opener"
         onClick={handleOpenerClick}
       />

--- a/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCardMenuV2.tsx
+++ b/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCardMenuV2.tsx
@@ -22,6 +22,7 @@ export const ControlPlaneCardMenuV2: FC<ControlPlaneCardMenuV2Props> = ({
         id={openerId}
         icon="overflow"
         icon-end
+        design="Transparent"
         data-testid="ControlPlaneCardMenuV2-opener"
         onClick={() => setMenuIsOpen(true)}
       />

--- a/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCardV2.module.css
+++ b/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCardV2.module.css
@@ -1,0 +1,330 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border-radius: 0.875rem;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  background: linear-gradient(145deg, #ffffff 0%, #fafbfc 100%);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow: hidden;
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.04),
+    0 4px 8px rgba(0, 0, 0, 0.02),
+    0 0 0 1px rgba(0, 0, 0, 0.02);
+  position: relative;
+}
+
+.card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.8) 20%,
+    rgba(255, 255, 255, 0.8) 80%,
+    transparent
+  );
+  pointer-events: none;
+}
+
+.card:hover {
+  border-color: rgba(0, 0, 0, 0.08);
+  box-shadow:
+    0 8px 20px rgba(0, 0, 0, 0.06),
+    0 12px 32px rgba(0, 0, 0, 0.04),
+    0 0 0 1px rgba(0, 0, 0, 0.03);
+  transform: translateY(-3px);
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 1.25rem 1.25rem 1rem 1.25rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.04);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.6) 0%, rgba(250, 251, 252, 0.4) 100%);
+  backdrop-filter: blur(8px);
+}
+
+.titleSection {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.875rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.statusIndicator {
+  width: 0.25rem;
+  height: 2.75rem;
+  border-radius: 0.25rem;
+  flex-shrink: 0;
+  margin-top: 0.125rem;
+  opacity: 1;
+}
+
+.statusIndicator.success {
+  background: var(--sapPositiveColor);
+}
+
+.statusIndicator.error {
+  background: var(--sapNegativeColor);
+}
+
+.statusIndicator.warning {
+  background: var(--sapCriticalColor);
+}
+
+.statusIndicator.neutral {
+  background: var(--sapNeutralColor);
+}
+
+.titleContent {
+  flex: 1;
+  min-width: 0;
+  gap: 0.5rem;
+}
+
+.title {
+  font-weight: 600;
+  font-size: 1.0625rem;
+  color: var(--sapTextColor);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+
+.metaRow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.subtitle {
+  font-size: 0.875rem;
+  color: var(--sapContent_LabelColor);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.headerActions {
+  flex-shrink: 0;
+}
+
+.cardBody {
+  padding: 1.25rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.membersSection {
+  margin-top: 0;
+  padding: 1rem;
+  background: linear-gradient(135deg, rgba(248, 249, 250, 0.5) 0%, rgba(255, 255, 255, 0.3) 100%);
+  border-radius: 0.625rem;
+  border: 1px solid rgba(0, 0, 0, 0.04);
+  min-height: 80px;
+}
+
+.componentsSection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+  padding: 1rem;
+  background: linear-gradient(135deg, rgba(248, 249, 250, 0.5) 0%, rgba(255, 255, 255, 0.3) 100%);
+  border-radius: 0.625rem;
+  border: 1px solid rgba(0, 0, 0, 0.04);
+  min-height: 80px;
+}
+
+.deprecatedSection {
+  margin-top: 0.5rem;
+}
+
+.sectionLabel {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(0, 0, 0, 0.5);
+}
+
+.componentIcons {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 0.5rem;
+  overflow-x: auto;
+}
+
+.componentIcon {
+  width: 2rem;
+  height: 2rem;
+  padding: 0.375rem;
+  background: linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  cursor: help;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.componentIcon:hover {
+  background: linear-gradient(135deg, #ffffff 0%, #ffffff 100%);
+  border-color: rgba(0, 0, 0, 0.12);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.08);
+}
+
+.componentLogo {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.emptyComponents {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.875rem 1rem;
+  background: linear-gradient(135deg, rgba(248, 249, 250, 0.6) 0%, rgba(241, 243, 245, 0.4) 100%);
+  border-radius: 0.625rem;
+  border: 1px dashed rgba(0, 0, 0, 0.1);
+}
+
+.emptyIcon {
+  color: rgba(0, 0, 0, 0.35);
+  font-size: 1rem;
+}
+
+.emptyText {
+  font-size: 0.8125rem;
+  color: rgba(0, 0, 0, 0.5);
+  font-style: italic;
+  font-weight: 500;
+}
+
+.metaInfo {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: auto;
+  padding-top: 0.5rem;
+}
+
+.membersSection {
+  margin-top: 0.5rem;
+  padding: 1rem;
+  background: linear-gradient(135deg, rgba(248, 249, 250, 0.5) 0%, rgba(255, 255, 255, 0.3) 100%);
+  border-radius: 0.625rem;
+  border: 1px solid rgba(0, 0, 0, 0.04);
+}
+
+.deprecatedSection {
+  margin-top: 0.5rem;
+}
+
+.metaItem {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.metaIcon {
+  color: rgba(0, 0, 0, 0.45);
+  font-size: 0.875rem;
+}
+
+.metaText {
+  font-size: 0.8125rem;
+  color: rgba(0, 0, 0, 0.55);
+  font-weight: 500;
+}
+
+.cardFooter {
+  padding: 1rem 1.25rem;
+  border-top: 1px solid rgba(0, 0, 0, 0.05);
+  background: linear-gradient(180deg, rgba(250, 251, 252, 0.8) 0%, rgba(245, 247, 249, 0.6) 100%);
+  backdrop-filter: blur(4px);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.footerLeft {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.footerRight {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+}
+
+/* Skeleton loading styles */
+.skeletonWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.skeletonLabel {
+  width: 80px;
+  height: 10px;
+  background: linear-gradient(90deg, rgba(0, 0, 0, 0.08) 25%, rgba(0, 0, 0, 0.12) 50%, rgba(0, 0, 0, 0.08) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+  border-radius: 4px;
+}
+
+.skeletonAvatars {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.skeletonAvatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: linear-gradient(90deg, rgba(0, 0, 0, 0.08) 25%, rgba(0, 0, 0, 0.12) 50%, rgba(0, 0, 0, 0.08) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+.skeletonIcons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.skeletonIcon {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.5rem;
+  background: linear-gradient(90deg, rgba(0, 0, 0, 0.08) 25%, rgba(0, 0, 0, 0.12) 50%, rgba(0, 0, 0, 0.08) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}

--- a/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCardV2.tsx
+++ b/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCardV2.tsx
@@ -1,0 +1,313 @@
+import { Card, FlexBox, Label, Title, Icon } from '@ui5/webcomponents-react';
+import '@ui5/webcomponents-fiori/dist/illustrations/NoData.js';
+import '@ui5/webcomponents-fiori/dist/illustrations/EmptyList.js';
+import '@ui5/webcomponents-icons/dist/delete';
+import ConnectButton from '../ConnectButton/ConnectButton.tsx';
+import TitleLevel from '@ui5/webcomponents/dist/types/TitleLevel.js';
+import { useState, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { DeleteConfirmationDialog } from '../../Dialogs/DeleteConfirmationDialog.tsx';
+import MCPHealthPopoverButton from '../../ControlPlane/MCPHealthPopoverButton.tsx';
+import styles from './ControlPlaneCardV2.module.css';
+import { KubectlDeleteMcpDialog } from '../../Dialogs/KubectlCommandInfo/KubectlDeleteMcpDialog.tsx';
+import { ControlPlaneListItem, ReadyStatus } from '../../../spaces/onboarding/types/ControlPlane.ts';
+import { Workspace } from '../../../spaces/onboarding/types/Workspace.ts';
+import { YamlViewButton } from '../../Yaml/YamlViewButton.tsx';
+import { canConnectToMCP } from '../controlPlanes.ts';
+import { ControlPlaneCardMenu } from './ControlPlaneCardMenu.tsx';
+import { ControlPlaneCardMenuV2 } from './ControlPlaneCardMenuV2.tsx';
+import { EditManagedControlPlaneWizardDataLoader } from '../../Wizards/CreateManagedControlPlane/EditManagedControlPlaneWizardDataLoader.tsx';
+import { DISPLAY_NAME_ANNOTATION } from '../../../lib/api/types/shared/keyNames.ts';
+import { useDeleteManagedControlPlane as _useDeleteManagedControlPlane } from '../../../hooks/useDeleteManagedControlPlane.ts';
+import { useDeleteManagedControlPlaneV2GraphQL as _useDeleteManagedControlPlaneV2GraphQL } from '../../../spaces/mcp/hooks/useDeleteManagedControlPlaneV2GraphQL.ts';
+import { DeprecatedLabel } from '../../Ui/DeprecatedLabel/DeprecatedLabel.tsx';
+import { useFeatureToggle } from '../../../context/FeatureToggleContext.tsx';
+import ConnectButtonV2 from '../ConnectButton/ConnectButtonV2.tsx';
+import { useMcpComponents } from './useMcpComponents.ts';
+import ReactTimeAgo from 'react-time-ago';
+import { McpMembersAvatarView } from '../McpMembersAvatarView/McpMembersAvatarView.tsx';
+
+import LogoCrossplane from '../../../assets/images/logo-crossplane.svg';
+import LogoFlux from '../../../assets/images/logo-flux.svg';
+import LogoLandscaper from '../../../assets/images/logo-landscaper.svg';
+import LogoKyverno from '../../../assets/images/logo-kyverno.png';
+import LogoEso from '../../../assets/images/logo-eso.svg';
+
+interface Props {
+  controlPlane: ControlPlaneListItem;
+  workspace: Workspace;
+  projectName: string;
+  useDeleteManagedControlPlane?: typeof _useDeleteManagedControlPlane;
+  useDeleteManagedControlPlaneV2GraphQL?: typeof _useDeleteManagedControlPlaneV2GraphQL;
+}
+
+type MCPWizardState = {
+  isOpen: boolean;
+  mode?: 'edit' | 'duplicate';
+};
+
+interface ComponentInfo {
+  name: string;
+  logo: string;
+  installed: boolean;
+  version?: string;
+}
+
+export const ControlPlaneCardV2 = ({
+  controlPlane,
+  workspace,
+  projectName,
+  useDeleteManagedControlPlane = _useDeleteManagedControlPlane,
+  useDeleteManagedControlPlaneV2GraphQL = _useDeleteManagedControlPlaneV2GraphQL,
+}: Props) => {
+  const { markMcpV1asDeprecated } = useFeatureToggle();
+  const [dialogDeleteMcpIsOpen, setDialogDeleteMcpIsOpen] = useState(false);
+  const [managedControlPlaneWizardState, setManagedControlPlaneWizardState] = useState<MCPWizardState>({
+    isOpen: false,
+    mode: undefined,
+  });
+
+  const handleIsManagedControlPlaneWizardOpen = (isOpen: boolean, mode?: 'edit' | 'duplicate') => {
+    setManagedControlPlaneWizardState({ isOpen, mode });
+  };
+
+  const { deleteManagedControlPlane } = useDeleteManagedControlPlane(
+    controlPlane.metadata.namespace,
+    controlPlane.metadata.name,
+  );
+
+  const { deleteManagedControlPlaneV2 } = useDeleteManagedControlPlaneV2GraphQL(
+    controlPlane.metadata.namespace,
+    controlPlane.metadata.name,
+  );
+
+  const { t } = useTranslation();
+
+  const name = controlPlane.metadata.name;
+  const displayName = controlPlane.metadata.annotations?.[DISPLAY_NAME_ANNOTATION];
+  const namespace = controlPlane.metadata.namespace;
+  const isConnectButtonEnabled = canConnectToMCP(controlPlane);
+
+  const {
+    components: mcpComponents,
+    roleBindings,
+    isLoading,
+  } = useMcpComponents(projectName, workspace.metadata.name, name);
+
+  const components = useMemo<ComponentInfo[]>(() => {
+    return [
+      {
+        name: 'Crossplane',
+        logo: LogoCrossplane,
+        installed: !!mcpComponents?.crossplane,
+        version: mcpComponents?.crossplane?.version,
+      },
+      {
+        name: 'Flux',
+        logo: LogoFlux,
+        installed: !!mcpComponents?.flux,
+        version: mcpComponents?.flux?.version,
+      },
+      {
+        name: 'Landscaper',
+        logo: LogoLandscaper,
+        installed: !!mcpComponents?.landscaper,
+      },
+      {
+        name: 'Kyverno',
+        logo: LogoKyverno,
+        installed: !!mcpComponents?.kyverno,
+        version: mcpComponents?.kyverno?.version,
+      },
+      {
+        name: 'External Secrets Operator',
+        logo: LogoEso,
+        installed: !!mcpComponents?.externalSecretsOperator,
+        version: mcpComponents?.externalSecretsOperator?.version,
+      },
+    ];
+  }, [mcpComponents]);
+
+  const installedComponents = useMemo(() => components.filter((c) => c.installed), [components]);
+
+  const getStatusColor = () => {
+    const status = controlPlane.status?.status ?? controlPlane.status?.phase;
+    switch (status) {
+      case ReadyStatus.Ready:
+        return 'success';
+      case ReadyStatus.NotReady:
+        return 'error';
+      case ReadyStatus.Progressing:
+        return 'warning';
+      case ReadyStatus.InDeletion:
+        return 'neutral';
+      default:
+        return 'neutral';
+    }
+  };
+
+  return (
+    <>
+      <Card key={`${name}--${namespace}`} className={styles.card}>
+        <div className={styles.cardHeader}>
+          <div className={styles.titleSection}>
+            <div className={`${styles.statusIndicator} ${styles[getStatusColor()]}`} />
+            <FlexBox direction="Column" className={styles.titleContent}>
+              <Title level={TitleLevel.H5} className={styles.title}>
+                {displayName ? displayName : name}
+              </Title>
+              <div className={styles.metaRow}>
+                <Icon name="sap-icon://time-entry-request" className={styles.metaIcon} />
+                <span className={styles.metaText}>
+                  <ReactTimeAgo date={new Date(controlPlane.metadata.creationTimestamp)} />
+                </span>
+              </div>
+            </FlexBox>
+          </div>
+
+          <div className={styles.headerActions}>
+            <MCPHealthPopoverButton
+              mcpStatus={controlPlane.status}
+              projectName={projectName}
+              workspaceName={workspace.metadata.name ?? ''}
+              mcpName={controlPlane.metadata.name}
+            />
+          </div>
+        </div>
+
+        <div className={styles.cardBody}>
+          <div className={styles.membersSection}>
+            {isLoading ? (
+              <div className={styles.skeletonWrapper}>
+                <div className={styles.skeletonLabel} />
+                <div className={styles.skeletonAvatars}>
+                  <div className={styles.skeletonAvatar} />
+                  <div className={styles.skeletonAvatar} />
+                  <div className={styles.skeletonAvatar} />
+                </div>
+              </div>
+            ) : (
+              <McpMembersAvatarView
+                roleBindings={roleBindings}
+                project={projectName}
+                workspace={workspace.metadata.name}
+              />
+            )}
+          </div>
+
+          <div className={styles.componentsSection}>
+            <Label className={styles.sectionLabel}>
+              {t('ControlPlaneCard.installedComponents', {
+                count: installedComponents.length,
+                defaultValue: 'Installed Components ({{count}})',
+              })}
+            </Label>
+            {isLoading ? (
+              <div className={styles.skeletonIcons}>
+                <div className={styles.skeletonIcon} />
+                <div className={styles.skeletonIcon} />
+                <div className={styles.skeletonIcon} />
+              </div>
+            ) : installedComponents.length > 0 ? (
+              <div className={styles.componentIcons}>
+                {installedComponents.map((component) => (
+                  <div key={component.name} className={styles.componentIcon} title={component.name}>
+                    <img src={component.logo} alt={component.name} className={styles.componentLogo} />
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className={styles.emptyComponents}>
+                <Icon name="sap-icon://question-mark" className={styles.emptyIcon} />
+                <span className={styles.emptyText}>{t('ControlPlaneCard.noComponents', 'No components detected')}</span>
+              </div>
+            )}
+          </div>
+
+          {markMcpV1asDeprecated && controlPlane.version !== 'v2' && (
+            <div className={styles.deprecatedSection}>
+              <DeprecatedLabel />
+            </div>
+          )}
+        </div>
+
+        <div className={styles.cardFooter}>
+          <div className={styles.footerLeft}>
+            {controlPlane.version !== 'v2' && (
+              <ControlPlaneCardMenu
+                setDialogDeleteMcpIsOpen={setDialogDeleteMcpIsOpen}
+                isDeleteMcpButtonDisabled={controlPlane.status?.status === ReadyStatus.InDeletion}
+                setIsEditManagedControlPlaneWizardOpen={handleIsManagedControlPlaneWizardOpen}
+              />
+            )}
+            {controlPlane.version === 'v2' && (
+              <ControlPlaneCardMenuV2
+                setDialogDeleteMcpIsOpen={setDialogDeleteMcpIsOpen}
+                isDeleteMcpButtonDisabled={controlPlane.status?.status === ReadyStatus.InDeletion}
+              />
+            )}
+            <YamlViewButton
+              variant="loader"
+              workspaceName={controlPlane.metadata.namespace}
+              resourceName={controlPlane.metadata.name}
+              resourceType={controlPlane.version === 'v2' ? 'managedcontrolplanev2s' : 'managedcontrolplanes'}
+            />
+          </div>
+
+          <div className={styles.footerRight}>
+            {controlPlane.version === 'v2' ? (
+              <ConnectButtonV2
+                controlPlaneName={name}
+                projectName={projectName}
+                workspaceName={workspace.metadata.name ?? ''}
+              />
+            ) : (
+              <ConnectButton
+                disabled={!isConnectButtonEnabled}
+                controlPlaneName={name}
+                projectName={projectName}
+                workspaceName={workspace.metadata.name ?? ''}
+                namespace={controlPlane.status?.access?.namespace ?? ''}
+                secretName={controlPlane.status?.access?.name ?? ''}
+                secretKey={controlPlane.status?.access?.key ?? ''}
+              />
+            )}
+          </div>
+        </div>
+      </Card>
+
+      {controlPlane.version !== 'v2' && (
+        <DeleteConfirmationDialog
+          resourceName={controlPlane.metadata.name}
+          kubectlDialog={({ isOpen, onClose }) => (
+            <KubectlDeleteMcpDialog
+              projectName={projectName}
+              workspaceName={workspace.metadata.name}
+              resourceName={controlPlane.metadata.name}
+              isOpen={isOpen}
+              onClose={onClose}
+            />
+          )}
+          isOpen={dialogDeleteMcpIsOpen}
+          setIsOpen={setDialogDeleteMcpIsOpen}
+          onDeletionConfirmed={deleteManagedControlPlane}
+        />
+      )}
+      {controlPlane.version === 'v2' && (
+        <DeleteConfirmationDialog
+          resourceName={controlPlane.metadata.name}
+          isOpen={dialogDeleteMcpIsOpen}
+          setIsOpen={setDialogDeleteMcpIsOpen}
+          onDeletionConfirmed={deleteManagedControlPlaneV2}
+        />
+      )}
+      <EditManagedControlPlaneWizardDataLoader
+        isOpen={managedControlPlaneWizardState.isOpen}
+        setIsOpen={(isOpen) => handleIsManagedControlPlaneWizardOpen(isOpen)}
+        workspaceName={namespace}
+        resourceName={name}
+        mode={managedControlPlaneWizardState.mode}
+      />
+    </>
+  );
+};


### PR DESCRIPTION
## Summary

- **`ControlPlaneCardV2`** — fully redesigned control plane card:
  - Color-coded left-edge status bar (green/red/yellow/gray)
  - Installed component icon row (Crossplane, Flux, Landscaper, Kyverno, ESO) via `useMcpComponents`
  - Creation date, deprecation label, role-binding count
  - Loading skeleton, hover lift effect (`translateY(-3px)`)
- **`ConnectButton` / `ConnectButtonV2`** — `ButtonDesign.Emphasized`
- **`ControlPlaneCardMenu` / `ControlPlaneCardMenuV2`** — `design="Transparent"` on overflow button

## Dependencies

⚠️ **Requires** `feat/workspace-health-indicator` (PR #569) to be merged first — imports `useMcpComponents` from that PR.

**Merge order for the full redesign:**
1. `feat/workspace-health-indicator` (PR #569) → `main`
2. ✅ This PR (`feat/control-plane-card-v2`) → `main`
3. `feat/copy-namespace-button-redesign` (PR #534, independent)
4. `feat/revamped-project-view-integration` (depends on all of the above)

## Test plan

- [ ] `npm run lint && npm run type-check` pass
- [ ] Card renders correctly in the project view (visual check)
- [ ] Status bar reflects MCP ready/notReady/progressing states
- [ ] Component icons appear for installed components only