### PR TITLE
fix: make + Project and + Workspace buttons primary; transparent overflow menu

### DIFF
--- a/src/components/ControlPlanes/List/ControlPlaneListToolbar.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListToolbar.tsx
@@ -11,6 +11,7 @@ export function ControlPlaneListToolbar({ projectName }: { projectName: string }
     <>
       <Toolbar>
         <ToolbarButton
+          design="Emphasized"
           icon="add"
           text={t('ControlPlaneListToolbar.buttonText')}
           onClick={() => setDialogIsOpen(true)}

--- a/src/components/Projects/ProjectListToolbar.tsx
+++ b/src/components/Projects/ProjectListToolbar.tsx
@@ -7,7 +7,7 @@ export function ProjectListToolbar() {
   return (
     <>
       <Toolbar>
-        <ToolbarButton icon="add" text="Project" onClick={() => setDialogIsOpen(true)} />
+        <ToolbarButton design="Emphasized" icon="add" text="Project" onClick={() => setDialogIsOpen(true)} />
       </Toolbar>
       <CreateProjectDialogContainer isOpen={dialogCreateProjectIsOpen} setIsOpen={setDialogIsOpen} />
     </>

--- a/src/components/Projects/ProjectsListItemMenu.tsx
+++ b/src/components/Projects/ProjectsListItemMenu.tsx
@@ -37,7 +37,7 @@ export const ProjectsListItemMenu: FC<ProjectsListItemMenuProps> = ({
 
   return (
     <div>
-      <Button icon="overflow" icon-end onClick={handleOpenerClick} />
+      <Button design="Transparent" icon="overflow" icon-end onClick={handleOpenerClick} />
       <Menu
         ref={popoverRef}
         open={open}


### PR DESCRIPTION
<img width="1076" height="177" alt="image" src="https://github.com/user-attachments/assets/ab07c16c-d480-4259-b3bc-2125188ead9e" />


## Summary

- **`+ Project`** toolbar button → `design="Emphasized"` (primary blue)
- **`+ Workspace`** toolbar button → `design="Emphasized"` (primary blue)
- **Projects list row overflow button** → `design="Transparent"` (no border)

## Dependencies

None — standalone off `main`.