### PR TITLE
fix: mcpv2 permissions schema

### DIFF
--- a/src/spaces/onboarding/types/ControlPlane.ts
+++ b/src/spaces/onboarding/types/ControlPlane.ts
@@ -111,7 +111,7 @@ const AccessV2Schema = z.preprocess(
 const StatusV2Schema = z.object({
   phase: z.string().nullish(),
   conditions: ConditionsSchema,
-  access: AccessV2Schema,
+  access: AccessV2Schema.nullish(),
 });
 
 const SpecV2Schema = z.object({

--- a/src/spaces/onboarding/types/ControlPlane.ts
+++ b/src/spaces/onboarding/types/ControlPlane.ts
@@ -129,17 +129,25 @@ const SpecV2Schema = z.object({
             .object({
               name: z.string().nullish(),
               permissions: z
-                .object({
-                  rules: z
-                    .array(
-                      z.object({
-                        apiGroups: z.array(z.string().nullable()).nullish(),
-                        resources: z.array(z.string().nullable()).nullish(),
-                        verbs: z.array(z.string().nullable()).nullish(),
-                      }),
-                    )
-                    .nullish(),
-                })
+                .array(
+                  z
+                    .object({
+                      name: z.string().nullish(),
+                      namespace: z.string().nullish(),
+                      rules: z
+                        .array(
+                          z.object({
+                            apiGroups: z.array(z.string().nullable()).nullish(),
+                            nonResourceURLs: z.array(z.string().nullable()).nullish(),
+                            resourceNames: z.array(z.string().nullable()).nullish(),
+                            resources: z.array(z.string().nullable()).nullish(),
+                            verbs: z.array(z.string().nullable()).nullish(),
+                          }),
+                        )
+                        .nullish(),
+                    })
+                    .nullable(),
+                )
                 .nullish(),
               roleRefs: z.array(RoleRefSchema.nullable()).nullish(),
             })


### PR DESCRIPTION
This PR adjusts our zod schema to match the v2 control plane schema: https://github.com/openmcp-project/openmcp-operator/blob/main/api/crds/manifests/core.openmcp.cloud_managedcontrolplanev2s.yaml