### PR TITLE
feat: truncate long YAML values in read-only view

### DIFF
--- a/src/components/YamlEditor/YamlEditor.module.css
+++ b/src/components/YamlEditor/YamlEditor.module.css
@@ -28,3 +28,36 @@
   list-style: disc;
   font-family: monospace;
 }
+
+/* Hides the tail of a long value — text is invisible but still in the model */
+:global(.monaco-editor) :global(.yaml-value-tail) {
+  opacity: 0;
+  font-size: 0;
+  letter-spacing: 0;
+}
+
+/* "… more" injected label */
+:global(.monaco-editor) :global(.yaml-inject-more) {
+  color: var(--sapLinkColor);
+  cursor: pointer;
+  font-style: italic;
+  opacity: 0.8;
+}
+
+:global(.monaco-editor) :global(.yaml-inject-more:hover) {
+  opacity: 1;
+  text-decoration: underline;
+}
+
+/* "↑ less" injected label */
+:global(.monaco-editor) :global(.yaml-inject-less) {
+  color: var(--sapLinkColor);
+  cursor: pointer;
+  font-style: italic;
+  opacity: 0.8;
+}
+
+:global(.monaco-editor) :global(.yaml-inject-less:hover) {
+  opacity: 1;
+  text-decoration: underline;
+}

--- a/src/components/YamlEditor/YamlEditor.tsx
+++ b/src/components/YamlEditor/YamlEditor.tsx
@@ -4,7 +4,7 @@ import * as monaco from 'monaco-editor';
 import type { JSONSchema } from 'monaco-yaml';
 import { configureMonacoYaml } from 'monaco-yaml';
 import type { ComponentProps } from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { parseDocument } from 'yaml';
 import { useTheme } from '../../hooks/useTheme';
@@ -18,6 +18,83 @@ export type YamlEditorProps = Omit<ComponentProps<typeof Editor>, 'language'> & 
   onApply?: (parsed: unknown, yaml: string) => void;
   schema?: JSONSchema4;
 };
+
+// How many characters into a value before we truncate.
+const TRUNCATE_AT = 30;
+
+// Injected-text marker stored in attachedData so we can identify clicks.
+const INJECTED_MORE = 'yaml-value-more';
+const INJECTED_LESS = 'yaml-value-less';
+
+// Fixed (non-hashed) class names applied by Monaco — must match :global selectors in the CSS module.
+const CLS_TAIL = 'yaml-value-tail';
+const CLS_MORE = 'yaml-inject-more';
+const CLS_LESS = 'yaml-inject-less';
+
+interface TruncationData {
+  lineNumber: number;
+  marker: typeof INJECTED_MORE | typeof INJECTED_LESS;
+}
+
+function applyTruncationDecorations(editor: monaco.editor.IStandaloneCodeEditor, expandedLines: Set<number>): string[] {
+  const model = editor.getModel();
+  if (!model) return [];
+
+  const newDecorations: monaco.editor.IModelDeltaDecoration[] = [];
+  const lineCount = model.getLineCount();
+
+  for (let lineNum = 1; lineNum <= lineCount; lineNum++) {
+    const line = model.getLineContent(lineNum);
+
+    // Match either:
+    //   "key: value"  — inline scalar
+    //   "  'value'"   — indented continuation / block scalar (quoted or plain, no key)
+    const inlineMatch = line.match(/^(\s*[\w\-./]+\s*:\s+)(.*)/);
+    const continuationMatch = !inlineMatch ? line.match(/^(\s+)(['"]?.+['"]?)$/) : null;
+    const match = inlineMatch ?? continuationMatch;
+    if (!match) continue;
+
+    const valueStart = match[1].length + 1; // 1-based column where value begins
+    const value = match[2];
+
+    if (value.length <= TRUNCATE_AT) continue;
+
+    const isExpanded = expandedLines.has(lineNum);
+    const tailStartCol = valueStart + TRUNCATE_AT;
+    const tailEndCol = valueStart + value.length;
+
+    if (isExpanded) {
+      // Show full value, inject "less" button after
+      newDecorations.push({
+        range: new monaco.Range(lineNum, tailEndCol, lineNum, tailEndCol),
+        options: {
+          after: {
+            content: '  ↑ less',
+            inlineClassName: CLS_LESS,
+            attachedData: { lineNumber: lineNum, marker: INJECTED_LESS } satisfies TruncationData,
+            cursorStops: monaco.editor.InjectedTextCursorStops.None,
+          },
+        },
+      });
+    } else {
+      // Hide the tail, inject "more" button
+      newDecorations.push({
+        range: new monaco.Range(lineNum, tailStartCol, lineNum, tailEndCol),
+        options: {
+          inlineClassName: CLS_TAIL,
+          after: {
+            content: '  … more',
+            inlineClassName: CLS_MORE,
+            attachedData: { lineNumber: lineNum, marker: INJECTED_MORE } satisfies TruncationData,
+            cursorStops: monaco.editor.InjectedTextCursorStops.None,
+          },
+        },
+      });
+    }
+  }
+
+  return editor.deltaDecorations([], newDecorations);
+}
 
 export const YamlEditor = (props: YamlEditorProps) => {
   const { isDarkTheme } = useTheme();
@@ -40,6 +117,10 @@ export const YamlEditor = (props: YamlEditorProps) => {
   const [validationErrors, setValidationErrors] = useState<string[]>([]);
   const [applyAttempted, setApplyAttempted] = useState(false);
 
+  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
+  const decorationIdsRef = useRef<string[]>([]);
+  const expandedLinesRef = useRef<Set<number>>(new Set());
+
   useEffect(() => {
     const { dispose } = configureMonacoYaml(monaco, {
       isKubernetes: true,
@@ -59,6 +140,14 @@ export const YamlEditor = (props: YamlEditorProps) => {
     return () => dispose();
   }, [schema]);
 
+  const refreshDecorations = useCallback(() => {
+    const editor = editorRef.current;
+    if (!editor || isEdit) return;
+    // Remove previous decorations before applying new ones
+    editor.deltaDecorations(decorationIdsRef.current, []);
+    decorationIdsRef.current = applyTruncationDecorations(editor, expandedLinesRef.current);
+  }, [isEdit]);
+
   const enforcedOptions: monaco.editor.IStandaloneEditorConstructionOptions = useMemo(
     () => ({
       ...(options as monaco.editor.IStandaloneEditorConstructionOptions),
@@ -68,7 +157,7 @@ export const YamlEditor = (props: YamlEditorProps) => {
       tabSize: 2,
       insertSpaces: true,
       detectIndentation: false,
-      wordWrap: 'on',
+      wordWrap: isEdit ? 'on' : 'off',
       folding: true,
       foldingStrategy: 'indentation',
       quickSuggestions: {
@@ -124,6 +213,43 @@ export const YamlEditor = (props: YamlEditorProps) => {
     run();
   }, [editorContent, onApply]);
 
+  const handleMount = useCallback(
+    (editor: monaco.editor.IStandaloneCodeEditor) => {
+      editorRef.current = editor;
+
+      if (!isEdit) {
+        refreshDecorations();
+
+        editor.onMouseDown((e) => {
+          if (e.target.type !== monaco.editor.MouseTargetType.CONTENT_TEXT) return;
+          // attachedData lives on detail.injectedText.options — not in the public types
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const data = (e.target.detail as any)?.injectedText?.options?.attachedData as TruncationData | undefined;
+          if (!data) return;
+
+          const { lineNumber, marker } = data;
+          if (marker === INJECTED_MORE) {
+            expandedLinesRef.current.add(lineNumber);
+          } else {
+            expandedLinesRef.current.delete(lineNumber);
+          }
+          refreshDecorations();
+        });
+      }
+
+      parentOnMount?.(editor, monaco);
+    },
+    [isEdit, refreshDecorations, parentOnMount],
+  );
+
+  // Re-apply decorations whenever the YAML value changes (e.g. "show only important" toggle)
+  useEffect(() => {
+    if (!isEdit) {
+      expandedLinesRef.current = new Set();
+      refreshDecorations();
+    }
+  }, [value, isEdit, refreshDecorations]);
+
   const showValidationErrors = isEdit && applyAttempted && validationErrors.length > 0;
 
   return (
@@ -149,6 +275,7 @@ export const YamlEditor = (props: YamlEditorProps) => {
           height="100%"
           language="yaml"
           onChange={handleEditorChange}
+          onMount={handleMount}
         />
       </div>
       {showValidationErrors && (


### PR DESCRIPTION
## Summary
<img width="1048" height="1870" alt="image" src="https://github.com/user-attachments/assets/c698eb50-e81d-4fce-9b7e-8ab69e0eee5c" />

- Uses Monaco's `InjectedTextOptions` (`after` decoration) to hide value tails beyond 30 characters in read-only YAML view
- Injects a clickable `… more` label inline; clicking expands the full value in place with a `↑ less` toggle
- Handles both inline scalars (`key: value`) and block scalar continuations (indented quoted/plain strings on their own line)
- Disables word wrap in read-only mode so hidden tail characters don't produce blank wrapped lines
- Edit mode is completely unaffected — Monaco stays unchanged there

## Test plan

- [ ] Open any resource YAML side panel in read-only mode
- [ ] Verify long values (>30 chars) are truncated with `… more` label
- [ ] Click `… more` to expand — full value appears inline
- [ ] Click `↑ less` to collapse again
- [ ] Verify block scalar continuations (e.g. `message:` with value on next line) are also truncated
- [ ] Open a resource in edit mode — verify no truncation occurs and editor behaves normally
- [ ] Verify copy button still copies the full YAML (model is unchanged)