### PR TITLE
feat: add subheader with learn more link to project list

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -262,7 +262,7 @@
   },
   "ProjectsListView": {
     "pageTitle": "Let's get started",
-    "subHeader": "Select a project to manage your control planes, workspaces, and members.",
+    "subHeader": "Create or select a project to manage your control planes, workspaces, and members.",
     "learnMore": "Learn more",
     "title": "Projects",
     "fetchError": "Failed to load projects",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -262,6 +262,8 @@
   },
   "ProjectsListView": {
     "pageTitle": "Let's get started",
+    "subHeader": "Select a project to manage your control planes, workspaces, and members.",
+    "learnMore": "Learn more",
     "title": "Projects",
     "fetchError": "Failed to load projects",
     "deleteProject": "Delete project",

--- a/src/views/ProjectList.tsx
+++ b/src/views/ProjectList.tsx
@@ -1,8 +1,10 @@
-import { ObjectPage, ObjectPageSection, ObjectPageTitle } from '@ui5/webcomponents-react';
+import { Link, ObjectPage, ObjectPageSection, ObjectPageTitle } from '@ui5/webcomponents-react';
+import { useTranslation } from 'react-i18next';
 import ProjectsList from '../components/Projects/ProjectsList.tsx';
 import { BreadcrumbFeedbackHeader } from '../components/Core/BreadcrumbFeedbackHeader.tsx';
 import { ProjectListToolbar } from '../components/Projects/ProjectListToolbar.tsx';
-import { useTranslation } from 'react-i18next';
+
+const LEARN_MORE_URL = 'https://open-control-plane.io/users/concepts/projects-and-workspaces/';
 
 export default function ProjectsListView() {
   const { t } = useTranslation();
@@ -13,6 +15,14 @@ export default function ProjectsListView() {
       titleArea={
         <ObjectPageTitle
           header={t('ProjectsListView.pageTitle')}
+          subHeader={
+            <span>
+              {t('ProjectsListView.subHeader')}{' '}
+              <Link href={LEARN_MORE_URL} target="_blank">
+                {t('ProjectsListView.learnMore')}
+              </Link>
+            </span>
+          }
           breadcrumbs={<BreadcrumbFeedbackHeader />}
           actionsBar={<ProjectListToolbar />}
         />


### PR DESCRIPTION
## Summary

- Adds a descriptive subheader to the project list page: "Select a project to manage your control planes, workspaces, and members."
- Adds a "Learn more" link pointing to the projects-and-workspaces concept docs

## Test plan

- [ ] Open the project list page → subheader text is visible below the page title
- [ ] Click "Learn more" → opens docs URL in a new tab