### PR TITLE
fix: correct maxAge unit from seconds to milliseconds

### DIFF
--- a/server/encrypted-session.ts
+++ b/server/encrypted-session.ts
@@ -32,18 +32,20 @@ async function encryptedSession(fastify) {
 
   await fastify.register(fastifyCookie);
 
-  const cookieOptions = { ...COOKIE_OPTIONS, maxAge: 60 * 60 * 24 * 1000 }; // 24 hours in ms
+  // @fastify/secure-session expects maxAge in seconds; @fastify/session expects milliseconds
+  const secureSessionCookieOptions = { ...COOKIE_OPTIONS, maxAge: 60 * 60 * 24 }; // 24 hours in seconds
+  const sessionCookieOptions = { ...COOKIE_OPTIONS, maxAge: 60 * 60 * 24 * 1000 }; // 24 hours in ms
 
   fastify.register(secureSession, {
     secret: Buffer.from(COOKIE_SECRET, 'hex'),
     cookieName: ENCRYPTION_KEY_COOKIE_NAME,
     sessionName: ENCRYPTED_COOKIE_REQUEST_DECORATOR,
-    cookie: cookieOptions,
+    cookie: secureSessionCookieOptions,
   });
   fastify.register(fastifySession, {
     secret: SESSION_SECRET,
     cookieName: SESSION_COOKIE_NAME,
-    cookie: cookieOptions,
+    cookie: sessionCookieOptions,
     rolling: false,
     saveUninitialized: false,
   });

--- a/server/encrypted-session.ts
+++ b/server/encrypted-session.ts
@@ -32,7 +32,7 @@ async function encryptedSession(fastify) {
 
   await fastify.register(fastifyCookie);
 
-  const cookieOptions = { ...COOKIE_OPTIONS, maxAge: 60 * 60 * 24 }; // 24 hours
+  const cookieOptions = { ...COOKIE_OPTIONS, maxAge: 60 * 60 * 24 * 1000 }; // 24 hours in ms
 
   fastify.register(secureSession, {
     secret: Buffer.from(COOKIE_SECRET, 'hex'),

--- a/src/components/Dialogs/CreateProjectDialogContainer.cy.tsx
+++ b/src/components/Dialogs/CreateProjectDialogContainer.cy.tsx
@@ -139,6 +139,7 @@ describe('CreateProjectDialogContainer', () => {
     cy.get('#name').find('input[id*="inner"]').type('test-project');
     cy.get('#chargingTargetType').click();
     cy.contains('BTP').click();
+    cy.get('#chargingTarget').should('not.have.attr', 'disabled');
     cy.get('#chargingTarget').find('input[id*="inner"]').type('12345678-1234-1234-1234-123456789abc');
 
     goToMembers();


### PR DESCRIPTION
## Summary

`@fastify/session` treats `maxAge` as **milliseconds**, not seconds. The existing value `60 * 60 * 24` = 86,400 ms = **86.4 seconds**, so the session expired ~86 seconds after login.

On expiry, `@fastify/session` destroys and regenerates the session as a fresh empty one — wiping `headlamp_kubeconfig` from the encrypted store. Without the kubeconfig, the Headlamp proxy forwarded requests without auth headers, Headlamp evicted the cluster context, and the Headlamp view crashed requiring a full page reload to recover.

Fix: `60 * 60 * 24 * 1000` — 24 hours in ms as intended.

## Test plan

- [ ] Log in and navigate to the Headlamp view
- [ ] Wait >90 seconds — confirm Headlamp stays alive (previously crashed at ~86s)
- [ ] Confirm session persists for the intended 24 hours