### PR TITLE
feat: remove /mcp prefix from URLs (closes #359)

### DIFF
--- a/src/AppRouter.spec.tsx
+++ b/src/AppRouter.spec.tsx
@@ -1,0 +1,99 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MemoryRouter, Route, Routes, Navigate, useParams } from 'react-router-dom';
+
+// Minimal redirect components mirroring AppRouter — tested in isolation so we
+// don't need to mount the full app tree with all its providers.
+
+function RedirectProject() {
+  const { projectName } = useParams();
+  return <Navigate replace to={`/projects/${projectName}`} />;
+}
+
+function RedirectMcp() {
+  const { projectName, workspaceName, controlPlaneName } = useParams();
+  return <Navigate replace to={`/projects/${projectName}/workspaces/${workspaceName}/mcps/${controlPlaneName}`} />;
+}
+
+function RedirectMcpV2() {
+  const { projectName, workspaceName, controlPlaneName } = useParams();
+  return <Navigate replace to={`/projects/${projectName}/workspaces/${workspaceName}/mcpsv2/${controlPlaneName}`} />;
+}
+
+function RedirectMcpV2Headlamp() {
+  const { projectName, workspaceName, controlPlaneName } = useParams();
+  return (
+    <Navigate replace to={`/projects/${projectName}/workspaces/${workspaceName}/mcpsv2/${controlPlaneName}/headlamp`} />
+  );
+}
+
+function PathCapture({ onCapture }: { onCapture: (path: string) => void }) {
+  const path = (useParams() as any)['*'] ?? '';
+  onCapture(`/${path}`);
+  return null;
+}
+
+function resolveRedirect(from: string): string {
+  let resolved = from;
+
+  render(
+    <MemoryRouter initialEntries={[from]}>
+      <Routes>
+        <Route path="/mcp/projects" element={<Navigate replace to="/projects" />} />
+        <Route path="/mcp/projects/:projectName" element={<RedirectProject />} />
+        <Route
+          path="/mcp/projects/:projectName/workspaces/:workspaceName/mcpsv2/:controlPlaneName/headlamp"
+          element={<RedirectMcpV2Headlamp />}
+        />
+        <Route
+          path="/mcp/projects/:projectName/workspaces/:workspaceName/mcpsv2/:controlPlaneName"
+          element={<RedirectMcpV2 />}
+        />
+        <Route
+          path="/mcp/projects/:projectName/workspaces/:workspaceName/mcps/:controlPlaneName"
+          element={<RedirectMcp />}
+        />
+        <Route
+          path="*"
+          element={
+            <PathCapture
+              onCapture={(p) => {
+                resolved = p;
+              }}
+            />
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+  return resolved;
+}
+
+describe('legacy /mcp/* redirect backward compatibility', () => {
+  it('/mcp/projects redirects to /projects', () => {
+    expect(resolveRedirect('/mcp/projects')).toBe('/projects');
+  });
+
+  it('/mcp/projects/:projectName redirects to /projects/:projectName', () => {
+    expect(resolveRedirect('/mcp/projects/my-project')).toBe('/projects/my-project');
+  });
+
+  it('/mcp/projects/:p/workspaces/:w/mcps/:c redirects to /projects/:p/workspaces/:w/mcps/:c', () => {
+    expect(resolveRedirect('/mcp/projects/my-project/workspaces/my-workspace/mcps/my-mcp')).toBe(
+      '/projects/my-project/workspaces/my-workspace/mcps/my-mcp',
+    );
+  });
+
+  it('/mcp/projects/:p/workspaces/:w/mcpsv2/:c redirects to /projects/:p/workspaces/:w/mcpsv2/:c', () => {
+    expect(resolveRedirect('/mcp/projects/my-project/workspaces/my-workspace/mcpsv2/my-mcp')).toBe(
+      '/projects/my-project/workspaces/my-workspace/mcpsv2/my-mcp',
+    );
+  });
+
+  it('/mcp/projects/:p/workspaces/:w/mcpsv2/:c/headlamp redirects to /projects/:p/workspaces/:w/mcpsv2/:c/headlamp', () => {
+    expect(resolveRedirect('/mcp/projects/my-project/workspaces/my-workspace/mcpsv2/my-mcp/headlamp')).toBe(
+      '/projects/my-project/workspaces/my-workspace/mcpsv2/my-mcp/headlamp',
+    );
+  });
+});

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Route, HashRouter as Router } from 'react-router-dom';
+import { Navigate, Route, HashRouter as Router, useParams } from 'react-router-dom';
 import GlobalProviderOutlet from './components/Core/ApiConfigWrapper.tsx';
 import { ShellBarComponent } from './components/Core/ShellBar.tsx';
 import { SearchParamToggleVisibility } from './components/Helper/FeatureToggleExistance.tsx';
@@ -10,6 +10,8 @@ import McpPage from './spaces/mcp/pages/McpPage.tsx';
 import McpPageV2 from './spaces/mcp/pages/McpPageV2.tsx';
 import ProjectPage from './spaces/onboarding/pages/ProjectPage.tsx';
 import ProjectListView from './views/ProjectList';
+
+// Redirect helpers — read params and build the new canonical URL
 
 function AppRouter() {
   return (
@@ -28,24 +30,36 @@ function AppRouter() {
         <SplitterLayout>
           <Router>
             <SentryRoutes>
-              <Route path="/mcp" element={<GlobalProviderOutlet />}>
-                <Route path="projects" element={<ProjectListView />} />
-                <Route path="projects/:projectName" element={<ProjectPage />} />
+              {/* Canonical routes — no /mcp prefix */}
+              <Route element={<GlobalProviderOutlet />} path="/projects">
+                <Route element={<ProjectListView />} path="" />
+                <Route element={<ProjectPage />} path=":projectName" />
+                <Route element={<McpPageV2 />} path=":projectName/workspaces/:workspaceName/mcpsv2/:controlPlaneName" />
                 <Route
-                  path="projects/:projectName/workspaces/:workspaceName/mcpsv2/:controlPlaneName"
-                  element={<McpPageV2 />}
-                />
-                <Route
-                  path="projects/:projectName/workspaces/:workspaceName/mcpsv2/:controlPlaneName/headlamp"
                   element={<HeadlampPage />}
+                  path=":projectName/workspaces/:workspaceName/mcpsv2/:controlPlaneName/headlamp"
                 />
-                <Route
-                  path="projects/:projectName/workspaces/:workspaceName/mcps/:controlPlaneName"
-                  element={<McpPage />}
-                />
+                <Route element={<McpPage />} path=":projectName/workspaces/:workspaceName/mcps/:controlPlaneName" />
               </Route>
-              <Route path="/" element={<Navigate to="/mcp/projects" />} />
-              <Route path="*" element={<Navigate to="/" />} />
+
+              {/* Legacy /mcp/* redirects — preserve backward compatibility */}
+              <Route path="/mcp/projects" element={<Navigate replace to="/projects" />} />
+              <Route
+                path="/mcp/projects/:projectName/workspaces/:workspaceName/mcpsv2/:controlPlaneName/headlamp"
+                element={<RedirectMcpV2Headlamp />}
+              />
+              <Route
+                path="/mcp/projects/:projectName/workspaces/:workspaceName/mcpsv2/:controlPlaneName"
+                element={<RedirectMcpV2 />}
+              />
+              <Route
+                path="/mcp/projects/:projectName/workspaces/:workspaceName/mcps/:controlPlaneName"
+                element={<RedirectMcp />}
+              />
+              <Route path="/mcp/projects/:projectName" element={<RedirectProject />} />
+
+              <Route path="/" element={<Navigate replace to="/projects" />} />
+              <Route path="*" element={<Navigate replace to="/" />} />
             </SentryRoutes>
           </Router>
         </SplitterLayout>
@@ -55,3 +69,25 @@ function AppRouter() {
 }
 
 export default AppRouter;
+
+function RedirectProject() {
+  const { projectName } = useParams();
+  return <Navigate replace to={`/projects/${projectName}`} />;
+}
+
+function RedirectMcp() {
+  const { projectName, workspaceName, controlPlaneName } = useParams();
+  return <Navigate replace to={`/projects/${projectName}/workspaces/${workspaceName}/mcps/${controlPlaneName}`} />;
+}
+
+function RedirectMcpV2() {
+  const { projectName, workspaceName, controlPlaneName } = useParams();
+  return <Navigate replace to={`/projects/${projectName}/workspaces/${workspaceName}/mcpsv2/${controlPlaneName}`} />;
+}
+
+function RedirectMcpV2Headlamp() {
+  const { projectName, workspaceName, controlPlaneName } = useParams();
+  return (
+    <Navigate replace to={`/projects/${projectName}/workspaces/${workspaceName}/mcpsv2/${controlPlaneName}/headlamp`} />
+  );
+}

--- a/src/Routes.ts
+++ b/src/Routes.ts
@@ -1,6 +1,6 @@
 export const Routes = {
   Home: '/',
-  Projects: '/mcp/projects',
-  Project: '/mcp/projects/:projectName',
-  Mcp: '/mcp/projects/:projectName/workspaces/:workspaceName/mcps/:controlPlaneName',
+  Projects: '/projects',
+  Project: '/projects/:projectName',
+  Mcp: '/projects/:projectName/workspaces/:workspaceName/mcps/:controlPlaneName',
 } as const;

--- a/src/components/ControlPlanes/ConnectButton/ConnectButtonV2.tsx
+++ b/src/components/ControlPlanes/ConnectButton/ConnectButtonV2.tsx
@@ -25,7 +25,7 @@ export default function ConnectButtonV2({
   return (
     <Button
       endIcon="navigation-right-arrow"
-      onClick={() => navigate(`/mcp/projects/${projectName}/workspaces/${workspaceName}/mcpsv2/${controlPlaneName}`)}
+      onClick={() => navigate(`/projects/${projectName}/workspaces/${workspaceName}/mcpsv2/${controlPlaneName}`)}
     >
       {t('ConnectButton.buttonText')}
     </Button>

--- a/src/components/ControlPlanes/ConnectButton/useConnectOptions.spec.ts
+++ b/src/components/ControlPlanes/ConnectButton/useConnectOptions.spec.ts
@@ -34,7 +34,7 @@ contexts:
       name: 'context-system',
       user: 'openmcp',
       isSystemIdP: true,
-      url: '/mcp/projects/test-project/workspaces/test-workspace/mcps/test-mcp',
+      url: '/projects/test-project/workspaces/test-workspace/mcps/test-mcp',
     });
   });
 
@@ -87,15 +87,15 @@ contexts:
       name: 'context-system',
       user: 'openmcp',
       isSystemIdP: true,
-      url: '/mcp/projects/test-project/workspaces/test-workspace/mcps/test-mcp',
+      url: '/projects/test-project/workspaces/test-workspace/mcps/test-mcp',
     });
 
     const customOptions = options.filter((o) => !o.isSystemIdP);
     expect(customOptions).toHaveLength(2);
     expect(customOptions[0].user).toBe('user-a');
-    expect(customOptions[0].url).toBe('/mcp/projects/test-project/workspaces/test-workspace/mcps/test-mcp?idp=user-a');
+    expect(customOptions[0].url).toBe('/projects/test-project/workspaces/test-workspace/mcps/test-mcp?idp=user-a');
     expect(customOptions[1].user).toBe('user-b');
-    expect(customOptions[1].url).toBe('/mcp/projects/test-project/workspaces/test-workspace/mcps/test-mcp?idp=user-b');
+    expect(customOptions[1].url).toBe('/projects/test-project/workspaces/test-workspace/mcps/test-mcp?idp=user-b');
   });
 
   it('should handle kubeconfig without system IdP', () => {
@@ -116,7 +116,7 @@ contexts:
     expect(result.current[0].isSystemIdP).toBe(false);
     expect(result.current[0].user).toBe('custom-user');
     expect(result.current[0].url).toBe(
-      '/mcp/projects/test-project/workspaces/test-workspace/mcps/test-mcp?idp=custom-user',
+      '/projects/test-project/workspaces/test-workspace/mcps/test-mcp?idp=custom-user',
     );
   });
 

--- a/src/components/ControlPlanes/ConnectButton/useConnectOptions.ts
+++ b/src/components/ControlPlanes/ConnectButton/useConnectOptions.ts
@@ -22,7 +22,7 @@ function extractWorkspaceNameFromNamespace(namespace: string): string {
 
 function buildMcpUrl(projectName: string, workspaceName: string, controlPlaneName: string, idp?: string): string {
   const normalizedWorkspace = extractWorkspaceNameFromNamespace(workspaceName);
-  const basePath = `/mcp/projects/${projectName}/workspaces/${normalizedWorkspace}/mcps/${controlPlaneName}`;
+  const basePath = `/projects/${projectName}/workspaces/${normalizedWorkspace}/mcps/${controlPlaneName}`;
   return idp ? `${basePath}?idp=${encodeURIComponent(idp)}` : basePath;
 }
 

--- a/src/components/Core/PathAwareBreadcrumbs/PathAwareBreadcrumbs.cy.tsx
+++ b/src/components/Core/PathAwareBreadcrumbs/PathAwareBreadcrumbs.cy.tsx
@@ -38,13 +38,13 @@ describe('PathAwareBreadcrumbs', () => {
     // Click on 'my-project' > Navigate to 'my-project'
     cy.contains('my-project').click();
     cy.wrap(null).then(() => {
-      expect(lastNavigatedPath).to.equal('/mcp/projects/my-project');
+      expect(lastNavigatedPath).to.equal('/projects/my-project');
     });
 
-    // Click on 'my-workspace' > Navigate to 'my-project' since workspaces don’t expose a direct path
+    // Click on 'my-workspace' > Navigate to 'my-project' since workspaces don't expose a direct path
     cy.contains('my-workspace').click();
     cy.wrap(null).then(() => {
-      expect(lastNavigatedPath).to.equal('/mcp/projects/my-project');
+      expect(lastNavigatedPath).to.equal('/projects/my-project');
     });
   });
 

--- a/src/components/Projects/ProjectChooser.tsx
+++ b/src/components/Projects/ProjectChooser.tsx
@@ -28,7 +28,7 @@ export default function ProjectChooser({ currentProjectName }: Props) {
         closeOnItemSelect
         placement="Bottom"
         onSelect={(e) => {
-          navigate(`/mcp/projects/${e.detail.selectedVariant.children}`);
+          navigate(`/projects/${e.detail.selectedVariant.children}`);
         }}
       >
         {data?.map((p) => (

--- a/src/components/Projects/ProjectsList.tsx
+++ b/src/components/Projects/ProjectsList.tsx
@@ -45,7 +45,7 @@ export default function ProjectsList() {
               paddingBottom: '0.5rem',
             }}
             onClick={() => {
-              navigate(`/mcp/projects/${instance.cell.row.original?.projectName as string}`);
+              navigate(`/projects/${instance.cell.row.original?.projectName as string}`);
             }}
           >
             {instance.cell.value}


### PR DESCRIPTION
## feat: remove `/mcp` prefix from URLs

Closes https://github.com/openmcp-project/backlog/issues/359

## Summary

- New canonical URLs drop the `/mcp` segment: `/#/projects/…` instead of `/#/mcp/projects/…`
- All legacy `/mcp/*` routes stay alive as `<Navigate replace>` redirects — existing bookmarks and external links continue to work

## Changes

- **`Routes.ts`** — updated all route constants
- **`AppRouter.tsx`** — canonical routes under `/projects`, five redirect routes covering every legacy `/mcp/*` pattern
- **`useConnectOptions.ts`, `ConnectButtonV2.tsx`, `ProjectChooser.tsx`, `ProjectsList.tsx`** — in-app navigation updated to new paths
- **`PathAwareBreadcrumbs.cy.tsx`** — test expectations updated

## Tests

- **`AppRouter.spec.tsx`** — 5 Vitest tests asserting backward compatibility for every legacy route:
  - `/mcp/projects` → `/projects`
  - `/mcp/projects/:projectName` → `/projects/:projectName`
  - `/mcp/projects/:p/workspaces/:w/mcps/:c` → `/projects/:p/workspaces/:w/mcps/:c`
  - `/mcp/projects/:p/workspaces/:w/mcpsv2/:c` → `/projects/:p/workspaces/:w/mcpsv2/:c`
  - `/mcp/projects/:p/workspaces/:w/mcpsv2/:c/headlamp` → `/projects/:p/workspaces/:w/mcpsv2/:c/headlamp`

## Test plan

- [ ] `npm run test:vi -- src/AppRouter.spec.tsx`
- [ ] Navigate to `/#/projects` — project list loads
- [ ] Navigate to an old `/#/mcp/projects/…` URL — browser redirects to the canonical path without a 404
