### PR TITLE
feat: wire redesigned components into project view

### DIFF
--- a/cypress/support/component.tsx
+++ b/cypress/support/component.tsx
@@ -25,9 +25,14 @@ import { FrontendConfigContext } from '../../src/context/FrontendConfigContext';
 import { mockedFrontendConfig } from '../../src/utils/testing';
 import { ToastProvider } from '../../src/context/ToastContext.tsx';
 import { configureMonaco } from '../../src/lib/monaco';
+import TimeAgo from 'javascript-time-ago';
+import en from 'javascript-time-ago/locale/en';
 
 // Initialize Monaco Editor for Cypress tests
 configureMonaco();
+
+// Register time-ago locale for tests
+TimeAgo.addDefaultLocale(en);
 
 // Known race conditions during test teardown / module loading.
 Cypress.on('uncaught:exception', (err) => {

--- a/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCard.cy.tsx
+++ b/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCard.cy.tsx
@@ -1,4 +1,3 @@
-import '@ui5/webcomponents-cypress-commands';
 import { MemoryRouter } from 'react-router-dom';
 import { FeatureToggleProvider } from '../../../context/FeatureToggleContext.tsx';
 import { FrontendConfigContext } from '../../../context/FrontendConfigContext.tsx';

--- a/src/components/ControlPlanes/ControlPlanesListMenu.tsx
+++ b/src/components/ControlPlanes/ControlPlanesListMenu.tsx
@@ -39,7 +39,13 @@ export const ControlPlanesListMenu: FC<ControlPlanesListMenuProps> = ({
 
   return (
     <>
-      <Button icon="overflow" icon-end data-testid="ControlPlanesListMenu-opener" onClick={handleOpenerClick} />
+      <Button
+        icon="overflow"
+        icon-end
+        design="Transparent"
+        data-testid="ControlPlanesListMenu-opener"
+        onClick={handleOpenerClick}
+      />
       <Menu
         ref={popoverRef}
         open={open}

--- a/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.cy.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.cy.tsx
@@ -1,5 +1,4 @@
 import { MockedProvider } from '@apollo/client/testing/react';
-import '@ui5/webcomponents-cypress-commands';
 import { MemoryRouter } from 'react-router-dom';
 import { FeatureToggleProvider } from '../../../context/FeatureToggleContext.tsx';
 import { FrontendConfigContext } from '../../../context/FrontendConfigContext.tsx';
@@ -122,5 +121,138 @@ describe('ControlPlaneListWorkspaceGridTile', () => {
     cy.then(() => cy.wrap(deleteWorkspaceCalled).should('equal', false));
     cy.get('ui5-dialog[open]').find('ui5-button').contains('Delete').click();
     cy.then(() => cy.wrap(deleteWorkspaceCalled).should('equal', true));
+  });
+
+  it('displays WorkspaceHealthIndicator with correct stats for all healthy', () => {
+    const workspace: Workspace = {
+      metadata: {
+        name: 'workspaceName',
+        namespace: 'project-webapp-playground--ws-workspaceName',
+        annotations: {},
+      },
+      spec: {
+        members: [],
+      },
+    };
+
+    cy.mount(
+      <MockedProvider mocks={[]}>
+        <MemoryRouter>
+          <FrontendConfigContext.Provider
+            value={{
+              documentationBaseUrl: '',
+              githubBaseUrl: '',
+              featureToggles: { markMcpV1asDeprecated: false, enableMcpV2: false },
+            }}
+          >
+            <SplitterProvider>
+              <FeatureToggleProvider>
+                <ControlPlaneListWorkspaceGridTile
+                  workspace={workspace}
+                  projectName="some-project"
+                  useMcpsQuery={fakeUseMCPsListQuery}
+                  useDeleteWorkspace={fakeUseDeleteWorkspace}
+                />
+              </FeatureToggleProvider>
+            </SplitterProvider>
+          </FrontendConfigContext.Provider>
+        </MemoryRouter>
+      </MockedProvider>,
+    );
+
+    // Check health indicator displays "3/3 healthy" when all are ready
+    cy.contains('3/3 healthy').should('be.visible');
+  });
+
+  it('displays WorkspaceHealthIndicator with correct stats for unhealthy workspace', () => {
+    const mixedHealthControlPlanes: ControlPlaneListItem[] = [
+      {
+        version: 'v1',
+        metadata: {
+          name: 'mcp-ready',
+          namespace: 'project-test--ws-test',
+          creationTimestamp: '2024-05-28T10:00:00Z',
+          annotations: {},
+        },
+        status: {
+          status: ReadyStatus.Ready,
+          conditions: [],
+          access: undefined,
+        },
+      },
+      {
+        version: 'v1',
+        metadata: {
+          name: 'mcp-notready-1',
+          namespace: 'project-test--ws-test',
+          creationTimestamp: '2024-05-28T10:00:00Z',
+          annotations: {},
+        },
+        status: {
+          status: ReadyStatus.NotReady,
+          conditions: [],
+          access: undefined,
+        },
+      },
+      {
+        version: 'v1',
+        metadata: {
+          name: 'mcp-notready-2',
+          namespace: 'project-test--ws-test',
+          creationTimestamp: '2024-05-28T10:00:00Z',
+          annotations: {},
+        },
+        status: {
+          status: ReadyStatus.NotReady,
+          conditions: [],
+          access: undefined,
+        },
+      },
+    ];
+
+    const fakeUseMCPsListQueryMixed: typeof useMcpsQuery = () => ({
+      data: mixedHealthControlPlanes,
+      error: undefined,
+      isPending: false,
+    });
+
+    const workspace: Workspace = {
+      metadata: {
+        name: 'test',
+        namespace: 'project-test--ws-test',
+        annotations: {},
+      },
+      spec: {
+        members: [],
+      },
+    };
+
+    cy.mount(
+      <MockedProvider mocks={[]}>
+        <MemoryRouter>
+          <FrontendConfigContext.Provider
+            value={{
+              documentationBaseUrl: '',
+              githubBaseUrl: '',
+              featureToggles: { markMcpV1asDeprecated: false, enableMcpV2: false },
+            }}
+          >
+            <SplitterProvider>
+              <FeatureToggleProvider>
+                <ControlPlaneListWorkspaceGridTile
+                  workspace={workspace}
+                  projectName="test"
+                  useMcpsQuery={fakeUseMCPsListQueryMixed}
+                  useDeleteWorkspace={fakeUseDeleteWorkspace}
+                />
+              </FeatureToggleProvider>
+            </SplitterProvider>
+          </FrontendConfigContext.Provider>
+        </MemoryRouter>
+      </MockedProvider>,
+    );
+
+    // Check health indicator shows "1/3 healthy" when only 1 is ready
+    cy.contains('1/3 healthy').should('be.visible');
   });
 });

--- a/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
@@ -2,7 +2,7 @@ import '@ui5/webcomponents-fiori/dist/illustrations/EmptyList.js';
 import '@ui5/webcomponents-fiori/dist/illustrations/NoData.js';
 import IllustrationMessageType from '@ui5/webcomponents-fiori/dist/types/IllustrationMessageType.js';
 import '@ui5/webcomponents-icons/dist/delete';
-import { Button, FlexBox, ObjectPageSection, Panel, Title } from '@ui5/webcomponents-react';
+import { Button, ObjectPageSection, Panel, Title } from '@ui5/webcomponents-react';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFeatureToggle } from '../../../context/FeatureToggleContext.tsx';
@@ -14,15 +14,16 @@ import { useMcpsQuery as _useMcpsQuery } from '../../../spaces/onboarding/hooks/
 import { Workspace } from '../../../spaces/onboarding/types/Workspace.ts';
 import { DeleteConfirmationDialog } from '../../Dialogs/DeleteConfirmationDialog.tsx';
 import { DeleteWorkspaceDialog } from '../../Dialogs/KubectlCommandInfo/KubectlDeleteWorkspaceDialog.tsx';
-import { CopyButton } from '../../Shared/CopyButton.tsx';
+import { CopyNamespaceButton } from '../../Shared/CopyNamespaceButton.tsx';
 import IllustratedError from '../../Shared/IllustratedError.tsx';
 import { IllustratedBanner } from '../../Ui/IllustratedBanner/IllustratedBanner.tsx';
 import { CreateManagedControlPlaneV2WizardContainer } from '../../Wizards/CreateManagedControlPlane/CreateManagedControlPlaneV2WizardContainer.tsx';
 import { CreateManagedControlPlaneWizardContainer } from '../../Wizards/CreateManagedControlPlane/CreateManagedControlPlaneWizardContainer.tsx';
 import { YamlViewButton } from '../../Yaml/YamlViewButton.tsx';
-import { ControlPlaneCard } from '../ControlPlaneCard/ControlPlaneCard.tsx';
+import { ControlPlaneCardV2 } from '../ControlPlaneCard/ControlPlaneCardV2.tsx';
 import { ControlPlanesListMenu } from '../ControlPlanesListMenu.tsx';
 import { MembersAvatarView } from './MembersAvatarView.tsx';
+import { WorkspaceHealthIndicator } from '../WorkspaceHealthIndicator/WorkspaceHealthIndicator.tsx';
 import styles from './WorkspacesList.module.css';
 
 interface Props {
@@ -110,28 +111,34 @@ export function ControlPlaneListWorkspaceGridTile({
       >
         <Panel
           headerLevel="H2"
-          style={{ maxWidth: '1280px', margin: '0px auto 0px auto', width: '100%' }}
+          style={{ maxWidth: '1280px', margin: '0px auto 0px auto', width: '100%', background: 'transparent' }}
           collapsed={shouldCollapsePanel}
           header={
             <div
               style={{
                 width: '100%',
                 display: 'grid',
-                gridTemplateColumns: '0.3fr 0.3fr 0.24fr auto',
-                gap: '1rem',
-                justifyContent: 'space-between',
+                gridTemplateColumns: '1fr auto 1fr',
                 alignItems: 'center',
+                gap: '1rem',
               }}
             >
-              <Title level="H3">
-                {showDisplayName ? workspaceDisplayName : workspaceName}{' '}
-                {!isWorkspaceReady(workspace) ? '(Loading)' : ''}
-              </Title>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <Title level="H3">
+                  {showDisplayName ? workspaceDisplayName : workspaceName}{' '}
+                  {!isWorkspaceReady(workspace) ? '(Loading)' : ''}
+                </Title>
+                <CopyNamespaceButton namespace={workspace.status?.namespace || '-'} />
+              </div>
 
-              <CopyButton text={workspace.status?.namespace || '-'} style={{ justifyContent: 'start' }} />
+              <div style={{ display: 'flex', justifyContent: 'center' }}>
+                {managedControlPlanes && managedControlPlanes.length > 0 && (
+                  <WorkspaceHealthIndicator controlPlanes={managedControlPlanes} compact />
+                )}
+              </div>
 
-              <MembersAvatarView members={uniqueMembers} project={projectName} workspace={workspaceName} />
-              <FlexBox justifyContent={'SpaceBetween'} gap={10}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', justifyContent: 'flex-end' }}>
+                <MembersAvatarView members={uniqueMembers} project={projectName} workspace={workspaceName} />
                 <YamlViewButton
                   variant="loader"
                   workspaceName={workspace.metadata.namespace}
@@ -144,7 +151,7 @@ export function ControlPlaneListWorkspaceGridTile({
                   setInitialTemplateName={setInitialTemplateName}
                   setIsCreateManagedControlPlaneWizardOpenV2={setIsCreateManagedControlPlaneWizardOpenV2}
                 />
-              </FlexBox>
+              </div>
             </div>
           }
           noAnimation
@@ -192,7 +199,7 @@ export function ControlPlaneListWorkspaceGridTile({
             <div className={styles.wrapper}>
               <div className={styles.grid}>
                 {managedControlPlanes?.map((mcp) => (
-                  <ControlPlaneCard
+                  <ControlPlaneCardV2
                     key={`${mcp.metadata.name}--${mcp.metadata.namespace}`}
                     controlPlane={mcp}
                     projectName={projectName}

--- a/src/components/ControlPlanes/List/MembersAvatarView.tsx
+++ b/src/components/ControlPlanes/List/MembersAvatarView.tsx
@@ -33,7 +33,7 @@ export function MembersAvatarView({ members, project, workspace, hideNamespaceCo
   }
 
   return (
-    <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+    <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
       <AvatarGroup id={openerId} style={{ maxWidth: '200px' }} type={AvatarGroupType.Group} onClick={handleOnClick}>
         {avatars}
       </AvatarGroup>

--- a/src/components/ControlPlanes/List/WorkspacesList.module.css
+++ b/src/components/ControlPlanes/List/WorkspacesList.module.css
@@ -3,8 +3,20 @@
 }
 
 .wrapper {
-  margin-top: 0.375rem;
-  margin-bottom: 0.375rem;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  animation: fadeInDown 0.25s ease-out;
+}
+
+@keyframes fadeInDown {
+  from {
+    opacity: 0;
+    transform: translateY(-12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .grid {
@@ -12,9 +24,12 @@
   grid-template-columns: 1fr;
   gap: 1.5rem;
   @container (width > 768px) {
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(2, 1fr);
   }
-  @container (width > 1024px) {
-    grid-template-columns: 1fr 1fr 1fr;
+  @container (width > 1200px) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  @container (width > 1600px) {
+    grid-template-columns: repeat(4, 1fr);
   }
 }

--- a/src/components/ControlPlanes/McpMembersAvatarView/McpMembersAvatarView.module.css
+++ b/src/components/ControlPlanes/McpMembersAvatarView/McpMembersAvatarView.module.css
@@ -1,5 +1,9 @@
 .membersTitle {
-  margin-left: 5px;
-  font-weight: bold;
-  margin-bottom: 0.5rem;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(0, 0, 0, 0.5);
+  margin-bottom: 0.75rem;
+  display: block;
 }

--- a/src/components/Projects/ProjectChooser.tsx
+++ b/src/components/Projects/ProjectChooser.tsx
@@ -1,5 +1,5 @@
 import { VariantItem, VariantManagement } from '@ui5/webcomponents-react';
-import { CopyButton } from '../Shared/CopyButton.tsx';
+import { CopyNamespaceButton } from '../Shared/CopyNamespaceButton.tsx';
 import useLuigiNavigate from '../Shared/useLuigiNavigate.tsx';
 import IllustratedError from '../Shared/IllustratedError.tsx';
 import { useApiResource } from '../../lib/api/useApiResource';
@@ -36,7 +36,7 @@ export default function ProjectChooser({ currentProjectName }: Props) {
           </VariantItem>
         ))}
       </VariantManagement>
-      <CopyButton text={`project-${currentProjectName}`} />
+      <CopyNamespaceButton namespace={`project-${currentProjectName}`} />
     </>
   );
 }

--- a/src/components/Shared/CopyNamespaceButton.cy.tsx
+++ b/src/components/Shared/CopyNamespaceButton.cy.tsx
@@ -1,0 +1,105 @@
+import { CopyNamespaceButton } from './CopyNamespaceButton.tsx';
+import '@ui5/webcomponents-cypress-commands';
+import { CopyButtonProvider } from '../../context/CopyButtonContext.tsx';
+import { ToastProvider } from '../../context/ToastContext.tsx';
+
+describe('CopyNamespaceButton', () => {
+  const testNamespace = 'project-test--ws-workspace';
+
+  const mountWithProviders = (component: React.ReactElement) => {
+    return cy.mount(
+      <ToastProvider>
+        <CopyButtonProvider>{component}</CopyButtonProvider>
+      </ToastProvider>,
+    );
+  };
+
+  it('renders with copy icon only when not hovered', () => {
+    mountWithProviders(<CopyNamespaceButton namespace={testNamespace} />);
+
+    // Button should be visible
+    cy.get('ui5-button[icon="copy"]').should('exist');
+  });
+
+  it('expands to show namespace text on hover', () => {
+    mountWithProviders(<CopyNamespaceButton namespace={testNamespace} />);
+
+    // Get the button
+    const button = cy.get('ui5-button[icon="copy"]');
+
+    // Hover over the button itself
+    button.trigger('mouseenter', { force: true });
+
+    // Wait for animation and verify text is visible
+    cy.wait(350); // Wait for animation to complete
+    button.should('contain.text', testNamespace);
+  });
+
+  it('collapses when mouse leaves', () => {
+    mountWithProviders(<CopyNamespaceButton namespace={testNamespace} />);
+
+    const button = cy.get('ui5-button[icon="copy"]');
+
+    // Hover to expand
+    button.trigger('mouseenter', { force: true });
+    cy.wait(350);
+
+    // Leave hover
+    button.trigger('mouseleave', { force: true });
+    cy.wait(350);
+
+    // Text should be hidden (opacity 0 via CSS)
+    button.should('exist');
+  });
+
+  it('shows success state when clicked', () => {
+    cy.window().then((win) => {
+      // Stub clipboard BEFORE mounting
+      const writeTextStub = cy.stub().resolves();
+      Object.defineProperty(win.navigator, 'clipboard', {
+        value: {
+          writeText: writeTextStub,
+          readText: cy.stub().resolves(''),
+        },
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    mountWithProviders(<CopyNamespaceButton namespace={testNamespace} />);
+
+    const button = cy.get('ui5-button[icon="copy"]');
+
+    // Hover and click
+    button.trigger('mouseenter', { force: true });
+    cy.wait(350);
+    button.click();
+
+    // Wait for the async operation and state update
+    cy.wait(500);
+
+    // Check if design changed to Positive
+    button.should('have.attr', 'design', 'Positive');
+    button.should('contain.text', 'Copied to clipboard');
+  });
+
+  it('displays namespace as tooltip', () => {
+    mountWithProviders(<CopyNamespaceButton namespace={testNamespace} />);
+
+    cy.get('ui5-button[icon="copy"]').should('have.attr', 'tooltip', testNamespace);
+  });
+
+  it('handles long namespace strings', () => {
+    const longNamespace = 'project-very-long-project-name--ws-very-long-workspace-name';
+    mountWithProviders(<CopyNamespaceButton namespace={longNamespace} />);
+
+    const button = cy.get('ui5-button[icon="copy"]');
+
+    // Hover to expand
+    button.trigger('mouseenter', { force: true });
+    cy.wait(350);
+
+    // Should display full namespace
+    button.should('contain.text', longNamespace);
+  });
+});

--- a/src/components/Shared/CopyNamespaceButton.module.css
+++ b/src/components/Shared/CopyNamespaceButton.module.css
@@ -1,0 +1,32 @@
+.container {
+  display: inline-flex;
+  align-items: center;
+  overflow: hidden;
+}
+
+.button {
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.button .text {
+  display: inline-block;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.collapsed .text {
+  max-width: 0;
+  opacity: 0;
+  margin-left: 0;
+}
+
+.expanded .text {
+  max-width: 500px;
+  opacity: 1;
+  margin-left: 0.5rem;
+}
+
+.button:hover {
+  background-color: var(--sapButton_Hover_Background);
+}

--- a/src/components/Shared/CopyNamespaceButton.spec.tsx
+++ b/src/components/Shared/CopyNamespaceButton.spec.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
+import { useCopyButton } from '../../context/CopyButtonContext';
+
+const mockCopyToClipboard = vi.fn();
+const mockSetActiveCopyId = vi.fn();
+let mockActiveCopyId = '';
+
+vi.mock('../../hooks/useCopyToClipboard', () => ({
+  useCopyToClipboard: vi.fn(),
+}));
+
+vi.mock('../../context/CopyButtonContext', () => ({
+  useCopyButton: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('CopyNamespaceButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockActiveCopyId = '';
+
+    (useCopyToClipboard as ReturnType<typeof vi.fn>).mockReturnValue({
+      copyToClipboard: mockCopyToClipboard,
+    });
+
+    (useCopyButton as ReturnType<typeof vi.fn>).mockReturnValue({
+      activeCopyId: mockActiveCopyId,
+      setActiveCopyId: mockSetActiveCopyId,
+    });
+  });
+
+  it('provides copyToClipboard functionality', () => {
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    expect(result.current.copyToClipboard).toBeDefined();
+    expect(typeof result.current.copyToClipboard).toBe('function');
+  });
+
+  it('calls copyToClipboard with correct namespace', async () => {
+    const { result } = renderHook(() => useCopyToClipboard());
+    const namespace = 'test-namespace';
+
+    await act(async () => {
+      await result.current.copyToClipboard(namespace, { showToastOnSuccess: false });
+    });
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(namespace, { showToastOnSuccess: false });
+  });
+
+  it('updates active copy id when copy is triggered', () => {
+    const { result } = renderHook(() => useCopyButton());
+
+    act(() => {
+      result.current.setActiveCopyId('test-id');
+    });
+
+    expect(mockSetActiveCopyId).toHaveBeenCalledWith('test-id');
+  });
+
+  it('provides namespace prop for button text', () => {
+    const namespace = 'project-test--ws-workspace';
+
+    expect(namespace).toBe('project-test--ws-workspace');
+  });
+});

--- a/src/components/Shared/CopyNamespaceButton.tsx
+++ b/src/components/Shared/CopyNamespaceButton.tsx
@@ -1,0 +1,52 @@
+import { Button, ButtonPropTypes } from '@ui5/webcomponents-react';
+import { useCopyToClipboard } from '../../hooks/useCopyToClipboard.ts';
+import { useId, CSSProperties, useState } from 'react';
+import { useCopyButton } from '../../context/CopyButtonContext.tsx';
+import { ThemingParameters } from '@ui5/webcomponents-react-base';
+import { useTranslation } from 'react-i18next';
+import styles from './CopyNamespaceButton.module.css';
+
+interface CopyNamespaceButtonProps extends Omit<ButtonPropTypes, 'children'> {
+  namespace: string;
+  style?: CSSProperties;
+}
+
+export const CopyNamespaceButton = ({ namespace, style = {}, ...buttonProps }: CopyNamespaceButtonProps) => {
+  const { copyToClipboard } = useCopyToClipboard();
+  const { activeCopyId, setActiveCopyId } = useCopyButton();
+  const uniqueId = useId();
+  const isCopied = activeCopyId === uniqueId;
+  const { t } = useTranslation();
+  const [isHovered, setIsHovered] = useState(false);
+
+  const handleCopy = async () => {
+    await copyToClipboard(namespace, { showToastOnSuccess: false });
+    setActiveCopyId(uniqueId);
+  };
+
+  const defaultStyle: CSSProperties = {
+    color: isCopied ? undefined : ThemingParameters.sapContent_LabelColor,
+    justifyContent: 'start',
+  };
+
+  const buttonText = isCopied ? t('common.copyToClipboardSuccessToast') : namespace;
+  const showFullText = isHovered || isCopied;
+
+  return (
+    <div className={styles.container}>
+      <Button
+        icon="copy"
+        design={isCopied ? 'Positive' : 'Transparent'}
+        tooltip={namespace}
+        style={{ ...defaultStyle, ...style }}
+        className={`${styles.button} ${showFullText ? styles.expanded : styles.collapsed}`}
+        onClick={handleCopy}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        {...buttonProps}
+      >
+        <span className={styles.text}>{buttonText}</span>
+      </Button>
+    </div>
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -96,12 +96,19 @@ body {
 body {
   margin: 0;
   height: 100vh;
-  background-color: var(--sapBackgroundColor);
+  background: linear-gradient(
+    135deg,
+    rgba(250, 250, 250, 1) 0%,
+    rgba(4, 159, 154, 0.02) 35%,
+    rgba(4, 159, 154, 0.04) 50%,
+    rgba(4, 159, 154, 0.02) 65%,
+    rgba(250, 250, 250, 1) 100%
+  );
 }
 
 #root {
   height: 100%;
-  background-color: var(--sapBackgroundColor);
+  background: transparent;
 }
 
 ui5-form-item {
@@ -121,4 +128,46 @@ ui5-toast {
 .infobox {
   margin: 1rem auto;
   max-width: 80%;
+}
+
+/* Panel background - white header, transparent content */
+ui5-panel::part(header) {
+  background: white !important;
+  border-radius: 0.5rem !important;
+}
+
+ui5-panel::part(content) {
+  background: transparent !important;
+  padding: 1rem !important;
+}
+
+/* ObjectPageContent background - teal gradient */
+ui5-object-page::part(content) {
+  background: linear-gradient(
+    135deg,
+    rgba(250, 250, 250, 1) 0%,
+    rgba(4, 159, 154, 0.02) 35%,
+    rgba(4, 159, 154, 0.04) 50%,
+    rgba(4, 159, 154, 0.02) 65%,
+    rgba(250, 250, 250, 1) 100%
+  ) !important;
+}
+
+/* Page background gradient */
+body {
+  margin: 0;
+  height: 100vh;
+  background: linear-gradient(
+    135deg,
+    rgba(250, 250, 250, 1) 0%,
+    rgba(4, 159, 154, 0.02) 35%,
+    rgba(4, 159, 154, 0.04) 50%,
+    rgba(4, 159, 154, 0.02) 65%,
+    rgba(250, 250, 250, 1) 100%
+  );
+}
+
+#root {
+  height: 100%;
+  background: transparent;
 }


### PR DESCRIPTION
## Summary

Integration PR — swaps old components for new ones in the live workspace grid view:

- **`ControlPlaneListWorkspaceGridTile`** — uses `ControlPlaneCardV2`, `CopyNamespaceButton`, `WorkspaceHealthIndicator` in header
- **`WorkspacesList.module.css`** — fade-in animation, responsive breakpoints (2 cols @768px, 3 @1200px, 4 @1600px)
- **`MembersAvatarView`** — left-align avatar group
- **`McpMembersAvatarView`** — uppercase title with letter-spacing
- **`ProjectChooser`** — `CopyButton` → `CopyNamespaceButton`
- **`ControlPlanesListMenu`** — transparent design on overflow button
- **`index.css`** — gradient backgrounds, UI5 panel shadow parts
- **`cypress/support`** — register `TimeAgo` locale for component tests

> Note: this PR temporarily includes `CopyNamespaceButton` to stay self-contained. Once PR #534 merges into `main` and the base branches are rebased, `CopyNamespaceButton` can be removed from this branch.

## Dependencies

⚠️ **Requires all three PRs to merge first**, in order:
1. `feat/workspace-health-indicator` (PR #569) → `main`
2. `feat/control-plane-card-v2` (PR #570) → `main`
3. `feat/copy-namespace-button-redesign` (PR #534) → `main`
4. ✅ Then this PR → `main`

## Test plan

- [ ] `npm run lint && npm run type-check` pass
- [ ] `npm run test:vi` — full suite green
- [ ] `npm run test:cy -- --spec 'src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.cy.tsx'`
- [ ] Visual check: workspace grid renders with new cards, health indicator in header, responsive columns