### PR TITLE
fix: use Transparent design for all overflow menu buttons

### DIFF
--- a/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCardMenu.tsx
+++ b/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCardMenu.tsx
@@ -29,6 +29,7 @@ export const ControlPlaneCardMenu: FC<ControlPlanesListMenuProps> = ({
     <>
       <Button
         id={openerId}
+        design="Transparent"
         icon="overflow"
         icon-end
         data-testid="ControlPlaneCardMenu-opener"

--- a/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCardMenuV2.tsx
+++ b/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCardMenuV2.tsx
@@ -20,6 +20,7 @@ export const ControlPlaneCardMenuV2: FC<ControlPlaneCardMenuV2Props> = ({
     <>
       <Button
         id={openerId}
+        design="Transparent"
         icon="overflow"
         icon-end
         data-testid="ControlPlaneCardMenuV2-opener"

--- a/src/components/ControlPlanes/ControlPlanePageMenu.tsx
+++ b/src/components/ControlPlanes/ControlPlanePageMenu.tsx
@@ -17,7 +17,7 @@ export const ControlPlanePageMenu: FC<ControlPlanesListMenuProps> = ({ setIsEdit
 
   return (
     <>
-      <Button id={openerId} icon="overflow" icon-end onClick={handleOpenerClick} />
+      <Button id={openerId} design="Transparent" icon="overflow" icon-end onClick={handleOpenerClick} />
       <Menu
         open={menuIsOpen}
         opener={openerId}

--- a/src/components/ControlPlanes/List/ControlPlaneListToolbar.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListToolbar.tsx
@@ -51,6 +51,7 @@ export function ControlPlaneListToolbar({
         <Button
           id={menuButtonId}
           data-testid="project-overflow-menu"
+          design="Transparent"
           icon="overflow"
           onClick={() => setMenuOpen((prev) => !prev)}
         />


### PR DESCRIPTION
<img width="287" height="141" alt="image" src="https://github.com/user-attachments/assets/3c1f1e79-3ee7-4d56-99a8-fe83caf6ff9b" />


## Summary

Overflow (`...`) buttons were inconsistently styled — some had `design="Transparent"` and some had the default (filled) style. This makes them all consistent.

**Fixed:**
- `ControlPlaneListToolbar` — next to Add Workspace button
- `ControlPlanePageMenu` — on the MCP detail page  
- `ControlPlaneCardMenu` — on each control plane card
- `ControlPlaneCardMenuV2` — V2 variant

`ControlPlanesListMenu` and `ProjectsListItemMenu` were already Transparent.

## Test plan
- [ ] Run `npm run test:cy -- --spec 'src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCard.cy.tsx'`
- [ ] Manual: verify overflow buttons appear transparent across workspace list, MCP cards and MCP detail page