### PR TITLE
fix(session): clear stale cookies on server restart to unblock local dev login

### DIFF
--- a/server/encrypted-session.ts
+++ b/server/encrypted-session.ts
@@ -54,8 +54,11 @@ async function encryptedSession(fastify) {
     },
   });
 
-  // Clear undecryptable cookies on server restart so OIDC state survives the next login attempt.
+  // On server restart COOKIE_SECRET changes, making existing cookies undecryptable.
+  // Redirect to /api/clear-session which clears them and sends the browser back with a fresh session.
   fastify.addHook('onRequest', async (req, reply) => {
+    if (req.url.startsWith('/api/clear-session')) return; // avoid redirect loop
+
     const encryptedStore = req.session?.get?.('encryptedStore');
     if (!encryptedStore) return;
 
@@ -67,15 +70,20 @@ async function encryptedSession(fastify) {
       const { cipherText, iv, tag } = encryptedStore;
       decryptSymetric(cipherText, iv, tag, key);
     } catch {
-      req.log.warn(
-        { plugin: 'encrypted-session' },
-        'Stale session cookies detected (undecryptable after server restart) — clearing',
-      );
-      await new Promise<void>((resolve) => req.session.destroy(() => resolve()));
-      req[ENCRYPTED_COOKIE_REQUEST_DECORATOR].delete();
-      reply.clearCookie(SESSION_COOKIE_NAME, COOKIE_OPTIONS);
-      reply.clearCookie(ENCRYPTION_KEY_COOKIE_NAME, COOKIE_OPTIONS);
+      req.log.warn({ plugin: 'encrypted-session' }, 'Stale session cookies detected — redirecting to clear');
+      reply.redirect(`/api/clear-session?redirectTo=${encodeURIComponent(req.url)}`);
     }
+  });
+
+  // @ts-ignore
+  fastify.get('/clear-session', async (req, reply) => {
+    const { redirectTo } = req.query as { redirectTo?: string };
+    await new Promise<void>((resolve) => req.session.destroy(() => resolve()));
+    req[ENCRYPTED_COOKIE_REQUEST_DECORATOR].delete();
+    reply.clearCookie(SESSION_COOKIE_NAME, COOKIE_OPTIONS);
+    reply.clearCookie(ENCRYPTION_KEY_COOKIE_NAME, COOKIE_OPTIONS);
+    const target = redirectTo && redirectTo.startsWith('/') ? redirectTo : '/';
+    return reply.redirect(target);
   });
 }
 
@@ -96,7 +104,7 @@ function createStore(request) {
 
   const loadedEncryptionKey = Buffer.from(userEncryptionKey, 'base64');
   let currentEncryptionKey = loadedEncryptionKey;
-  const encryptedStore = request.session?.get('encryptedStore');
+  const encryptedStore = request.session.get('encryptedStore');
   if (encryptedStore) {
     try {
       const { cipherText, iv, tag } = encryptedStore;
@@ -113,7 +121,6 @@ function createStore(request) {
   }
 
   async function save() {
-    if (!request.session) return; // destroyed by stale-cookie cleanup
     const stringifiedData = JSON.stringify(unencryptedStore);
     const { cipherText, iv, tag } = encryptSymetric(stringifiedData, currentEncryptionKey);
 

--- a/server/encrypted-session.ts
+++ b/server/encrypted-session.ts
@@ -54,9 +54,7 @@ async function encryptedSession(fastify) {
     },
   });
 
-  // When a server restarts it generates a new COOKIE_SECRET, making existing browser cookies
-  // undecryptable. Detect this early and clear stale cookies so the browser gets a fresh session
-  // on the very next request — otherwise OIDC state set during login is lost by callback time.
+  // Clear undecryptable cookies on server restart so OIDC state survives the next login attempt.
   fastify.addHook('onRequest', async (req, reply) => {
     const encryptedStore = req.session?.get?.('encryptedStore');
     if (!encryptedStore) return;
@@ -110,12 +108,12 @@ function createStore(request) {
       request.log.error({ plugin: 'encrypted-session' }, 'Failed to parse encrypted session store', error);
     }
   } else {
-    // we could not parse the encrypted store, so we create a new one and it would overwrite the previously stored store.
+    // No encrypted store yet — new session.
     request.log.info({ plugin: 'encrypted-session' }, 'No encrypted store found, creating new empty store');
   }
 
   async function save() {
-    if (!request.session) return; // session was destroyed (e.g. stale cookie cleanup)
+    if (!request.session) return; // destroyed by stale-cookie cleanup
     const stringifiedData = JSON.stringify(unencryptedStore);
     const { cipherText, iv, tag } = encryptSymetric(stringifiedData, currentEncryptionKey);
 

--- a/server/encrypted-session.ts
+++ b/server/encrypted-session.ts
@@ -53,6 +53,32 @@ async function encryptedSession(fastify) {
       return createStore(this);
     },
   });
+
+  // When a server restarts it generates a new COOKIE_SECRET, making existing browser cookies
+  // undecryptable. Detect this early and clear stale cookies so the browser gets a fresh session
+  // on the very next request — otherwise OIDC state set during login is lost by callback time.
+  fastify.addHook('onRequest', async (req, reply) => {
+    const encryptedStore = req.session?.get?.('encryptedStore');
+    if (!encryptedStore) return;
+
+    const userEncryptionKey = req[ENCRYPTED_COOKIE_REQUEST_DECORATOR]?.get?.(ENCRYPTED_COOKIE_KEY_ENCRYPTION_KEY);
+    if (!userEncryptionKey) return;
+
+    try {
+      const key = Buffer.from(userEncryptionKey, 'base64');
+      const { cipherText, iv, tag } = encryptedStore;
+      decryptSymetric(cipherText, iv, tag, key);
+    } catch {
+      req.log.warn(
+        { plugin: 'encrypted-session' },
+        'Stale session cookies detected (undecryptable after server restart) — clearing',
+      );
+      await new Promise<void>((resolve) => req.session.destroy(() => resolve()));
+      req[ENCRYPTED_COOKIE_REQUEST_DECORATOR].delete();
+      reply.clearCookie(SESSION_COOKIE_NAME, COOKIE_OPTIONS);
+      reply.clearCookie(ENCRYPTION_KEY_COOKIE_NAME, COOKIE_OPTIONS);
+    }
+  });
 }
 
 export default fp(encryptedSession);

--- a/server/encrypted-session.ts
+++ b/server/encrypted-session.ts
@@ -98,7 +98,7 @@ function createStore(request) {
 
   const loadedEncryptionKey = Buffer.from(userEncryptionKey, 'base64');
   let currentEncryptionKey = loadedEncryptionKey;
-  const encryptedStore = request.session.get('encryptedStore');
+  const encryptedStore = request.session?.get('encryptedStore');
   if (encryptedStore) {
     try {
       const { cipherText, iv, tag } = encryptedStore;
@@ -115,6 +115,7 @@ function createStore(request) {
   }
 
   async function save() {
+    if (!request.session) return; // session was destroyed (e.g. stale cookie cleanup)
     const stringifiedData = JSON.stringify(unencryptedStore);
     const { cipherText, iv, tag } = encryptSymetric(stringifiedData, currentEncryptionKey);
 


### PR DESCRIPTION
## Summary

- After a server restart the `COOKIE_SECRET` changes, making existing browser cookies undecryptable. The old code silently continued with an empty session store, which broke the OIDC flow: the `oauthState` written during `/login` was lost by the time `/callback` arrived, resulting in a persistent 503 until the user manually cleared cookies.
- Add an `onRequest` hook that attempts to decrypt the session store on every request. If decryption fails, the hook destroys the server-side session and clears both session cookies so the browser gets a clean slate on its very next request.
- Guard `createStore` and `save()` against `req.session` being `null` after `destroy()` is called.

## Test plan

- [ ] Start dev server, sign in, then restart the server (`Ctrl-C` + `npm run dev`)
- [ ] Navigate to the app — expect to see the login page (not a 503 redirect loop)
- [ ] Sign in again — expect successful authentication without manually clearing cookies