### PR TITLE
fix: remove redundant step titles and improve wizard form layout

### DIFF
--- a/src/components/ComponentsSelection/ComponentsSelection.tsx
+++ b/src/components/ComponentsSelection/ComponentsSelection.tsx
@@ -14,7 +14,6 @@ import {
   Select,
   SelectDomRef,
   Text,
-  Title,
   Ui5CustomEvent,
 } from '@ui5/webcomponents-react';
 import styles from './ComponentsSelection.module.css';
@@ -89,8 +88,6 @@ export const ComponentsSelection: React.FC<ComponentsSelectionProps> = ({
 
   return (
     <div>
-      <Title>{t('componentsSelection.selectComponents')}</Title>
-
       <Input
         placeholder={t('common.search')}
         id="search"

--- a/src/components/Dialogs/MetadataForm.module.css
+++ b/src/components/Dialogs/MetadataForm.module.css
@@ -6,8 +6,7 @@
 
 .input {
   width: 100%;
-  margin-bottom: 2rem;
-  max-width: 40ch;
+  margin-bottom: 1rem;
 }
 
 .wrapper {

--- a/src/components/Dialogs/MetadataForm.tsx
+++ b/src/components/Dialogs/MetadataForm.tsx
@@ -109,7 +109,7 @@ export function MetadataForm({
 
   return (
     <Form>
-      <FormGroup headerText={t('CreateProjectWorkspaceDialog.metadataHeader')} columnSpan={12}>
+      <FormGroup columnSpan={12}>
         <Label for="name" required>
           {t('CreateProjectWorkspaceDialog.nameLabel')}
         </Label>

--- a/src/components/Wizards/CreateManagedControlPlane/CreateManagedControlPlaneV2WizardContainer.tsx
+++ b/src/components/Wizards/CreateManagedControlPlane/CreateManagedControlPlaneV2WizardContainer.tsx
@@ -516,7 +516,7 @@ export const CreateManagedControlPlaneV2WizardContainer: FC<CreateManagedControl
             disabled={isStepDisabled('members')}
           >
             <Form>
-              <FormGroup headerText={t('CreateProjectWorkspaceDialog.membersHeader')}>
+              <FormGroup>
                 <EditMembers
                   members={members}
                   isValidationError={!!errors.members}

--- a/src/components/Wizards/CreateManagedControlPlane/CreateManagedControlPlaneWizardContainer.module.css
+++ b/src/components/Wizards/CreateManagedControlPlane/CreateManagedControlPlaneWizardContainer.module.css
@@ -5,11 +5,13 @@
 }
 
 .metadataForm {
-  width: 50%;
+  width: 100%;
+  max-width: 480px;
 }
 
 .infoboxContainer {
-  width: 50%;
-  padding-right: 1rem;
-  padding-top: 2rem;
+  flex: 1;
+  padding-left: 2rem;
+  padding-top: 0.5rem;
+  max-width: 400px;
 }

--- a/src/components/Wizards/CreateManagedControlPlane/CreateManagedControlPlaneWizardContainer.tsx
+++ b/src/components/Wizards/CreateManagedControlPlane/CreateManagedControlPlaneWizardContainer.tsx
@@ -679,7 +679,7 @@ export const CreateManagedControlPlaneWizardContainer: FC<CreateManagedControlPl
             />
           </WizardStep>
           <WizardStep
-            icon="activities"
+            icon="accept"
             titleText={t('common.success')}
             disabled={isStepDisabled('success')}
             selected={selectedStep === 'success'}

--- a/src/components/Wizards/CreateManagedControlPlane/CreateManagedControlPlaneWizardContainer.tsx
+++ b/src/components/Wizards/CreateManagedControlPlane/CreateManagedControlPlaneWizardContainer.tsx
@@ -616,7 +616,7 @@ export const CreateManagedControlPlaneWizardContainer: FC<CreateManagedControlPl
             disabled={isStepDisabled('members')}
           >
             <Form>
-              <FormGroup headerText={t('CreateProjectWorkspaceDialog.membersHeader')}>
+              <FormGroup>
                 <EditMembers
                   members={watchedMembers}
                   isValidationError={!!errors.members}

--- a/src/components/Wizards/CreateManagedControlPlane/SummarizeStep.tsx
+++ b/src/components/Wizards/CreateManagedControlPlane/SummarizeStep.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Grid, List, ListItemStandard, Title } from '@ui5/webcomponents-react';
+import { Grid, List, ListItemStandard } from '@ui5/webcomponents-react';
 import { stringify } from 'yaml';
 import { getSelectedComponents } from '../../ComponentsSelection/ComponentsSelectionContainer.tsx';
 import {
@@ -52,7 +52,6 @@ export const SummarizeStep: React.FC<SummarizeStepProps> = ({
   const { apiGroupName, apiVersion } = parseResourceApiInfo(resource);
   return (
     <div className={styles.wrapper}>
-      <Title>{t('common.summarize')}</Title>
       <Grid defaultSpan="XL6 L6 M6 S6">
         <div>
           <List headerText={t('common.metadata')}>

--- a/src/components/Wizards/CreateManagedControlPlane/SummarizeStepV2.tsx
+++ b/src/components/Wizards/CreateManagedControlPlane/SummarizeStepV2.tsx
@@ -1,4 +1,4 @@
-import { Grid, List, ListItemStandard, Title } from '@ui5/webcomponents-react';
+import { Grid, List, ListItemStandard } from '@ui5/webcomponents-react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { stringify } from 'yaml';
@@ -26,7 +26,6 @@ export const SummarizeStepV2: React.FC<SummarizeStepProps> = ({ rawInput }) => {
 
   return (
     <div className={styles.wrapper}>
-      <Title>{t('common.summarize')}</Title>
       <Grid defaultSpan="XL6 L6 M6 S6">
         <div>
           <List headerText={t('common.metadata')}>


### PR DESCRIPTION
## Summary

Small UI polish for the Create/Edit Control Plane wizard — no behavioural changes.



## Dependencies

None — standalone off `main`.