### PR TITLE
fix: forward auth headers over WebSocket

### DIFF
--- a/server/plugins/http-proxy.ts
+++ b/server/plugins/http-proxy.ts
@@ -109,6 +109,20 @@ function proxyPlugin(fastify) {
         upstream: HEADLAMP_UPSTREAM_URL,
         rewritePrefix: '/api/headlamp',
         websocket: true,
+        wsClientOptions: {
+          // @ts-ignore
+          rewriteRequestHeaders: (_headers: any, req: any) => {
+            const token = req.encryptedSession?.get('mcp_accessToken');
+            const kubeconfig = req.encryptedSession?.get('headlamp_kubeconfig');
+            const userInfo = req.encryptedSession?.get('onboarding_userInfo');
+            const base: Record<string, string> = {};
+            if (req.headers?.cookie) base['cookie'] = req.headers.cookie;
+            if (token) base['authorization'] = `Bearer ${token}`;
+            if (kubeconfig) base['kubeconfig'] = kubeconfig;
+            if (userInfo?.email) base['x-headlamp-user-id'] = userInfo.email;
+            return base;
+          },
+        },
         replyOptions: {
           // @ts-ignore
           rewriteRequestHeaders: (req: any, headers: any) => {


### PR DESCRIPTION
## Summary

- **WebSocket auth headers missing**: `wsClientOptions.rewriteRequestHeaders` was never configured on the Headlamp proxy, so WebSocket upgrade requests went to the Headlamp upstream without the `authorization`, `kubeconfig`, or `x-headlamp-user-id` headers. The existing `replyOptions.rewriteRequestHeaders` only applies to HTTP — not WS upgrades. Fixed by adding `wsClientOptions` with the same header injection logic.

- **"Something went wrong" after ~1 minute**: The BFF patches `mcp_accessToken` into `headlamp_kubeconfig` at registration time (in `/api/headlamp-kubeconfig`). But `HeadlampPage` only called `registerKubeconfigWithBff` once on mount. When `mcp_accessToken` was silently refreshed (55 s before expiry), the session's `headlamp_kubeconfig` still held the stale token, so every Headlamp cluster API call started returning 404. Fixed by:
  - Exposing `tokenExpiresAt` from `AuthContextMcp` so dependants can observe token rotations.
  - Watching `tokenExpiresAt` in `HeadlampIframe` and re-registering the kubeconfig on each change. On a background refresh (`prevTokenExpiresAt !== null`), the re-registration is silent and the iframe stays alive; an initial load or cluster switch resets the view as before.

## Not addressed

- **CSP font warning**: `font-src 'self' https: data:` already covers all HTTPS fonts on the parent page. Headlamp responses have no CSP at all (early return in the `onSend` hook). The console warning originates inside the Headlamp iframe and is outside our control.
- **403 on Crossplane resources**: Requires investigation on the RBAC side (cluster role bindings for the MCP service account); this is not a frontend change.
- **Node listing returns errors**: By design — the kiosk plugin restricts what the Headlamp user can see. An error banner for a disallowed resource is expected Headlamp behaviour.

## Test plan

- [ ] Open the Headlamp tab for an MCP, wait >60 s (past the default token lifetime), confirm the view does not switch to "Something went wrong"
- [ ] Verify WebSocket-backed features in Headlamp (live pod logs, watch streams) work after the token refreshes
- [ ] Confirm the iframe is not flickered/reloaded on background token refresh