### PR TITLE
fix: place CopyButton inline after workspace title

### DIFF
--- a/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
@@ -117,18 +117,19 @@ export function ControlPlaneListWorkspaceGridTile({
               style={{
                 width: '100%',
                 display: 'grid',
-                gridTemplateColumns: '0.3fr 0.3fr 0.24fr auto',
+                gridTemplateColumns: '1fr 0.24fr auto',
                 gap: '1rem',
                 justifyContent: 'space-between',
                 alignItems: 'center',
               }}
             >
-              <Title level="H3">
-                {showDisplayName ? workspaceDisplayName : workspaceName}{' '}
-                {!isWorkspaceReady(workspace) ? '(Loading)' : ''}
-              </Title>
-
-              <CopyButton text={workspace.status?.namespace || '-'} style={{ justifyContent: 'start' }} />
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem', minWidth: 0 }}>
+                <Title level="H3">
+                  {showDisplayName ? workspaceDisplayName : workspaceName}{' '}
+                  {!isWorkspaceReady(workspace) ? '(Loading)' : ''}
+                </Title>
+                <CopyButton collapsible text={workspace.status?.namespace || '-'} />
+              </div>
 
               <MembersAvatarView members={uniqueMembers} project={projectName} workspace={workspaceName} />
               <FlexBox justifyContent={'SpaceBetween'} gap={10}>


### PR DESCRIPTION

<img width="1179" height="191" alt="image" src="https://github.com/user-attachments/assets/b5eb1b14-8312-41e0-8151-a39010202c57" />


## Summary

Wraps the workspace `Title` and `CopyButton` in a flex row so the copy button sits directly after the title text instead of occupying a separate grid column.

- Replaces the `<>` fragment with a `display: flex` div
- Reduces the header grid from 4 columns to 3 (title+button now share one cell)

## Dependencies

⚠️ Requires `feat/copy-namespace-button-redesign` (PR #534) — depends on the `collapsible` prop on `CopyButton`.