### PR TITLE
feat: improve YAML side panel UX

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -464,7 +464,6 @@
   "yaml": {
     "YAML": "File",
     "showOnlyImportant": "Show only important fields",
-    "panelTitle": "YAML",
     "applySuccess2": "The control plane will reconcile this resource shortly.",
     "applySuccess": "Update submitted ",
     "diffConfirmTitle": "Review changes",

--- a/src/components/ControlPlane/ManagedResources.cy.tsx
+++ b/src/components/ControlPlane/ManagedResources.cy.tsx
@@ -330,31 +330,6 @@ describe('ManagedResources - Edit Resource', () => {
     cy.wrap(null).should(() => expect(patchedItem).to.not.be.null);
   });
 
-  it('does not show a "YAML" heading in the panel toolbar', () => {
-    cy.mount(
-      <MemoryRouter>
-        <SplitterProvider>
-          <SplitterLayout>
-            <ManagedResources
-              useHandleResourcePatch={fakeUseHandleResourcePatch}
-              useApiResource={fakeUseApiResource}
-              useResourcePluralNames={fakeUseResourcePluralNames}
-              useHasMcpAdminRights={fakeUseHasMcpAdminRights}
-            />
-          </SplitterLayout>
-        </SplitterProvider>
-      </MemoryRouter>,
-    );
-
-    cy.get('button[aria-label*="xpand"]').first().click({ force: true });
-    cy.get('[data-testid="ActionsMenu-opener"]').first().click({ force: true });
-    cy.contains('Edit').click({ force: true });
-
-    cy.get('[data-testid="yaml-close-button"]').should('be.visible');
-    // The standalone "YAML" title label must not appear in the panel header
-    cy.get('ui5-panel').contains('YAML').should('not.exist');
-  });
-
   it('shows copy and download buttons in the panel', () => {
     cy.mount(
       <MemoryRouter>

--- a/src/components/ControlPlane/ManagedResources.cy.tsx
+++ b/src/components/ControlPlane/ManagedResources.cy.tsx
@@ -313,7 +313,7 @@ describe('ManagedResources - Edit Resource', () => {
     cy.contains('Edit').click({ force: true });
 
     // Wait for YAML panel and Monaco editor to fully load (schema loader async re-renders)
-    cy.contains('YAML').should('be.visible');
+    cy.get('[data-testid="yaml-close-button"]').should('be.visible');
     cy.get('.monaco-editor', { timeout: 10000 }).should('exist');
 
     // Click Apply button — use force to avoid detached-DOM race from SWR revalidation re-renders
@@ -328,6 +328,80 @@ describe('ManagedResources - Edit Resource', () => {
     // Verify patch was called
     cy.wrap(null).should(() => expect(patchCalled).to.equal(true));
     cy.wrap(null).should(() => expect(patchedItem).to.not.be.null);
+  });
+
+  it('does not show a "YAML" heading in the panel toolbar', () => {
+    cy.mount(
+      <MemoryRouter>
+        <SplitterProvider>
+          <SplitterLayout>
+            <ManagedResources
+              useHandleResourcePatch={fakeUseHandleResourcePatch}
+              useApiResource={fakeUseApiResource}
+              useResourcePluralNames={fakeUseResourcePluralNames}
+              useHasMcpAdminRights={fakeUseHasMcpAdminRights}
+            />
+          </SplitterLayout>
+        </SplitterProvider>
+      </MemoryRouter>,
+    );
+
+    cy.get('button[aria-label*="xpand"]').first().click({ force: true });
+    cy.get('[data-testid="ActionsMenu-opener"]').first().click({ force: true });
+    cy.contains('Edit').click({ force: true });
+
+    cy.get('[data-testid="yaml-close-button"]').should('be.visible');
+    // The standalone "YAML" title label must not appear in the panel header
+    cy.get('ui5-panel').contains('YAML').should('not.exist');
+  });
+
+  it('shows copy and download buttons in the panel', () => {
+    cy.mount(
+      <MemoryRouter>
+        <SplitterProvider>
+          <SplitterLayout>
+            <ManagedResources
+              useHandleResourcePatch={fakeUseHandleResourcePatch}
+              useApiResource={fakeUseApiResource}
+              useResourcePluralNames={fakeUseResourcePluralNames}
+              useHasMcpAdminRights={fakeUseHasMcpAdminRights}
+            />
+          </SplitterLayout>
+        </SplitterProvider>
+      </MemoryRouter>,
+    );
+
+    cy.get('button[aria-label*="xpand"]').first().click({ force: true });
+    cy.get('[data-testid="ActionsMenu-opener"]').first().click({ force: true });
+    cy.contains('Edit').click({ force: true });
+
+    cy.get('[data-testid="yaml-close-button"]').should('be.visible');
+    cy.get('[data-testid="yaml-copy-button"]').should('exist');
+    cy.get('[data-testid="yaml-download-button"]').should('exist');
+  });
+
+  it('closes the panel when the close button is clicked', () => {
+    cy.mount(
+      <MemoryRouter>
+        <SplitterProvider>
+          <SplitterLayout>
+            <ManagedResources
+              useHandleResourcePatch={fakeUseHandleResourcePatch}
+              useApiResource={fakeUseApiResource}
+              useResourcePluralNames={fakeUseResourcePluralNames}
+              useHasMcpAdminRights={fakeUseHasMcpAdminRights}
+            />
+          </SplitterLayout>
+        </SplitterProvider>
+      </MemoryRouter>,
+    );
+
+    cy.get('button[aria-label*="xpand"]').first().click({ force: true });
+    cy.get('[data-testid="ActionsMenu-opener"]').first().click({ force: true });
+    cy.contains('Edit').click({ force: true });
+
+    cy.get('[data-testid="yaml-close-button"]').should('be.visible').click({ force: true });
+    cy.get('[data-testid="yaml-close-button"]').should('not.exist');
   });
 });
 

--- a/src/components/Wizards/CreateManagedControlPlane/YamlSummarize.tsx
+++ b/src/components/Wizards/CreateManagedControlPlane/YamlSummarize.tsx
@@ -3,7 +3,6 @@ import { Button, FlexBox } from '@ui5/webcomponents-react';
 import styles from './YamlSummarize.module.css';
 import { useTranslation } from 'react-i18next';
 import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard.ts';
-import { SHOW_DOWNLOAD_BUTTON } from '../../Yaml/YamlSidePanel.tsx';
 import { YamlResourceEditorSchemaLoader } from '../../Yaml/YamlResourceEditorSchemaLoader.tsx';
 
 type YamlPanelProps = {
@@ -34,11 +33,9 @@ const YamlSummarize: FC<YamlPanelProps> = ({ yamlString, filename, apiVersion, a
         <Button icon="copy" onClick={() => copyToClipboard(yamlString)}>
           {t('buttons.copy')}
         </Button>
-        {SHOW_DOWNLOAD_BUTTON && (
-          <Button icon="download" onClick={downloadYaml}>
-            {t('buttons.download')}
-          </Button>
-        )}
+        <Button icon="download" onClick={downloadYaml}>
+          {t('buttons.download')}
+        </Button>
       </FlexBox>
       <YamlResourceEditorSchemaLoader
         apiGroupName={apiGroupName}

--- a/src/components/Yaml/YamlSidePanel.module.css
+++ b/src/components/Yaml/YamlSidePanel.module.css
@@ -1,5 +1,34 @@
+.panelWrapper {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.panelWrapper:hover .floatingActions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
 .panel {
   width: 100%;
+  height: 100%;
+}
+
+.floatingActions {
+  position: absolute;
+  top: 3rem;
+  right: 1.75rem; /* offset from scrollbar */
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+  z-index: 100;
+  background: var(--sapGroup_TitleBackground);
+  border-radius: 0.5rem;
+  padding: 0.25rem;
+  box-shadow: var(--sapContent_Shadow1);
 }
 
 .content {

--- a/src/components/Yaml/YamlSidePanel.module.css
+++ b/src/components/Yaml/YamlSidePanel.module.css
@@ -16,10 +16,10 @@
 
 .floatingActions {
   position: absolute;
-  top: 3rem;
+  bottom: 1.75rem;
   right: 1.75rem; /* offset from scrollbar */
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   gap: 0.25rem;
   opacity: 0;
   pointer-events: none;

--- a/src/components/Yaml/YamlSidePanel.tsx
+++ b/src/components/Yaml/YamlSidePanel.tsx
@@ -2,12 +2,11 @@ import {
   CheckBox,
   FlexBox,
   Panel,
-  Title,
   Toolbar,
   ToolbarButton,
-  ToolbarSeparator,
   ToolbarSpacer,
   Button,
+  Title,
 } from '@ui5/webcomponents-react';
 import IllustrationMessageType from '@ui5/webcomponents-fiori/dist/types/IllustrationMessageType.js';
 import { useTranslation } from 'react-i18next';
@@ -22,8 +21,6 @@ import { useCopyToClipboard } from '../../hooks/useCopyToClipboard.ts';
 import styles from './YamlSidePanel.module.css';
 import { IllustratedBanner } from '../Ui/IllustratedBanner/IllustratedBanner.tsx';
 import { YamlDiff } from '../Wizards/CreateManagedControlPlane/YamlDiff.tsx';
-
-export const SHOW_DOWNLOAD_BUTTON = false; // Download button is hidden now due to stakeholder request
 
 export interface YamlSidePanelProps {
   resource: Resource;
@@ -50,11 +47,10 @@ export function YamlSidePanel({ resource, filename, onApply, isEdit, toolbarCont
     [isEdit, resource, showOnlyImportantData],
   );
   const yamlStringToDisplay = useMemo(() => editedYaml ?? originalYaml, [editedYaml, originalYaml]);
-  const yamlStringToCopy = useMemo(() => originalYaml, [originalYaml]);
   const { copyToClipboard } = useCopyToClipboard();
 
   const handleDownloadClick = () => {
-    const blob = new Blob([yamlStringToCopy], { type: 'text/yaml' });
+    const blob = new Blob([originalYaml], { type: 'text/yaml' });
     const url = window.URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
@@ -85,93 +81,96 @@ export function YamlSidePanel({ resource, filename, onApply, isEdit, toolbarCont
   const { apiGroupName, apiVersion, kind } = parseResourceApiInfo(resource);
 
   return (
-    <Panel
-      className={styles.panel}
-      fixed
-      header={
-        <Toolbar>
-          {toolbarContent ?? <Title>{t('yaml.panelTitle')}</Title>}
-          <ToolbarSpacer />
-          <FlexBox>
-            {!isEdit && (
-              <CheckBox
-                text={t('yaml.showOnlyImportant')}
-                checked={showOnlyImportantData}
-                onChange={() => setShowOnlyImportantData(!showOnlyImportantData)}
-              />
-            )}
-          </FlexBox>
-          <ToolbarButton
-            design="Transparent"
-            icon="copy"
-            text={t('buttons.copy')}
-            onClick={() => copyToClipboard(yamlStringToDisplay)}
-          />
-          {SHOW_DOWNLOAD_BUTTON ? (
+    <div className={styles.panelWrapper}>
+      <Panel
+        className={styles.panel}
+        fixed
+        header={
+          <Toolbar>
+            {toolbarContent}
+            <ToolbarSpacer />
+            <FlexBox>
+              {!isEdit && (
+                <CheckBox
+                  text={t('yaml.showOnlyImportant')}
+                  checked={showOnlyImportantData}
+                  onChange={() => setShowOnlyImportantData(!showOnlyImportantData)}
+                />
+              )}
+            </FlexBox>
             <ToolbarButton
+              overflowPriority="NeverOverflow"
               design="Transparent"
-              icon="download"
-              text={t('buttons.download')}
-              onClick={handleDownloadClick}
+              icon="decline"
+              data-testid="yaml-close-button"
+              onClick={closeAside}
             />
-          ) : null}
-          <ToolbarSeparator />
-          <ToolbarButton
-            overflowPriority="NeverOverflow"
-            design="Transparent"
-            icon="sap-icon://navigation-right-arrow"
-            data-testid="yaml-close-button"
-            onClick={closeAside}
-          />
-        </Toolbar>
-      }
-    >
-      <div className={styles.content}>
-        {mode === 'success' && (
-          <FlexBox direction="Column" className={styles.successContainer}>
-            <IllustratedBanner
-              illustrationName={IllustrationMessageType.SuccessScreen}
-              title={t('yaml.applySuccess')}
-              subtitle={t('yaml.applySuccess2')}
-            />
-            <Button design="Emphasized" data-testid="yaml-success-close-button" onClick={closeAside}>
-              {t('common.close')}
-            </Button>
-          </FlexBox>
-        )}
-        {mode === 'review' && (
-          <FlexBox direction="Column" className={styles.reviewContainer}>
-            <div className={styles.stickyHeader}>
-              <div className={styles.stickyHeaderInner}>
-                <Title level="H5">{t('yaml.diffConfirmTitle')}</Title>
-                <p className={styles.diffConfirmMessage}>{t('yaml.diffConfirmMessage')}</p>
+          </Toolbar>
+        }
+      >
+        <div className={styles.content}>
+          {mode === 'success' && (
+            <FlexBox direction="Column" className={styles.successContainer}>
+              <IllustratedBanner
+                illustrationName={IllustrationMessageType.SuccessScreen}
+                title={t('yaml.applySuccess')}
+                subtitle={t('yaml.applySuccess2')}
+              />
+              <Button design="Emphasized" data-testid="yaml-success-close-button" onClick={closeAside}>
+                {t('common.close')}
+              </Button>
+            </FlexBox>
+          )}
+          {mode === 'review' && (
+            <FlexBox direction="Column" className={styles.reviewContainer}>
+              <div className={styles.stickyHeader}>
+                <div className={styles.stickyHeaderInner}>
+                  <Title level="H5">{t('yaml.diffConfirmTitle')}</Title>
+                  <p className={styles.diffConfirmMessage}>{t('yaml.diffConfirmMessage')}</p>
+                </div>
+                <FlexBox className={styles.reviewButtons}>
+                  <Button design="Transparent" data-testid="yaml-cancel-confirmation-button" onClick={handleGoBack}>
+                    {t('yaml.diffNo')}
+                  </Button>
+                  <Button design="Emphasized" data-testid="yaml-confirm-button" onClick={handleConfirmPatch}>
+                    {t('yaml.diffYes', 'Yes')}
+                  </Button>
+                </FlexBox>
               </div>
-              <FlexBox className={styles.reviewButtons}>
-                <Button design="Transparent" data-testid="yaml-cancel-confirmation-button" onClick={handleGoBack}>
-                  {t('yaml.diffNo')}
-                </Button>
-                <Button design="Emphasized" data-testid="yaml-confirm-button" onClick={handleConfirmPatch}>
-                  {t('yaml.diffYes', 'Yes')}
-                </Button>
-              </FlexBox>
-            </div>
-            <div>
-              <YamlDiff originalYaml={originalYaml} modifiedYaml={editedYaml ?? originalYaml} />
-            </div>
-          </FlexBox>
-        )}
-        {mode === 'edit' && (
-          <YamlResourceEditorSchemaLoader
-            yamlString={yamlStringToDisplay}
-            filename={filename}
-            isEdit={isEdit}
-            apiGroupName={apiGroupName}
-            apiVersion={apiVersion}
-            kind={kind}
-            onApply={handleApplyFromEditor}
-          />
-        )}
+              <div>
+                <YamlDiff originalYaml={originalYaml} modifiedYaml={editedYaml ?? originalYaml} />
+              </div>
+            </FlexBox>
+          )}
+          {mode === 'edit' && (
+            <YamlResourceEditorSchemaLoader
+              yamlString={yamlStringToDisplay}
+              filename={filename}
+              isEdit={isEdit}
+              apiGroupName={apiGroupName}
+              apiVersion={apiVersion}
+              kind={kind}
+              onApply={handleApplyFromEditor}
+            />
+          )}
+        </div>
+      </Panel>
+      <div className={styles.floatingActions}>
+        <ToolbarButton
+          design="Transparent"
+          icon="copy"
+          tooltip={t('buttons.copy')}
+          data-testid="yaml-copy-button"
+          onClick={() => copyToClipboard(yamlStringToDisplay)}
+        />
+        <ToolbarButton
+          design="Transparent"
+          icon="download"
+          tooltip={t('buttons.download')}
+          data-testid="yaml-download-button"
+          onClick={handleDownloadClick}
+        />
       </div>
-    </Panel>
+    </div>
   );
 }


### PR DESCRIPTION
## NEW
<img width="1304" height="1160" alt="image" src="https://github.com/user-attachments/assets/7a6e3c09-fe7b-4ee4-8ca7-7e123bb9d476" />


## Summary

The YAML side panel had a few rough edges: a redundant heading, a confusing close icon, and no way to download the YAML. This PR cleans all of that up.

**What changed**

| Before | After |
|---|---|
| "YAML" heading always shown in toolbar | No heading — callers that set `toolbarContent` already provide context |
| Close button: `navigation-right-arrow` (hard to read) | Close button: standard `decline` (×) icon |
| Copy only, always visible in toolbar | Copy + Download, hidden by default, fade in on hover over the panel |
| `SHOW_DOWNLOAD_BUTTON = false` dead flag in `YamlSidePanel` | Flag removed; `YamlSummarize` (wizard) unconditionally shows both buttons |

**Implementation notes**
- Floating action buttons sit in an absolutely-positioned overlay (`z-index: 100`, offset `1.75rem` from right to clear the scrollbar), revealed via CSS `opacity` transition on parent `:hover`
- `ToolbarSeparator` and `yamlStringToCopy` memo removed as now-dead code
- `yaml.panelTitle` i18n key removed from `en.json`

## Test plan
- [ ] `npm run test:cy -- --spec 'src/components/ControlPlane/ManagedResources.cy.tsx'`
- [ ] Open any resource YAML panel → no standalone "YAML" text in the toolbar
- [ ] Close button renders as × and dismisses the panel
- [ ] While panel is open, hover mouse over it → copy + download buttons fade in
- [ ] Move mouse away → buttons fade out
- [ ] Copy copies current YAML to clipboard
- [ ] Download saves `<resource-name>.yaml` to disk
- [ ] Wizard "Summarize" step still shows both copy and download buttons (always visible there)

Follow up: 
https://github.com/openmcp-project/ui-frontend/pull/611