### PR TITLE
fix: use transparent design on workspace overflow menu button

### DIFF
--- a/src/components/ControlPlanes/ControlPlanesListMenu.tsx
+++ b/src/components/ControlPlanes/ControlPlanesListMenu.tsx
@@ -39,7 +39,7 @@ export const ControlPlanesListMenu: FC<ControlPlanesListMenuProps> = ({
 
   return (
     <>
-      <Button icon="overflow" icon-end data-testid="ControlPlanesListMenu-opener" onClick={handleOpenerClick} />
+      <Button design="Transparent" icon="overflow" icon-end data-testid="ControlPlanesListMenu-opener" onClick={handleOpenerClick} />
       <Menu
         ref={popoverRef}
         open={open}

--- a/src/components/ControlPlanes/ControlPlanesListMenu.tsx
+++ b/src/components/ControlPlanes/ControlPlanesListMenu.tsx
@@ -39,7 +39,13 @@ export const ControlPlanesListMenu: FC<ControlPlanesListMenuProps> = ({
 
   return (
     <>
-      <Button design="Transparent" icon="overflow" icon-end data-testid="ControlPlanesListMenu-opener" onClick={handleOpenerClick} />
+      <Button
+        design="Transparent"
+        icon="overflow"
+        icon-end
+        data-testid="ControlPlanesListMenu-opener"
+        onClick={handleOpenerClick}
+      />
       <Menu
         ref={popoverRef}
         open={open}


### PR DESCRIPTION
old: 

<img width="2358" height="250" alt="image" src="https://github.com/user-attachments/assets/a2aacc2b-3101-42ab-8ac1-92e2d232cb1e" />

 new: 

<img width="1179" height="125" alt="image" src="https://github.com/user-attachments/assets/dfdea70f-cca0-4ecd-83fd-0607d8619e79" />


## Summary

The overflow (`⋯`) button in the workspace panel header had the default UI5 button style with a visible border. Switching to `design="Transparent"` removes the border and background, making it visually subtle — consistent with how icon-only action buttons appear elsewhere in the app.