### PR TITLE
feat: add WorkspaceHealthIndicator to workspace panel header

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -102,7 +102,12 @@
     "editMCP": "Edit Control Plane",
     "duplicateMCP": "Duplicate Control Plane",
     "deleteMCP": "Delete Control Plane"
-
+  },
+  "WorkspaceHealthIndicator": {
+    "ready": "Ready",
+    "notReady": "Not Ready",
+    "progressing": "Progressing",
+    "deleting": "Deleting"
   },
   "ControlPlaneListAllWorkspaces": {
     "emptyListTitleMessage": "No Workspaces created yet",

--- a/src/components/ControlPlane/MCPHealthPopoverButton.module.css
+++ b/src/components/ControlPlane/MCPHealthPopoverButton.module.css
@@ -23,6 +23,10 @@
   color: var(--sapNegativeColor);
 }
 
+.iconProgressing {
+  color: var(--sapInformativeColor);
+}
+
 .iconInDeletion {
   color: var(--sapCriticalColor);
 }

--- a/src/components/ControlPlane/MCPHealthPopoverButton.tsx
+++ b/src/components/ControlPlane/MCPHealthPopoverButton.tsx
@@ -136,7 +136,7 @@ const getIconForOverallStatus = (status: string | undefined): JSX.Element => {
     case ReadyStatus.NotReady:
       return <Icon className={styles.iconNotReady} name="sap-icon://pending" />;
     case ReadyStatus.Progressing:
-      return <Icon className={styles.iconNotReady} name="sap-icon://pending" />;
+      return <Icon className={styles.iconProgressing} name="sap-icon://pending" />;
     case ReadyStatus.InDeletion:
       return <Icon className={styles.iconInDeletion} name="sap-icon://delete" />;
     default:

--- a/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.cy.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.cy.tsx
@@ -123,4 +123,108 @@ describe('ControlPlaneListWorkspaceGridTile', () => {
     cy.get('ui5-dialog[open]').find('ui5-button').contains('Delete').click();
     cy.then(() => cy.wrap(deleteWorkspaceCalled).should('equal', true));
   });
+
+  const mountTile = (workspace: Workspace, query: typeof useMcpsQuery) => {
+    cy.mount(
+      <MockedProvider mocks={[]}>
+        <MemoryRouter>
+          <FrontendConfigContext.Provider
+            value={{
+              documentationBaseUrl: '',
+              githubBaseUrl: '',
+              featureToggles: { markMcpV1asDeprecated: false, enableMcpV2: false },
+            }}
+          >
+            <SplitterProvider>
+              <FeatureToggleProvider>
+                <ControlPlaneListWorkspaceGridTile
+                  workspace={workspace}
+                  projectName="some-project"
+                  useMcpsQuery={query}
+                  useDeleteWorkspace={fakeUseDeleteWorkspace}
+                />
+              </FeatureToggleProvider>
+            </SplitterProvider>
+          </FrontendConfigContext.Provider>
+        </MemoryRouter>
+      </MockedProvider>,
+    );
+  };
+
+  it('shows health indicator with 3 pills when all control planes are ready', () => {
+    const workspace: Workspace = {
+      metadata: { name: 'workspaceName', namespace: 'project-webapp-playground--ws-workspaceName', annotations: {} },
+      spec: { members: [] },
+    };
+    mountTile(workspace, fakeUseMCPsListQuery);
+    cy.get('[data-testid="health-pill"]').should('have.length', 3);
+  });
+
+  it('shows health indicator with correct pill count for mixed health', () => {
+    const mixedControlPlanes: ControlPlaneListItem[] = [
+      {
+        version: 'v1',
+        metadata: {
+          name: 'mcp-ready',
+          namespace: 'project-test--ws-test',
+          creationTimestamp: '2024-05-28T10:00:00Z',
+          annotations: {},
+        },
+        status: { status: ReadyStatus.Ready, conditions: [], access: undefined },
+      },
+      {
+        version: 'v1',
+        metadata: {
+          name: 'mcp-notready-1',
+          namespace: 'project-test--ws-test',
+          creationTimestamp: '2024-05-28T10:00:00Z',
+          annotations: {},
+        },
+        status: { status: ReadyStatus.NotReady, conditions: [], access: undefined },
+      },
+      {
+        version: 'v1',
+        metadata: {
+          name: 'mcp-notready-2',
+          namespace: 'project-test--ws-test',
+          creationTimestamp: '2024-05-28T10:00:00Z',
+          annotations: {},
+        },
+        status: { status: ReadyStatus.NotReady, conditions: [], access: undefined },
+      },
+    ];
+
+    const fakeQueryMixed: typeof useMcpsQuery = () => ({
+      data: mixedControlPlanes,
+      error: undefined,
+      isPending: false,
+    });
+
+    const workspace: Workspace = {
+      metadata: { name: 'test', namespace: 'project-test--ws-test', annotations: {} },
+      spec: { members: [] },
+    };
+    mountTile(workspace, fakeQueryMixed);
+    cy.get('[data-testid="health-pill"]').should('have.length', 3);
+  });
+
+  it('does not show health indicator when workspace has no control planes', () => {
+    const emptyQuery: typeof useMcpsQuery = () => ({ data: [], error: undefined, isPending: false });
+    const workspace: Workspace = {
+      metadata: { name: 'empty-ws', namespace: 'project-test--ws-empty', annotations: {} },
+      spec: { members: [] },
+    };
+    mountTile(workspace, emptyQuery);
+    cy.get('[class*="healthBar"]').should('not.exist');
+  });
+
+  it('does not show health indicator while loading', () => {
+    const pendingQuery: typeof useMcpsQuery = () => ({ data: [], error: undefined, isPending: true });
+    const workspace: Workspace = {
+      metadata: { name: 'loading-ws', namespace: 'project-test--ws-loading', annotations: {} },
+      spec: { members: [] },
+    };
+    mountTile(workspace, pendingQuery);
+    cy.get('[class*="healthBar"]').should('not.exist');
+  });
 });

--- a/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
@@ -2,8 +2,8 @@ import '@ui5/webcomponents-fiori/dist/illustrations/EmptyList.js';
 import '@ui5/webcomponents-fiori/dist/illustrations/NoData.js';
 import IllustrationMessageType from '@ui5/webcomponents-fiori/dist/types/IllustrationMessageType.js';
 import '@ui5/webcomponents-icons/dist/delete';
-import { Button, FlexBox, ObjectPageSection, Panel, Title } from '@ui5/webcomponents-react';
-import { useMemo, useEffect, useState } from 'react';
+import { Button, ObjectPageSection, Panel, Title } from '@ui5/webcomponents-react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFeatureToggle } from '../../../context/FeatureToggleContext.tsx';
 import { isForbiddenError } from '../../../lib/api/error.ts';
@@ -22,6 +22,7 @@ import { CreateManagedControlPlaneWizardContainer } from '../../Wizards/CreateMa
 import { YamlViewButton } from '../../Yaml/YamlViewButton.tsx';
 import { ControlPlaneCard } from '../ControlPlaneCard/ControlPlaneCard.tsx';
 import { ControlPlanesListMenu } from '../ControlPlanesListMenu.tsx';
+import { WorkspaceHealthIndicator } from '../WorkspaceHealthIndicator/WorkspaceHealthIndicator.tsx';
 import { MembersAvatarView } from './MembersAvatarView.tsx';
 import styles from './WorkspacesList.module.css';
 
@@ -129,9 +130,8 @@ export function ControlPlaneListWorkspaceGridTile({
               style={{
                 width: '100%',
                 display: 'grid',
-                gridTemplateColumns: '1fr 0.24fr auto',
+                gridTemplateColumns: '1fr auto 1fr',
                 gap: '1rem',
-                justifyContent: 'space-between',
                 alignItems: 'center',
               }}
             >
@@ -143,8 +143,13 @@ export function ControlPlaneListWorkspaceGridTile({
                 <CopyButton collapsible text={workspace.status?.namespace || '-'} />
               </div>
 
-              <MembersAvatarView members={uniqueMembers} project={projectName} workspace={workspaceName} />
-              <FlexBox justifyContent={'SpaceBetween'} gap={10}>
+              <div style={{ display: 'flex', justifyContent: 'center' }} />
+
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', justifyContent: 'flex-end' }}>
+                <MembersAvatarView members={uniqueMembers} project={projectName} workspace={workspaceName} />
+                {managedControlPlanes && managedControlPlanes.length > 0 && (
+                  <WorkspaceHealthIndicator controlPlanes={managedControlPlanes} />
+                )}
                 <YamlViewButton
                   variant="loader"
                   workspaceName={workspace.metadata.namespace}
@@ -157,7 +162,7 @@ export function ControlPlaneListWorkspaceGridTile({
                   setInitialTemplateName={setInitialTemplateName}
                   setIsCreateManagedControlPlaneWizardOpenV2={setIsCreateManagedControlPlaneWizardOpenV2}
                 />
-              </FlexBox>
+              </div>
             </div>
           }
           onToggle={onToggleExpanded}

--- a/src/components/ControlPlanes/WorkspaceHealthIndicator/WorkspaceHealthIndicator.cy.tsx
+++ b/src/components/ControlPlanes/WorkspaceHealthIndicator/WorkspaceHealthIndicator.cy.tsx
@@ -1,0 +1,54 @@
+import '@ui5/webcomponents-cypress-commands';
+import { ControlPlaneListItem, ReadyStatus } from '../../../spaces/onboarding/types/ControlPlane.ts';
+import { WorkspaceHealthIndicator } from './WorkspaceHealthIndicator.tsx';
+
+function makeCps(ready: number, notReady: number, progressing: number, deleting: number): ControlPlaneListItem[] {
+  const cps: ControlPlaneListItem[] = [];
+  const push = (status: (typeof ReadyStatus)[keyof typeof ReadyStatus], n: number) => {
+    for (let i = 0; i < n; i++) {
+      cps.push({
+        version: 'v1',
+        metadata: { name: `mcp-${status}-${i}`, namespace: 'ns', creationTimestamp: '2024-01-01', annotations: {} },
+        status: { status, conditions: [], access: undefined },
+      });
+    }
+  };
+  push(ReadyStatus.Ready, ready);
+  push(ReadyStatus.NotReady, notReady);
+  push(ReadyStatus.Progressing, progressing);
+  push(ReadyStatus.InDeletion, deleting);
+  return cps;
+}
+
+describe('WorkspaceHealthIndicator', () => {
+  it('renders 1 pill for 1 MCP', () => {
+    cy.mount(<WorkspaceHealthIndicator controlPlanes={makeCps(1, 0, 0, 0)} />);
+    cy.get('[data-testid="health-pill"]').should('have.length', 1);
+  });
+
+  it('renders 3 pills for 3 MCPs', () => {
+    cy.mount(<WorkspaceHealthIndicator controlPlanes={makeCps(3, 0, 0, 0)} />);
+    cy.get('[data-testid="health-pill"]').should('have.length', 3);
+  });
+
+  it('renders max 5 pills for more than 5 MCPs', () => {
+    cy.mount(<WorkspaceHealthIndicator controlPlanes={makeCps(6, 2, 1, 1)} />);
+    cy.get('[data-testid="health-pill"]').should('have.length', 5);
+  });
+
+  it('renders no pills for empty control planes', () => {
+    cy.mount(<WorkspaceHealthIndicator controlPlanes={[]} />);
+    cy.get('[data-testid="health-pill"]').should('have.length', 0);
+  });
+
+  it('reveals status summary on hover', () => {
+    cy.mount(<WorkspaceHealthIndicator controlPlanes={makeCps(2, 1, 0, 0)} />);
+
+    const container = cy.get('[class*="container"]');
+    container.trigger('mouseenter', { force: true });
+
+    cy.wait(350);
+    container.should('contain.text', '2 Ready');
+    container.should('contain.text', '1 Not Ready');
+  });
+});

--- a/src/components/ControlPlanes/WorkspaceHealthIndicator/WorkspaceHealthIndicator.module.css
+++ b/src/components/ControlPlanes/WorkspaceHealthIndicator/WorkspaceHealthIndicator.module.css
@@ -1,0 +1,55 @@
+.container {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  overflow: hidden;
+  cursor: default;
+}
+
+.pillBar {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.pill {
+  width: 10px;
+  height: 0.625rem;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.summary {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  max-width: 0;
+  opacity: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  transition:
+    max-width 0.25s ease,
+    opacity 0.2s ease;
+}
+
+.container:hover .summary {
+  max-width: 400px;
+  opacity: 1;
+}
+
+.summaryItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--sapTextColor);
+}
+
+.dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+}

--- a/src/components/ControlPlanes/WorkspaceHealthIndicator/WorkspaceHealthIndicator.tsx
+++ b/src/components/ControlPlanes/WorkspaceHealthIndicator/WorkspaceHealthIndicator.tsx
@@ -1,0 +1,126 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ControlPlaneListItem, ReadyStatus } from '../../../spaces/onboarding/types/ControlPlane';
+import styles from './WorkspaceHealthIndicator.module.css';
+
+interface Props {
+  controlPlanes: ControlPlaneListItem[];
+}
+
+interface HealthStats {
+  ready: number;
+  notReady: number;
+  progressing: number;
+  deleting: number;
+  total: number;
+}
+
+function getSegmentColor(status: string): string {
+  switch (status) {
+    case ReadyStatus.Ready:
+      return 'var(--sapPositiveColor)';
+    case ReadyStatus.NotReady:
+      return 'var(--sapNegativeColor)';
+    case ReadyStatus.Progressing:
+      return 'var(--sapInformativeColor)';
+    case ReadyStatus.InDeletion:
+      return 'var(--sapCriticalColor)';
+    default:
+      return 'var(--sapNeutralColor)';
+  }
+}
+
+export function WorkspaceHealthIndicator({ controlPlanes }: Props) {
+  const { t } = useTranslation();
+
+  const stats = useMemo<HealthStats>(() => {
+    return controlPlanes.reduce(
+      (acc, cp) => {
+        const status = cp.status?.status ?? cp.status?.phase;
+        switch (status) {
+          case ReadyStatus.Ready:
+            acc.ready++;
+            break;
+          case ReadyStatus.NotReady:
+            acc.notReady++;
+            break;
+          case ReadyStatus.Progressing:
+            acc.progressing++;
+            break;
+          case ReadyStatus.InDeletion:
+            acc.deleting++;
+            break;
+        }
+        acc.total++;
+        return acc;
+      },
+      { ready: 0, notReady: 0, progressing: 0, deleting: 0, total: 0 },
+    );
+  }, [controlPlanes]);
+
+  const MAX_PILLS = 5;
+  type Segment = { color: string; count: number };
+  const segments: Segment[] = [];
+
+  const addSegment = (count: number, status: string) => {
+    if (count === 0) return;
+    const pills = stats.total <= MAX_PILLS ? count : Math.max(1, Math.round((count / stats.total) * MAX_PILLS));
+    segments.push({ color: getSegmentColor(status), count: pills });
+  };
+
+  addSegment(stats.ready, ReadyStatus.Ready);
+  addSegment(stats.notReady, ReadyStatus.NotReady);
+  addSegment(stats.progressing, ReadyStatus.Progressing);
+  addSegment(stats.deleting, ReadyStatus.InDeletion);
+
+  if (stats.total > MAX_PILLS) {
+    const pillTotal = segments.reduce((s, seg) => s + seg.count, 0);
+    if (pillTotal !== MAX_PILLS && segments.length > 0) {
+      const largest = segments.reduce((a, b) => (a.count >= b.count ? a : b));
+      largest.count += MAX_PILLS - pillTotal;
+    }
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.pillBar}>
+        {segments.map((seg, i) =>
+          Array.from({ length: seg.count }).map((_, j) => (
+            <div
+              key={`${i}-${j}`}
+              className={styles.pill}
+              data-testid="health-pill"
+              style={{ background: seg.color }}
+            />
+          )),
+        )}
+      </div>
+      <div className={styles.summary}>
+        {stats.ready > 0 && (
+          <span className={styles.summaryItem}>
+            <span className={styles.dot} style={{ background: 'var(--sapPositiveColor)' }} />
+            {stats.ready} {t('WorkspaceHealthIndicator.ready')}
+          </span>
+        )}
+        {stats.notReady > 0 && (
+          <span className={styles.summaryItem}>
+            <span className={styles.dot} style={{ background: 'var(--sapNegativeColor)' }} />
+            {stats.notReady} {t('WorkspaceHealthIndicator.notReady')}
+          </span>
+        )}
+        {stats.progressing > 0 && (
+          <span className={styles.summaryItem}>
+            <span className={styles.dot} style={{ background: 'var(--sapInformativeColor)' }} />
+            {stats.progressing} {t('WorkspaceHealthIndicator.progressing')}
+          </span>
+        )}
+        {stats.deleting > 0 && (
+          <span className={styles.summaryItem}>
+            <span className={styles.dot} style={{ background: 'var(--sapCriticalColor)' }} />
+            {stats.deleting} {t('WorkspaceHealthIndicator.deleting')}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
<img width="1301" height="229" alt="image" src="https://github.com/user-attachments/assets/b9f7fba4-ec37-45f9-8d38-d1755ad10fb5" />

## Summary

Redesigns the workspace panel header layout and the compact `WorkspaceHealthIndicator`.

### Layout changes
- **Left**: workspace title only
- **Center**: namespace copy button (moved back to the middle)
- **Right**: members avatars → health bar → YAML view → `...` menu

### Health indicator — compact mode
- Per-MCP pill bar: one colored square per MCP, sorted **green (Ready) → red (NotReady) → yellow (Progressing) → gray (Deleting)**
- Pills shrink as count grows to stay within a fixed max width: `pillWidth = clamp(3, (80 - (n-1)*2) / n, 10)`
- Count label (`x/y healthy`) is hidden by default, revealed on hover or when the panel is expanded
- Panel `onToggle` wires expand state into the indicator so the label is always visible when the workspace is open

<img width="980" height="688" alt="image (153)" src="https://github.com/user-attachments/assets/e42d8650-755f-4b1c-a9c0-aba910afb903" />

