### PR TITLE
docs: add patterns section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,21 +198,9 @@ Hooks that show a toast on error **must also rethrow** so callers (dialogs) can 
 - Mutations in hooks: catch, show toast, rethrow. The dialog/caller decides whether to close.
 - Use `<ErrorDialog ref={…} />` with `errorDialogRef.current?.showErrorDialog(message)` for errors that need a blocking dialog (not just a toast). See `CreateProjectDialogContainer.tsx`.
 
-### Monaco / YamlViewer in dialogs
-
-Lazy-load `YamlViewer` to prevent Monaco's synchronous initialisation from blocking dialog open and crashing Cypress tests during teardown:
-
-```tsx
-const YamlViewer = lazy(() => import('../Yaml/YamlViewer.tsx').then((m) => ({ default: m.YamlViewer })));
-// …
-<Suspense fallback={null}>
-  <YamlViewer … />
-</Suspense>
-```
-
 ### `javascript-time-ago` setup
 
-`TimeAgo.addDefaultLocale(en)` must be called before any component using `ReactTimeAgo` mounts, and it must appear **after all imports** in the file (ESLint `import/first` rule). Place it as the first non-import line.
+`TimeAgo.addDefaultLocale(en)` is initialised once in `src/utils/i18n/timeAgo.ts` — import that module before any component using `ReactTimeAgo` mounts. The call must appear **after all imports** in any file that hosts it (ESLint `import/first` rule).
 
 ### CSS modules and theming
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,106 @@ Hooks are invoked as `node .claude/hooks/*.mjs` (cross-platform). But `/bin/sh` 
   env var (`$env:GRAPHQL_TOKEN` on PowerShell, `$GRAPHQL_TOKEN` on bash),
   that is acceptable. Never echo the token value back, even partially.
 
+## Patterns
+
+### Injectable hooks — the testability convention
+
+Every component that calls a hook making a network request must accept it as an optional prop so tests can inject a fake:
+
+```tsx
+// real hook aliased with underscore prefix
+import { useMcpsQuery as _useMcpsQuery } from '…/useMcpsQuery';
+
+interface Props {
+  useMcpsQuery?: typeof _useMcpsQuery;   // optional, typed from the real hook
+}
+
+export function MyComponent({ useMcpsQuery = _useMcpsQuery }: Props) { … }
+```
+
+In tests pass a fake: `<MyComponent useMcpsQuery={fakeUseMcpsQuery} />`. See `ControlPlaneListWorkspaceGridTile.tsx` for a full example. Don't `vi.mock()` modules in Cypress tests — inject instead.
+
+### Forms: RHF + Zod + UI5 inputs
+
+UI5 web components don't fire native DOM `change` events that RHF listens for. The pattern:
+
+1. Always use `mode: 'onChange'` on `useForm` so `isValid` stays reactive.
+2. For `<Input>` / `<Select>` / `<ComboBox>`: use an `onInput` / `onChange` handler that calls `setValue(field, value, { shouldValidate: true, shouldDirty: true })` — do **not** spread `{...register()}` on a UI5 element.
+3. For programmatic `setValue` calls (e.g. populating a field from a side effect): always pass `{ shouldValidate: true }` or the field won't revalidate.
+4. Keep RHF registration alive via a hidden native input when the visible input is a UI5 component:
+   ```tsx
+   <input type="hidden" {...register('name')} value={currentValue} readOnly />
+   <Input value={currentValue} onInput={onNameInput} />
+   ```
+5. Define Zod schemas as functions that accept `t: TFunction` so validation messages are translated. Use `superRefine` for cross-field validation.
+
+See `src/components/Dialogs/MetadataForm.tsx` and `src/lib/api/validations/schemas.ts`.
+
+### Cypress component tests with UI5
+
+UI5 web components render in shadow DOM. Rules that prevent hours of debugging:
+
+- **Use `data-testid` on the React/UI5 element**, then query with `cy.get('[data-testid="…"]')`. Never traverse shadow DOM to find internal buttons or icons — class names change and visibility rules cause flakiness.
+- **Assert boolean web component state** with `invoke('prop', 'collapsed').should('equal', false)` — not `should('have.attr', 'collapsed')`. Boolean reflected attributes are unreliable.
+- **Trigger web component events** by dispatching a `CustomEvent` directly on the element instead of clicking inside shadow DOM:
+  ```ts
+  cy.get('[data-testid="my-panel"]').then(($el) =>
+    $el[0].dispatchEvent(new CustomEvent('toggle', { bubbles: true }))
+  );
+  ```
+- **Always provide `FrontendConfigContext.Provider` explicitly** inside the `cy.mount` call — don't rely on the support file's outer wrapper. React 19's `use()` (used by `FeatureToggleProvider`) can lose context during re-renders otherwise. Mirror the pattern in `ControlPlaneListWorkspaceGridTile.cy.tsx`.
+- **Type into UI5 inputs** with `cy.get('ui5-input').typeIntoUi5Input('value')` from `@ui5/webcomponents-cypress-commands`.
+
+### Vitest unit tests for hooks
+
+```ts
+import { act, renderHook } from '@testing-library/react';
+
+it('shows toast and rethrows on failure', async () => {
+  mutateMock.mockRejectedValue(new Error('API Error'));
+  const { result } = renderHook(() => useDeleteProject('test'));
+  await act(async () => {
+    await expect(result.current.deleteProject()).rejects.toThrow('API Error');
+  });
+  expect(toastShowMock).toHaveBeenCalledWith('API Error');
+});
+```
+
+Hooks that show a toast on error **must also rethrow** so callers (dialogs) can stay open on failure. Test with `rejects.toThrow()`, not `resolves.toBeUndefined()`.
+
+### Error handling
+
+- Use `isForbiddenError(error)` / `isNotFoundError(error)` from `src/lib/api/error.ts` — don't compare status codes inline.
+- Mutations in hooks: catch, show toast, rethrow. The dialog/caller decides whether to close.
+- Use `<ErrorDialog ref={…} />` with `errorDialogRef.current?.showErrorDialog(message)` for errors that need a blocking dialog (not just a toast). See `CreateProjectDialogContainer.tsx`.
+
+### Monaco / YamlViewer in dialogs
+
+Lazy-load `YamlViewer` to prevent Monaco's synchronous initialisation from blocking dialog open and crashing Cypress tests during teardown:
+
+```tsx
+const YamlViewer = lazy(() => import('../Yaml/YamlViewer.tsx').then((m) => ({ default: m.YamlViewer })));
+// …
+<Suspense fallback={null}>
+  <YamlViewer … />
+</Suspense>
+```
+
+### `javascript-time-ago` setup
+
+`TimeAgo.addDefaultLocale(en)` must be called before any component using `ReactTimeAgo` mounts, and it must appear **after all imports** in the file (ESLint `import/first` rule). Place it as the first non-import line.
+
+### CSS modules and theming
+
+Support both OS-level dark mode and SAP Horizon dark theme:
+
+```css
+@media (prefers-color-scheme: dark) { … }
+[data-ui5-theme*="dark"] .myClass { … }
+```
+
+Use `ThemingParameters` from `@ui5/webcomponents-react-base` for colours — never hardcode hex values that won't respond to theme changes.
+
 ## Commands cheatsheet
 
 ```


### PR DESCRIPTION
## Summary

- Adds a **Patterns** section to `CLAUDE.md` documenting non-obvious conventions that anyone using Claude Code needs to know when contributing
- Covers: injectable hooks, RHF + UI5 form wiring, Cypress UI5 test patterns, Vitest hook testing, error handling, Monaco lazy-loading, `javascript-time-ago` setup, CSS theming
- All patterns are derived from real issues encountered during development in this repo

## Why

The existing `CLAUDE.md` covers the stack well but didn't document the patterns that repeatedly cause bugs and wasted debugging time — particularly around UI5 web components, RHF integration, and Cypress test setup. This makes those hard-won lessons explicit and reusable across future sessions.