### PR TITLE
fix: add missing async to onSend hook in server.ts

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -154,7 +154,7 @@ fastify.register(helmet, {
 
 // Strip BFF CSP for Headlamp proxy responses — Helmet's script-src 'self' blocks inline scripts.
 // Headlamp's own CSP is already removed by rewriteHeaders in http-proxy.ts.
-fastify.addHook('onSend', (req, reply, payload) => {
+fastify.addHook('onSend', async (req, reply, payload) => {
   const pathname = req.url.split('?')[0];
   if (pathname === '/api/headlamp' || pathname.startsWith('/api/headlamp/')) {
     reply.removeHeader('content-security-policy');


### PR DESCRIPTION
## Summary
- Adds `async` to the `onSend` Fastify hook in `server.ts`
- Per the [Fastify docs](https://fastify.dev/docs/latest/Reference/Hooks/#onsend), the async form of an `onSend` hook must be declared `async` and return the payload directly — the non-async form requires a `done` callback instead
- Without `async`, the hook signature is invalid and can lead to unexpected behaviour (e.g. payload not being forwarded correctly)

## Test plan
- [ ] Start the BFF locally (`npm run dev`) and verify Headlamp proxy requests still work
- [ ] Verify non-Headlamp responses still include the `content-security-policy` header