### PR TITLE
feat: introduce telemetry service with multi-adapter support

### DIFF
--- a/server/plugins/auth-utils.ts
+++ b/server/plugins/auth-utils.ts
@@ -210,15 +210,21 @@ function extractUserInfoFromIdToken(request, idToken) {
   request.log.info('Extracting user info from ID token.');
 
   if (!idToken) {
-    request.log.warn('No ID token provided.');
+    request.log.error('No ID token provided.');
     return null;
   }
 
   const payloadBase64 = idToken.split('.')[1];
   const decodedPayload = JSON.parse(Buffer.from(payloadBase64, 'base64').toString('utf8'));
 
+  if (typeof decodedPayload.sub !== 'string' || decodedPayload.sub.length === 0) {
+    request.log.error('ID token missing sub claim.');
+    return null;
+  }
+
   request.log.info('User info extracted from ID token.');
   return {
+    sub: decodedPayload.sub,
     email: decodedPayload.email,
   };
 }

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -1,15 +1,17 @@
-import { Navigate, Route, HashRouter as Router } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
+import { Navigate, Route, HashRouter as Router, Routes } from 'react-router-dom';
 import GlobalProviderOutlet from './components/Core/ApiConfigWrapper.tsx';
 import { ShellBarComponent } from './components/Core/ShellBar.tsx';
 import { SearchParamToggleVisibility } from './components/Helper/FeatureToggleExistance.tsx';
 import { SplitterProvider } from './components/Splitter/SplitterContext.tsx';
 import { SplitterLayout } from './components/Splitter/SplitterLayout.tsx';
-import { SentryRoutes } from './mount.ts';
 import HeadlampPage from './spaces/mcp/pages/HeadlampPage.tsx';
 import McpPage from './spaces/mcp/pages/McpPage.tsx';
 import McpPageV2 from './spaces/mcp/pages/McpPageV2.tsx';
 import ProjectPage from './spaces/onboarding/pages/ProjectPage.tsx';
 import ProjectListView from './views/ProjectList';
+
+const SentryRoutes = Sentry.withSentryReactRouterV7Routing(Routes);
 
 function AppRouter() {
   return (

--- a/src/components/ControlPlanes/ConnectButton/ConnectButton.cy.tsx
+++ b/src/components/ControlPlanes/ConnectButton/ConnectButton.cy.tsx
@@ -1,6 +1,7 @@
 import { MemoryRouter } from 'react-router-dom';
 import ConnectButton from './ConnectButton';
 import { useApiResource } from '../../../lib/api/useApiResource.ts';
+import { useTelemetry } from '../../../lib/telemetry/telemetry.ts';
 import '@ui5/webcomponents-cypress-commands';
 import { APIError } from '../../../lib/api/error.ts';
 
@@ -189,5 +190,107 @@ describe('ConnectButton', () => {
     );
 
     cy.get('ui5-button').should('have.attr', 'disabled');
+  });
+
+  describe('telemetry', () => {
+    const mockUseTelemetryWith = (trackSpy: Cypress.Agent<sinon.SinonStub>): typeof useTelemetry => {
+      return () => ({ track: trackSpy, report: cy.stub(), identify: cy.stub() });
+    };
+
+    it('tracks mcp.connected with idp=system when connecting via system IdP', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const fakeUseApiResourceSingle: typeof useApiResource = (): any => {
+        return {
+          data: generateKubeconfigYaml([{ user: 'openmcp' }]),
+          error: undefined,
+          isLoading: false,
+        };
+      };
+      const trackSpy = cy.stub().as('trackSpy');
+      const mockUseNavigate = () => cy.stub();
+
+      cy.mount(
+        <MemoryRouter>
+          <ConnectButton
+            {...defaultProps}
+            useApiResource={fakeUseApiResourceSingle}
+            useNavigate={mockUseNavigate}
+            useTelemetry={mockUseTelemetryWith(trackSpy)}
+          />
+        </MemoryRouter>,
+      );
+
+      cy.get('ui5-button').click();
+
+      cy.get('@trackSpy').should('have.been.calledOnce');
+      cy.get('@trackSpy').should('have.been.calledWith', { name: 'mcp.connected', idp: 'system' });
+    });
+
+    it('tracks mcp.connected with idp=custom when connecting via custom IdP', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const fakeUseApiResourceSingle: typeof useApiResource = (): any => {
+        return {
+          data: generateKubeconfigYaml([{ user: 'custom-user' }]),
+          error: undefined,
+          isLoading: false,
+        };
+      };
+      const trackSpy = cy.stub().as('trackSpy');
+      const mockUseNavigate = () => cy.stub();
+
+      cy.mount(
+        <MemoryRouter>
+          <ConnectButton
+            {...defaultProps}
+            useApiResource={fakeUseApiResourceSingle}
+            useNavigate={mockUseNavigate}
+            useTelemetry={mockUseTelemetryWith(trackSpy)}
+          />
+        </MemoryRouter>,
+      );
+
+      cy.get('ui5-button').click();
+
+      cy.get('@trackSpy').should('have.been.calledOnce');
+      cy.get('@trackSpy').should('have.been.calledWith', { name: 'mcp.connected', idp: 'custom' });
+    });
+
+    it('tracks the selected idp when picking from the menu with multiple IdPs', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const fakeUseApiResourceMultiple: typeof useApiResource = (): any => {
+        return {
+          data: generateKubeconfigYaml([{ user: 'openmcp' }, { user: 'custom-user' }]),
+          error: undefined,
+          isLoading: false,
+        };
+      };
+      const trackSpy = cy.stub().as('trackSpy');
+      const mockUseNavigate = () => cy.stub();
+
+      cy.mount(
+        <MemoryRouter>
+          <ConnectButton
+            {...defaultProps}
+            useApiResource={fakeUseApiResourceMultiple}
+            useNavigate={mockUseNavigate}
+            useTelemetry={mockUseTelemetryWith(trackSpy)}
+          />
+        </MemoryRouter>,
+      );
+
+      // Open menu and pick the system IdP
+      cy.get('ui5-button').click();
+      cy.get('ui5-menu-item').eq(0).click();
+
+      cy.get('@trackSpy').should('have.been.calledOnce');
+      cy.get('@trackSpy').should('have.been.calledWith', { name: 'mcp.connected', idp: 'system' });
+
+      // Open menu again and pick the custom IdP
+      cy.get('ui5-button').click();
+      cy.get('ui5-menu-item').eq(1).click();
+
+      cy.get('@trackSpy').should('have.been.calledTwice');
+      cy.get('@trackSpy').should('have.been.calledWith', { name: 'mcp.connected', idp: 'custom' });
+    });
   });
 });

--- a/src/components/ControlPlanes/ConnectButton/ConnectButton.tsx
+++ b/src/components/ControlPlanes/ConnectButton/ConnectButton.tsx
@@ -3,9 +3,10 @@ import { useId, useState } from 'react';
 import { DownloadKubeconfig } from '../CopyKubeconfigButton.tsx';
 import { useTranslation } from 'react-i18next';
 import { useNavigate as _useNavigate } from 'react-router-dom';
-import { useConnectOptions } from './useConnectOptions.ts';
+import { useConnectOptions, type ConnectOption } from './useConnectOptions.ts';
 import { useApiResource as _useApiResource } from '../../../lib/api/useApiResource.ts';
 import { GetKubeconfig } from '../../../lib/api/types/crate/getKubeconfig.ts';
+import { useTelemetry as _useTelemetry } from '../../../lib/telemetry/telemetry.ts';
 
 interface ConnectButtonProps {
   projectName: string;
@@ -17,6 +18,7 @@ interface ConnectButtonProps {
   disabled?: boolean;
   useApiResource?: typeof _useApiResource;
   useNavigate?: typeof _useNavigate;
+  useTelemetry?: typeof _useTelemetry;
 }
 
 export default function ConnectButton({
@@ -29,11 +31,13 @@ export default function ConnectButton({
   disabled,
   useApiResource = _useApiResource,
   useNavigate = _useNavigate,
+  useTelemetry = _useTelemetry,
 }: ConnectButtonProps) {
   const navigate = useNavigate();
   const buttonId = useId();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { t } = useTranslation();
+  const telemetry = useTelemetry();
 
   const {
     data: kubeconfigResource,
@@ -42,6 +46,11 @@ export default function ConnectButton({
   } = useApiResource(GetKubeconfig(secretKey, secretName, namespace));
 
   const connectionTargets = useConnectOptions(kubeconfigResource, projectName, workspaceName, controlPlaneName);
+
+  const connectTo = (target: ConnectOption) => {
+    telemetry.track({ name: 'mcp.connected', idp: target.isSystemIdP ? 'system' : 'custom' });
+    navigate(target.url);
+  };
 
   const handleMenuAction = (event: CustomEvent) => {
     const { action, target } = event.detail.item.dataset;
@@ -53,7 +62,9 @@ export default function ConnectButton({
     }
 
     if (target) {
-      navigate(target);
+      const selected = connectionTargets.find((option) => option.url === target);
+      if (!selected) return;
+      connectTo(selected);
       setIsMenuOpen(false);
       return;
     }
@@ -70,7 +81,7 @@ export default function ConnectButton({
   if (connectionTargets.length === 1) {
     const directTarget = connectionTargets[0];
     return (
-      <Button endIcon="navigation-right-arrow" disabled={disabled} onClick={() => navigate(directTarget.url)}>
+      <Button endIcon="navigation-right-arrow" disabled={disabled} onClick={() => connectTo(directTarget)}>
         {t('ConnectButton.buttonText')}
       </Button>
     );

--- a/src/components/ControlPlanes/CopyKubeconfigButton.tsx
+++ b/src/components/ControlPlanes/CopyKubeconfigButton.tsx
@@ -5,12 +5,14 @@ import '@ui5/webcomponents-icons/dist/copy';
 import '@ui5/webcomponents-icons/dist/accept';
 import { useMcp } from '../../lib/shared/McpContext.tsx';
 import { useTranslation } from 'react-i18next';
+import { useTelemetry } from '../../lib/telemetry/telemetry.ts';
 
 export default function CopyKubeconfigButton() {
   const popoverRef = useRef(null);
   const [open, setOpen] = useState(false);
   const { copyToClipboard } = useCopyToClipboard();
   const { t } = useTranslation();
+  const telemetry = useTelemetry();
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handleOpenerClick = (e: any) => {
@@ -34,10 +36,12 @@ export default function CopyKubeconfigButton() {
         onItemClick={(event) => {
           if (event.detail.item.dataset.action === 'download') {
             DownloadKubeconfig(mcp.kubeconfig, mcp.name);
+            telemetry.track({ name: 'kubeconfig.downloaded' });
             return;
           }
           if (event.detail.item.dataset.action === 'copy') {
             void copyToClipboard(mcp.kubeconfig ?? '');
+            telemetry.track({ name: 'kubeconfig.copied' });
           }
 
           setOpen(false);
@@ -77,5 +81,4 @@ export function DownloadKubeconfig(config: any, displayName: string) {
   } catch (error) {
     console.error(error);
   }
-  // dynaLeaveAction(id);
 }

--- a/src/components/Core/ShellBar.cy.tsx
+++ b/src/components/Core/ShellBar.cy.tsx
@@ -8,7 +8,7 @@ describe('ShellBar', () => {
   let logoutCalled = false;
 
   const fakeUseAuthOnboarding: typeof useAuthOnboarding = () => ({
-    user: { email: 'test@example.com' },
+    user: { sub: 'test@example.com', email: 'test@example.com' },
     logout: async () => {
       logoutCalled = true;
     },

--- a/src/lib/api/fetch.ts
+++ b/src/lib/api/fetch.ts
@@ -1,5 +1,5 @@
 import { APIError } from './error';
-import * as Sentry from '@sentry/react';
+import { telemetry } from '../telemetry/telemetry';
 import { ApiConfig } from './types/apiConfig';
 import { redirectToLogin } from '../../common/auth/redirectToLogin';
 import { refreshToken as refreshOnboardingToken } from '../../spaces/onboarding/auth/tokenRefresh';
@@ -88,8 +88,8 @@ export const fetchApiServer = async (
       body,
     });
   } catch (error) {
-    Sentry.captureException(error, {
-      extra: {
+    telemetry().report(error, {
+      context: {
         method: httpMethod,
         path: `/api/onboarding${path}`,
       },
@@ -104,12 +104,10 @@ export const fetchApiServer = async (
     const error = new APIError('An error occurred while fetching the data.', res.status);
     error.info = await parseJsonOrText(res);
 
-    Sentry.captureException(error, {
-      extra: {
+    telemetry().report(error, {
+      context: {
         method: httpMethod,
         path: `/api/onboarding${path}`,
-        status: res.status,
-        responseBody: error.info,
       },
     });
 

--- a/src/lib/api/useApiResource.ts
+++ b/src/lib/api/useApiResource.ts
@@ -1,6 +1,5 @@
 import { useContext, useEffect, useState, useRef, useMemo } from 'react';
 import useSWR, { SWRConfiguration, useSWRConfig } from 'swr';
-import * as Sentry from '@sentry/react';
 import { fetchApiServerJson } from './fetch';
 import { ApiConfigContext } from '../../components/Shared/k8s';
 import { APIError } from './error';
@@ -10,6 +9,7 @@ import useSWRMutation, { SWRMutationConfiguration } from 'swr/mutation';
 import { MutatorOptions } from 'swr/_internal';
 import { CRDRequest, CRDResponse } from './types/crossplane/CRDList';
 import { ProviderConfigs, ProviderConfigsData, ProviderConfigsDataForRequest } from '../shared/types';
+import { useTelemetry } from '../telemetry/telemetry';
 
 export const useApiResource = <T>(
   resource: Resource<T>,
@@ -75,6 +75,7 @@ export const useCRDItemsMapping = (config?: SWRConfiguration) => {
 
 export const useProvidersConfigResource = (config?: SWRConfiguration) => {
   const apiConfig = useContext(ApiConfigContext);
+  const telemetry = useTelemetry();
   const { data, error, isValidating } = useSWR(
     CRDRequest.path === null
       ? null //TODO: is null a valid key?
@@ -152,11 +153,9 @@ export const useProvidersConfigResource = (config?: SWRConfiguration) => {
       return providerConfigs.filter((config) => config !== null);
     } catch (error) {
       console.error('Error fetching provider configs:', error);
-      Sentry.captureException(error, {
-        extra: {
-          context: 'useProvidersConfigResource:fetchProviderConfigs',
-          requestCount: providerConfigsDataForRequest.length,
-        },
+      telemetry.report(error, {
+        message: 'Failed to fetch provider configs',
+        context: { requestCount: providerConfigsDataForRequest.length },
       });
       return []; // Return an empty array in case of error
     }
@@ -250,6 +249,7 @@ export function useMultipleApiResources<T>(
   getResource: (namespace: string) => { path: string | null },
 ) {
   const apiConfig = useContext(ApiConfigContext);
+  const telemetry = useTelemetry();
   const [data, setData] = useState<T[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -270,11 +270,9 @@ export function useMultipleApiResources<T>(
         setData(results);
       } catch (err) {
         console.error('Error fetching multiple resources:', err);
-        Sentry.captureException(err, {
-          extra: {
-            context: 'useMultipleApiResources',
-            namespacesCount: namespaces.length,
-          },
+        telemetry.report(err, {
+          message: 'Failed to fetch multiple resources',
+          context: { namespacesCount: namespaces.length },
         });
         setError(err as Error);
         setData([]);

--- a/src/lib/api/useApiResource.ts
+++ b/src/lib/api/useApiResource.ts
@@ -282,7 +282,7 @@ export function useMultipleApiResources<T>(
     };
 
     fetchData();
-  }, [namespaces, getResource, apiConfig]);
+  }, [namespaces, getResource, apiConfig, telemetry]);
 
   return { data, isLoading, error };
 }

--- a/src/lib/telemetry/TelemetryService.ts
+++ b/src/lib/telemetry/TelemetryService.ts
@@ -1,0 +1,28 @@
+import type { Telemetry, TelemetryUser } from './types';
+import type { TelemetryFeature } from './features';
+
+export class TelemetryService implements Telemetry {
+  constructor(private readonly adapters: Telemetry[]) {}
+
+  track(feature: TelemetryFeature): void {
+    this.dispatch('track', (a) => a.track(feature));
+  }
+
+  report(error: unknown, options?: { message?: string; context?: Record<string, unknown> }): void {
+    this.dispatch('report', (a) => a.report(error, options));
+  }
+
+  identify(user: TelemetryUser | null): void {
+    this.dispatch('identify', (a) => a.identify(user));
+  }
+
+  private dispatch(method: 'track' | 'report' | 'identify', call: (adapter: Telemetry) => void): void {
+    for (const adapter of this.adapters) {
+      try {
+        call(adapter);
+      } catch (err) {
+        console.error(`[TelemetryService] ${adapter.constructor.name}.${method} failed:`, err);
+      }
+    }
+  }
+}

--- a/src/lib/telemetry/adapters/ConsoleAdapter.ts
+++ b/src/lib/telemetry/adapters/ConsoleAdapter.ts
@@ -1,0 +1,17 @@
+import type { Telemetry, TelemetryUser } from '../types';
+import type { TelemetryFeature } from '../features';
+
+export class ConsoleAdapter implements Telemetry {
+  track(feature: TelemetryFeature): void {
+    const { name, ...rest } = feature;
+    console.info('[Telemetry] track', name, rest);
+  }
+
+  report(error: unknown, options?: { message?: string; context?: Record<string, unknown> }): void {
+    console.error('[Telemetry] report', options?.message ?? 'Error', error, options?.context ?? {});
+  }
+
+  identify(user: TelemetryUser | null): void {
+    console.info('[Telemetry] identify ', user);
+  }
+}

--- a/src/lib/telemetry/adapters/DynatraceAdapter.ts
+++ b/src/lib/telemetry/adapters/DynatraceAdapter.ts
@@ -1,0 +1,34 @@
+import type { Telemetry, TelemetryUser } from '../types';
+import type { TelemetryFeature } from '../features';
+import '../bootstrap/dynatrace';
+
+export class DynatraceAdapter implements Telemetry {
+  track(feature: TelemetryFeature): void {
+    if (!window.dtrum) return;
+
+    const actionId = window.dtrum.enterAction(feature.name, 'feature');
+    try {
+      const { name: _, ...rest } = feature;
+      const stringProps = Object.fromEntries(Object.entries(rest).map(([k, v]) => [k, String(v)]));
+      if (Object.keys(stringProps).length > 0) {
+        window.dtrum.addActionProperties(actionId, undefined, undefined, stringProps);
+      }
+    } finally {
+      window.dtrum.leaveAction(actionId);
+    }
+  }
+
+  report(error: unknown, options?: { message?: string; context?: Record<string, unknown> }): void {
+    if (!window.dtrum) return;
+
+    const cause = error instanceof Error ? error.message : String(error);
+    const prefix = options?.message ?? 'Error';
+    window.dtrum.reportError(`${prefix}: ${cause}`);
+  }
+
+  identify(user: TelemetryUser | null): void {
+    if (!window.dtrum) return;
+
+    window.dtrum.identifyUser(user?.id ?? '');
+  }
+}

--- a/src/lib/telemetry/adapters/SentryAdapter.ts
+++ b/src/lib/telemetry/adapters/SentryAdapter.ts
@@ -1,0 +1,32 @@
+import * as Sentry from '@sentry/react';
+import type { Telemetry, TelemetryUser } from '../types';
+import type { TelemetryFeature } from '../features';
+
+export class SentryAdapter implements Telemetry {
+  track(feature: TelemetryFeature): void {
+    Sentry.addBreadcrumb({
+      message: feature.name,
+      data: feature,
+      category: 'ui',
+      level: 'info',
+    });
+  }
+
+  report(error: unknown, options?: { message?: string; context?: Record<string, unknown> }): void {
+    Sentry.captureException(error, {
+      extra: {
+        ...(options?.message !== undefined && { message: options.message }),
+        ...options?.context,
+      },
+    });
+  }
+
+  identify(user: TelemetryUser | null): void {
+    Sentry.setUser(user ? { id: user.id, ...(user.email !== undefined && { email: user.email }) } : null);
+    Sentry.addBreadcrumb({
+      message: user ? 'User identified' : 'User cleared',
+      category: 'auth',
+      level: 'info',
+    });
+  }
+}

--- a/src/lib/telemetry/bootstrap/dynatrace.ts
+++ b/src/lib/telemetry/bootstrap/dynatrace.ts
@@ -1,0 +1,23 @@
+// Dynatrace has no code-side init: the OneAgent <script> tag populates
+// window.dtrum. This file just declares its shape so consumers type-check.
+
+interface DynatraceRUM {
+  enterAction(name: string, type?: string): number;
+  leaveAction(actionId: number): void;
+  addActionProperties(
+    actionId: number,
+    numberProps?: Record<string, number>,
+    dateProps?: Record<string, Date>,
+    stringProps?: Record<string, string>,
+  ): void;
+  reportError(error: string | Error, parentActionId?: number): void;
+  identifyUser(userTag: string): void;
+}
+
+declare global {
+  interface Window {
+    dtrum?: DynatraceRUM;
+  }
+}
+
+export type { DynatraceRUM };

--- a/src/lib/telemetry/bootstrap/sentry.ts
+++ b/src/lib/telemetry/bootstrap/sentry.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/react';
 import React from 'react';
-import { createRoutesFromChildren, matchRoutes, Routes, useLocation, useNavigationType } from 'react-router-dom';
+import { createRoutesFromChildren, matchRoutes, useLocation, useNavigationType } from 'react-router-dom';
 
 // Define proper typing for Sentry configuration
 interface SentryConfig {
@@ -37,19 +37,16 @@ async function fetchSentryConfig(): Promise<unknown> {
   }
 }
 
-// Initialize Sentry and return the wrapped Routes component
-export async function initializeSentry(): Promise<{
-  SentryRoutes: typeof Routes;
-  isSentryEnabled: boolean;
-}> {
+// Initialize Sentry. Returns whether init succeeded so callers can decide
+// whether to wire Sentry-aware error handlers / route wrappers.
+export async function initializeSentry(): Promise<{ isSentryEnabled: boolean }> {
   const sentryConfig = await fetchSentryConfig();
 
   if (!isValidSentryConfig(sentryConfig)) {
     console.warn('Invalid or missing Sentry configuration, continuing without Sentry integration');
-    return { SentryRoutes: Routes, isSentryEnabled: false };
+    return { isSentryEnabled: false };
   }
 
-  // Initialize Sentry with valid configuration
   Sentry.init({
     dsn: sentryConfig.FRONTEND_SENTRY_DSN,
     environment: sentryConfig.FRONTEND_SENTRY_ENVIRONMENT,
@@ -90,8 +87,5 @@ export async function initializeSentry(): Promise<{
     },
   });
 
-  return {
-    SentryRoutes: Sentry.withSentryReactRouterV7Routing(Routes),
-    isSentryEnabled: true,
-  };
+  return { isSentryEnabled: true };
 }

--- a/src/lib/telemetry/features.ts
+++ b/src/lib/telemetry/features.ts
@@ -1,0 +1,12 @@
+// Add new tracked features here. Each variant must have a literal `name`
+// (the event identifier) and may carry additional context properties.
+//
+// Property values are restricted to strings for now. Dynatrace's
+// `addActionProperties` will need to be adjusted for other types.
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+type Feature<N extends string, P extends Record<string, string> = {}> = { name: N } & P;
+
+export type TelemetryFeature =
+  | Feature<'kubeconfig.copied'>
+  | Feature<'kubeconfig.downloaded'>
+  | Feature<'mcp.connected', { idp: 'system' | 'custom' }>;

--- a/src/lib/telemetry/telemetry.ts
+++ b/src/lib/telemetry/telemetry.ts
@@ -1,0 +1,26 @@
+import { TelemetryService } from './TelemetryService';
+import { ConsoleAdapter } from './adapters/ConsoleAdapter';
+import { DynatraceAdapter } from './adapters/DynatraceAdapter';
+import { SentryAdapter } from './adapters/SentryAdapter';
+import type { Telemetry } from './types';
+
+const buildAdapters = (): Telemetry[] => {
+  const adapters: Telemetry[] = [
+    // ── Telemetry providers ─────────────────────────────
+    new SentryAdapter(),
+    new DynatraceAdapter(),
+  ];
+
+  if (import.meta.env.DEV) {
+    // Dev-only (localhost)
+    adapters.push(new ConsoleAdapter());
+  }
+
+  return adapters;
+};
+
+const instance: Telemetry = new TelemetryService(buildAdapters());
+
+export const telemetry = (): Telemetry => instance;
+
+export const useTelemetry = (): Telemetry => telemetry();

--- a/src/lib/telemetry/types.ts
+++ b/src/lib/telemetry/types.ts
@@ -1,0 +1,12 @@
+import type { TelemetryFeature } from './features';
+
+export interface TelemetryUser {
+  id: string;
+  email?: string;
+}
+
+export interface Telemetry {
+  track: (feature: TelemetryFeature) => void;
+  report: (error: unknown, options?: { message?: string; context?: Record<string, unknown> }) => void;
+  identify: (user: TelemetryUser | null) => void;
+}

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -1,11 +1,9 @@
 import * as Sentry from '@sentry/react';
 import { createRoot } from 'react-dom/client';
-import { initializeSentry } from './lib/sentry.ts';
+import { initializeSentry } from './lib/telemetry/bootstrap/sentry.ts';
 import { createApp } from './main.tsx';
 
-const { SentryRoutes, isSentryEnabled } = await initializeSentry();
-
-export { SentryRoutes };
+const { isSentryEnabled } = await initializeSentry();
 
 const rootOptions = isSentryEnabled
   ? {

--- a/src/spaces/onboarding/auth/AuthContextOnboarding.tsx
+++ b/src/spaces/onboarding/auth/AuthContextOnboarding.tsx
@@ -4,6 +4,7 @@ import { STORAGE_KEY_AUTH_FLOW } from '../../../common/auth/AuthCallbackHandler.
 import * as Sentry from '@sentry/react';
 import { getRedirectSuffix } from '../../../common/auth/getRedirectSuffix.ts';
 import { registerRefreshFn, refreshToken } from './tokenRefresh';
+import { useTelemetry } from '../../../lib/telemetry/telemetry';
 
 interface AuthContextOnboardingType {
   isPending: boolean;
@@ -24,6 +25,7 @@ export function AuthProviderOnboarding({ children }: { children: ReactNode }) {
   const [isPending, setIsPending] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const [tokenExpiry, setTokenExpiry] = useState<number | null>(null);
+  const telemetry = useTelemetry();
 
   const refreshAuthStatus = useCallback(async (isBackground: boolean) => {
     // Only show loading spinner for user-initiated auth checks, not background token refreshes
@@ -60,12 +62,6 @@ export function AuthProviderOnboarding({ children }: { children: ReactNode }) {
 
       const validTokenExpiry = apiTokenExpiresAt && apiTokenExpiresAt > Date.now() ? apiTokenExpiresAt : null;
       setTokenExpiry(validTokenExpiry);
-
-      Sentry.addBreadcrumb({
-        category: 'auth',
-        message: 'Authenticated user ' + apiUser?.email,
-        level: 'info',
-      });
     } catch (err) {
       Sentry.captureException(err, {
         extra: {
@@ -88,6 +84,10 @@ export function AuthProviderOnboarding({ children }: { children: ReactNode }) {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     void refreshAuthStatus(false);
   }, [refreshAuthStatus]);
+
+  useEffect(() => {
+    telemetry.identify(user?.sub ? { id: user.sub, email: user.email } : null);
+  }, [user, telemetry]);
 
   const ensureFreshToken = useCallback(async () => {
     if (!tokenExpiry || tokenExpiry - Date.now() >= REFRESH_BUFFER_MS) {

--- a/src/spaces/onboarding/auth/auth.schemas.ts
+++ b/src/spaces/onboarding/auth/auth.schemas.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
 
 export const UserSchema = z.object({
-  email: z.string().email('Invalid email format.'),
+  sub: z.string().min(1, 'sub claim is required.'),
+  email: z.email('Invalid email format.'),
 });
 
 /**


### PR DESCRIPTION
Replace direct Sentry calls with a telemetry abstraction supporting Console, Sentry, and Dynatrace adapters. Enables product analytics tracking alongside error reporting.

- Add TelemetryService with track/report/identify API
- Add adapters: Console, Sentry, Dynatrace
- Move sentry bootstrap to lib/telemetry/bootstrap/
- Migrate fetch.ts, useApiResource.ts, AuthContextOnboarding to telemetry()
- Track mcp.connected (with idp) on ConnectButton
- Track kubeconfig.downloaded / kubeconfig.copied on CopyKubeconfigButton
- Extract sub claim from ID token to enable stable user identify()
