### PR TITLE
feat: expand only one workspace panel at a time

### DIFF
--- a/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.cy.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.cy.tsx
@@ -27,11 +27,7 @@ const fakeUseDeleteWorkspace: typeof useDeleteWorkspace = () => ({
 });
 
 const makeWorkspace = (name: string): Workspace => ({
-  metadata: {
-    name,
-    namespace: `project-test--ws-${name}`,
-    annotations: {},
-  },
+  metadata: { name, namespace: `project-test--ws-${name}`, annotations: {} },
   spec: { members: [] },
   status: { namespace: `project-test--ws-${name}` },
 });
@@ -59,39 +55,47 @@ function mountAllWorkspaces(ws: Workspace[]) {
   );
 }
 
+function panel(name: string) {
+  return cy.get(`[data-testid="workspace-panel-${name}"]`);
+}
+
+function togglePanel(name: string) {
+  panel(name).then(($el: JQuery<HTMLElement>) => $el[0].dispatchEvent(new CustomEvent('toggle', { bubbles: true })));
+}
+
 describe('ControlPlaneListAllWorkspaces — mutually exclusive expansion', () => {
   it('expands only the first workspace by default', () => {
     mountAllWorkspaces(workspaces);
 
-    cy.get('ui5-panel').eq(0).invoke('prop', 'collapsed').should('equal', false);
-    cy.get('ui5-panel').eq(1).invoke('prop', 'collapsed').should('equal', true);
-    cy.get('ui5-panel').eq(2).invoke('prop', 'collapsed').should('equal', true);
+    panel('alpha').invoke('prop', 'collapsed').should('equal', false);
+    panel('beta').invoke('prop', 'collapsed').should('equal', true);
+    panel('gamma').invoke('prop', 'collapsed').should('equal', true);
   });
 
   it('expanding a second workspace collapses the first', () => {
     mountAllWorkspaces(workspaces);
 
-    cy.get('ui5-panel').eq(1).shadow().find('ui5-button.ui5-panel-header-button').click({ force: true });
+    togglePanel('beta');
 
-    cy.get('ui5-panel').eq(0).invoke('prop', 'collapsed').should('equal', true);
-    cy.get('ui5-panel').eq(1).invoke('prop', 'collapsed').should('equal', false);
-    cy.get('ui5-panel').eq(2).invoke('prop', 'collapsed').should('equal', true);
+    panel('alpha').invoke('prop', 'collapsed').should('equal', true);
+    panel('beta').invoke('prop', 'collapsed').should('equal', false);
+    panel('gamma').invoke('prop', 'collapsed').should('equal', true);
   });
 
   it('collapsing the expanded workspace leaves all panels collapsed', () => {
     mountAllWorkspaces(workspaces);
 
-    cy.get('ui5-panel').eq(0).shadow().find('ui5-button.ui5-panel-header-button').click({ force: true });
+    togglePanel('alpha');
 
-    cy.get('ui5-panel').eq(0).invoke('prop', 'collapsed').should('equal', true);
-    cy.get('ui5-panel').eq(1).invoke('prop', 'collapsed').should('equal', true);
-    cy.get('ui5-panel').eq(2).invoke('prop', 'collapsed').should('equal', true);
+    panel('alpha').invoke('prop', 'collapsed').should('equal', true);
+    panel('beta').invoke('prop', 'collapsed').should('equal', true);
+    panel('gamma').invoke('prop', 'collapsed').should('equal', true);
   });
 
   it('renders empty state when there are no workspaces', () => {
     mountAllWorkspaces([]);
 
-    cy.get('ui5-panel').should('not.exist');
+    cy.get('[data-testid^="workspace-panel-"]').should('not.exist');
     cy.get('ui5-illustrated-message').should('exist');
   });
 });

--- a/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.cy.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.cy.tsx
@@ -22,6 +22,21 @@ const fakeUseMcpsQuery: typeof useMcpsQuery = () => ({
   isPending: false,
 });
 
+const fakeForbiddenMcpsQuery: typeof useMcpsQuery = () => ({
+  data: [],
+  error: Object.assign(new Error('is forbidden'), { graphQLErrors: [], networkError: null, clientErrors: [], cause: undefined, extraInfo: undefined, protocolErrors: [] }),
+  isPending: false,
+});
+
+const fakeUseMcpsQueryForWorkspace = (forbiddenWorkspace: string): typeof useMcpsQuery =>
+  (workspaceNamespace) => ({
+    data: [],
+    error: workspaceNamespace?.includes(forbiddenWorkspace)
+      ? Object.assign(new Error('is forbidden'), { graphQLErrors: [], networkError: null, clientErrors: [], cause: undefined, extraInfo: undefined, protocolErrors: [] })
+      : undefined,
+    isPending: false,
+  });
+
 const fakeUseDeleteWorkspace: typeof useDeleteWorkspace = () => ({
   deleteWorkspace: async () => undefined,
 });
@@ -34,7 +49,7 @@ const makeWorkspace = (name: string): Workspace => ({
 
 const workspaces = [makeWorkspace('alpha'), makeWorkspace('beta'), makeWorkspace('gamma')];
 
-function mountAllWorkspaces(ws: Workspace[]) {
+function mountAllWorkspaces(ws: Workspace[], useMcpsQueryOverride: typeof useMcpsQuery = fakeUseMcpsQuery) {
   cy.mount(
     <FrontendConfigContext.Provider value={frontendConfig}>
       <MockedProvider mocks={[]}>
@@ -44,7 +59,7 @@ function mountAllWorkspaces(ws: Workspace[]) {
               <ControlPlaneListAllWorkspaces
                 projectName="test"
                 workspaces={ws}
-                useMcpsQuery={fakeUseMcpsQuery}
+                useMcpsQuery={useMcpsQueryOverride}
                 useDeleteWorkspace={fakeUseDeleteWorkspace}
               />
             </SplitterProvider>
@@ -69,6 +84,22 @@ describe('ControlPlaneListAllWorkspaces — mutually exclusive expansion', () =>
 
     panel('alpha').invoke('prop', 'collapsed').should('equal', false);
     panel('beta').invoke('prop', 'collapsed').should('equal', true);
+    panel('gamma').invoke('prop', 'collapsed').should('equal', true);
+  });
+
+  it('skips forbidden workspaces when auto-expanding', () => {
+    mountAllWorkspaces(workspaces, fakeForbiddenMcpsQuery);
+
+    panel('alpha').invoke('prop', 'collapsed').should('equal', true);
+    panel('beta').invoke('prop', 'collapsed').should('equal', true);
+    panel('gamma').invoke('prop', 'collapsed').should('equal', true);
+  });
+
+  it('auto-expands second workspace when first is forbidden', () => {
+    mountAllWorkspaces(workspaces, fakeUseMcpsQueryForWorkspace('alpha'));
+
+    panel('alpha').invoke('prop', 'collapsed').should('equal', true);
+    panel('beta').invoke('prop', 'collapsed').should('equal', false);
     panel('gamma').invoke('prop', 'collapsed').should('equal', true);
   });
 

--- a/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.cy.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.cy.tsx
@@ -24,15 +24,30 @@ const fakeUseMcpsQuery: typeof useMcpsQuery = () => ({
 
 const fakeForbiddenMcpsQuery: typeof useMcpsQuery = () => ({
   data: [],
-  error: Object.assign(new Error('is forbidden'), { graphQLErrors: [], networkError: null, clientErrors: [], cause: undefined, extraInfo: undefined, protocolErrors: [] }),
+  error: Object.assign(new Error('is forbidden'), {
+    graphQLErrors: [],
+    networkError: null,
+    clientErrors: [],
+    cause: undefined,
+    extraInfo: undefined,
+    protocolErrors: [],
+  }),
   isPending: false,
 });
 
-const fakeUseMcpsQueryForWorkspace = (forbiddenWorkspace: string): typeof useMcpsQuery =>
+const fakeUseMcpsQueryForWorkspace =
+  (forbiddenWorkspace: string): typeof useMcpsQuery =>
   (workspaceNamespace) => ({
     data: [],
     error: workspaceNamespace?.includes(forbiddenWorkspace)
-      ? Object.assign(new Error('is forbidden'), { graphQLErrors: [], networkError: null, clientErrors: [], cause: undefined, extraInfo: undefined, protocolErrors: [] })
+      ? Object.assign(new Error('is forbidden'), {
+          graphQLErrors: [],
+          networkError: null,
+          clientErrors: [],
+          cause: undefined,
+          extraInfo: undefined,
+          protocolErrors: [],
+        })
       : undefined,
     isPending: false,
   });

--- a/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.cy.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.cy.tsx
@@ -1,0 +1,97 @@
+import { MockedProvider } from '@apollo/client/testing/react';
+import '@ui5/webcomponents-cypress-commands';
+import { MemoryRouter } from 'react-router-dom';
+import { FeatureToggleProvider } from '../../../context/FeatureToggleContext.tsx';
+import { FrontendConfigContext, Landscape } from '../../../context/FrontendConfigContext.tsx';
+import { useDeleteWorkspace } from '../../../spaces/onboarding/hooks/useDeleteWorkspace.ts';
+import { useMcpsQuery } from '../../../spaces/onboarding/hooks/useMcpsQuery.ts';
+import { Workspace } from '../../../spaces/onboarding/types/Workspace.ts';
+import { SplitterProvider } from '../../Splitter/SplitterContext.tsx';
+import ControlPlaneListAllWorkspaces from './ControlPlaneListAllWorkspaces.tsx';
+
+const frontendConfig = {
+  landscape: Landscape.Local,
+  documentationBaseUrl: 'http://localhost:3000',
+  githubBaseUrl: 'https://github.com/example/repo',
+  featureToggles: { markMcpV1asDeprecated: false, enableMcpV2: false },
+};
+
+const fakeUseMcpsQuery: typeof useMcpsQuery = () => ({
+  data: [],
+  error: undefined,
+  isPending: false,
+});
+
+const fakeUseDeleteWorkspace: typeof useDeleteWorkspace = () => ({
+  deleteWorkspace: async () => undefined,
+});
+
+const makeWorkspace = (name: string): Workspace => ({
+  metadata: {
+    name,
+    namespace: `project-test--ws-${name}`,
+    annotations: {},
+  },
+  spec: { members: [] },
+  status: { namespace: `project-test--ws-${name}` },
+});
+
+const workspaces = [makeWorkspace('alpha'), makeWorkspace('beta'), makeWorkspace('gamma')];
+
+function mountAllWorkspaces(ws: Workspace[]) {
+  cy.mount(
+    <FrontendConfigContext.Provider value={frontendConfig}>
+      <MockedProvider mocks={[]}>
+        <MemoryRouter>
+          <FeatureToggleProvider>
+            <SplitterProvider>
+              <ControlPlaneListAllWorkspaces
+                projectName="test"
+                workspaces={ws}
+                useMcpsQuery={fakeUseMcpsQuery}
+                useDeleteWorkspace={fakeUseDeleteWorkspace}
+              />
+            </SplitterProvider>
+          </FeatureToggleProvider>
+        </MemoryRouter>
+      </MockedProvider>
+    </FrontendConfigContext.Provider>,
+  );
+}
+
+describe('ControlPlaneListAllWorkspaces — mutually exclusive expansion', () => {
+  it('expands only the first workspace by default', () => {
+    mountAllWorkspaces(workspaces);
+
+    cy.get('ui5-panel').eq(0).invoke('prop', 'collapsed').should('equal', false);
+    cy.get('ui5-panel').eq(1).invoke('prop', 'collapsed').should('equal', true);
+    cy.get('ui5-panel').eq(2).invoke('prop', 'collapsed').should('equal', true);
+  });
+
+  it('expanding a second workspace collapses the first', () => {
+    mountAllWorkspaces(workspaces);
+
+    cy.get('ui5-panel').eq(1).shadow().find('ui5-button.ui5-panel-header-button').click({ force: true });
+
+    cy.get('ui5-panel').eq(0).invoke('prop', 'collapsed').should('equal', true);
+    cy.get('ui5-panel').eq(1).invoke('prop', 'collapsed').should('equal', false);
+    cy.get('ui5-panel').eq(2).invoke('prop', 'collapsed').should('equal', true);
+  });
+
+  it('collapsing the expanded workspace leaves all panels collapsed', () => {
+    mountAllWorkspaces(workspaces);
+
+    cy.get('ui5-panel').eq(0).shadow().find('ui5-button.ui5-panel-header-button').click({ force: true });
+
+    cy.get('ui5-panel').eq(0).invoke('prop', 'collapsed').should('equal', true);
+    cy.get('ui5-panel').eq(1).invoke('prop', 'collapsed').should('equal', true);
+    cy.get('ui5-panel').eq(2).invoke('prop', 'collapsed').should('equal', true);
+  });
+
+  it('renders empty state when there are no workspaces', () => {
+    mountAllWorkspaces([]);
+
+    cy.get('ui5-panel').should('not.exist');
+    cy.get('ui5-illustrated-message').should('exist');
+  });
+});

--- a/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.tsx
@@ -26,10 +26,19 @@ export default function ControlPlaneListAllWorkspaces({
 }: Props) {
   const { workspaceCreationGuide } = useLink();
   const { t } = useTranslation();
-  // null = initial (auto-expand first workspace); undefined = user explicitly collapsed all; string = user picked one
+  // null = initial (auto-expand first accessible workspace); undefined = user explicitly collapsed all; string = user picked one
   const [expandedWorkspace, setExpandedWorkspace] = useState<string | null | undefined>(null);
+  const [forbiddenWorkspaces, setForbiddenWorkspaces] = useState<Set<string>>(new Set());
 
-  const resolvedExpanded = expandedWorkspace === null ? (workspaces[0]?.metadata.name ?? null) : expandedWorkspace;
+  const firstAccessible = workspaces.find((ws) => !forbiddenWorkspaces.has(ws.metadata.name))?.metadata.name ?? null;
+  const resolvedExpanded = expandedWorkspace === null ? firstAccessible : expandedWorkspace;
+
+  function handleForbidden(workspaceName: string) {
+    setForbiddenWorkspaces((prev) => {
+      if (prev.has(workspaceName)) return prev;
+      return new Set(prev).add(workspaceName);
+    });
+  }
 
   return (
     <>
@@ -63,6 +72,7 @@ export default function ControlPlaneListAllWorkspaces({
               const isCurrentlyExpanded = resolvedExpanded === workspace.metadata.name;
               setExpandedWorkspace(isCurrentlyExpanded ? undefined : workspace.metadata.name);
             }}
+            onForbidden={() => handleForbidden(workspace.metadata.name)}
           />
         ))
       )}

--- a/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.tsx
@@ -3,20 +3,33 @@ import '@ui5/webcomponents-fiori/dist/illustrations/NoData.js';
 import '@ui5/webcomponents-fiori/dist/illustrations/EmptyList.js';
 import '@ui5/webcomponents-icons/dist/delete';
 import ButtonDesign from '@ui5/webcomponents/dist/types/ButtonDesign.js';
-import { ControlPlaneListWorkspaceGridTile } from './ControlPlaneListWorkspaceGridTile.tsx';
-import { Workspace } from '../../../spaces/onboarding/types/Workspace.ts';
-import { useLink } from '../../../lib/shared/useLink.ts';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDeleteWorkspace as _useDeleteWorkspace } from '../../../spaces/onboarding/hooks/useDeleteWorkspace.ts';
+import { useMcpsQuery as _useMcpsQuery } from '../../../spaces/onboarding/hooks/useMcpsQuery.ts';
+import { useLink } from '../../../lib/shared/useLink.ts';
+import { Workspace } from '../../../spaces/onboarding/types/Workspace.ts';
+import { ControlPlaneListWorkspaceGridTile } from './ControlPlaneListWorkspaceGridTile.tsx';
 
 interface Props {
   projectName: string;
   workspaces: Workspace[];
+  useMcpsQuery?: typeof _useMcpsQuery;
+  useDeleteWorkspace?: typeof _useDeleteWorkspace;
 }
 
-export default function ControlPlaneListAllWorkspaces({ projectName, workspaces }: Props) {
+export default function ControlPlaneListAllWorkspaces({
+  projectName,
+  workspaces,
+  useMcpsQuery = _useMcpsQuery,
+  useDeleteWorkspace = _useDeleteWorkspace,
+}: Props) {
   const { workspaceCreationGuide } = useLink();
-
   const { t } = useTranslation();
+  // null = initial (auto-expand first workspace); undefined = user explicitly collapsed all; string = user picked one
+  const [expandedWorkspace, setExpandedWorkspace] = useState<string | null | undefined>(null);
+
+  const resolvedExpanded = expandedWorkspace === null ? (workspaces[0]?.metadata.name ?? null) : expandedWorkspace;
 
   return (
     <>
@@ -43,6 +56,13 @@ export default function ControlPlaneListAllWorkspaces({ projectName, workspaces 
             key={`${projectName}-${workspace.metadata.name}`}
             projectName={projectName}
             workspace={workspace}
+            isExpanded={resolvedExpanded === workspace.metadata.name}
+            useMcpsQuery={useMcpsQuery}
+            useDeleteWorkspace={useDeleteWorkspace}
+            onToggleExpanded={() => {
+              const isCurrentlyExpanded = resolvedExpanded === workspace.metadata.name;
+              setExpandedWorkspace(isCurrentlyExpanded ? undefined : workspace.metadata.name);
+            }}
           />
         ))
       )}

--- a/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
@@ -3,7 +3,7 @@ import '@ui5/webcomponents-fiori/dist/illustrations/NoData.js';
 import IllustrationMessageType from '@ui5/webcomponents-fiori/dist/types/IllustrationMessageType.js';
 import '@ui5/webcomponents-icons/dist/delete';
 import { Button, FlexBox, ObjectPageSection, Panel, Title } from '@ui5/webcomponents-react';
-import { useMemo, useState } from 'react';
+import { useMemo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFeatureToggle } from '../../../context/FeatureToggleContext.tsx';
 import { isForbiddenError } from '../../../lib/api/error.ts';
@@ -30,6 +30,7 @@ interface Props {
   workspace: Workspace;
   isExpanded?: boolean;
   onToggleExpanded?: () => void;
+  onForbidden?: () => void;
   useMcpsQuery?: typeof _useMcpsQuery;
   useDeleteWorkspace?: typeof _useDeleteWorkspace;
 }
@@ -39,6 +40,7 @@ export function ControlPlaneListWorkspaceGridTile({
   workspace,
   isExpanded,
   onToggleExpanded,
+  onForbidden,
   useMcpsQuery = _useMcpsQuery,
   useDeleteWorkspace = _useDeleteWorkspace,
 }: Props) {
@@ -64,6 +66,10 @@ export function ControlPlaneListWorkspaceGridTile({
   const { mcpCreationGuide } = useLink();
   const errorView = createErrorView(cpsError);
   const shouldCollapsePanel = !isExpanded;
+
+  useEffect(() => {
+    if (isForbiddenError(cpsError)) onForbidden?.();
+  }, [cpsError, onForbidden]);
 
   function isWorkspaceReady(currentWorkspace: Workspace): boolean {
     return currentWorkspace.status != null && currentWorkspace.status.namespace != null;

--- a/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
@@ -116,6 +116,7 @@ export function ControlPlaneListWorkspaceGridTile({
           headerLevel="H2"
           style={{ maxWidth: '1280px', margin: '0px auto 0px auto', width: '100%' }}
           collapsed={shouldCollapsePanel}
+          data-testid={`workspace-panel-${workspaceName}`}
           noAnimation
           header={
             <div

--- a/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
@@ -28,6 +28,8 @@ import styles from './WorkspacesList.module.css';
 interface Props {
   projectName: string;
   workspace: Workspace;
+  isExpanded?: boolean;
+  onToggleExpanded?: () => void;
   useMcpsQuery?: typeof _useMcpsQuery;
   useDeleteWorkspace?: typeof _useDeleteWorkspace;
 }
@@ -35,6 +37,8 @@ interface Props {
 export function ControlPlaneListWorkspaceGridTile({
   projectName,
   workspace,
+  isExpanded,
+  onToggleExpanded,
   useMcpsQuery = _useMcpsQuery,
   useDeleteWorkspace = _useDeleteWorkspace,
 }: Props) {
@@ -59,7 +63,7 @@ export function ControlPlaneListWorkspaceGridTile({
   const { deleteWorkspace } = useDeleteWorkspace(projectNamespace, workspaceName);
   const { mcpCreationGuide } = useLink();
   const errorView = createErrorView(cpsError);
-  const shouldCollapsePanel = !!errorView;
+  const shouldCollapsePanel = !isExpanded;
 
   function isWorkspaceReady(currentWorkspace: Workspace): boolean {
     return currentWorkspace.status != null && currentWorkspace.status.namespace != null;
@@ -112,6 +116,7 @@ export function ControlPlaneListWorkspaceGridTile({
           headerLevel="H2"
           style={{ maxWidth: '1280px', margin: '0px auto 0px auto', width: '100%' }}
           collapsed={shouldCollapsePanel}
+          noAnimation
           header={
             <div
               style={{
@@ -148,7 +153,7 @@ export function ControlPlaneListWorkspaceGridTile({
               </FlexBox>
             </div>
           }
-          noAnimation
+          onToggle={onToggleExpanded}
         >
           {errorView ? (
             errorView


### PR DESCRIPTION

<img width="953" height="405" alt="Screenshot 2026-06-04 at 09 35 26" src="https://github.com/user-attachments/assets/dd70eae4-02ce-4ba8-b532-bcdccda95562" />

## on click on other workspace

<img width="953" height="405" alt="Screenshot 2026-06-04 at 09 35 17" src="https://github.com/user-attachments/assets/647fe612-44f0-4748-bd65-e821a1a6402a" />



## Summary

- Workspace panels on the project page now behave like an accordion: only one is expanded at a time
- The first workspace auto-expands on load
- Expanding a workspace always collapses the previously open one, regardless of whether it has an error (permission denied, load failure)
- Users can collapse all panels by clicking the currently open one

## Test plan

- [ ] Run `npm run test:cy -- --spec 'src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.cy.tsx'`
- [ ] Run `npm run test:cy -- --spec 'src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.cy.tsx'`
- [ ] Manual: open a project page with multiple workspaces — confirm only one expands at a time
- [ ] Manual: confirm workspaces with "Not permitted to list MCPs" still participate correctly in accordion behaviour