### PR TITLE
fix: align project list layout with workspace panels and fix cy test

### DIFF
--- a/src/components/Projects/ProjectsList.module.css
+++ b/src/components/Projects/ProjectsList.module.css
@@ -1,6 +1,5 @@
 .table {
   border-radius: 12px;
-  margin: 10px auto 0 auto;
   max-width: 1280px;
   overflow: hidden;
   width: 100%;

--- a/src/components/Projects/ProjectsList.tsx
+++ b/src/components/Projects/ProjectsList.tsx
@@ -64,7 +64,6 @@ export default function ProjectsList() {
       {
         Header: t('ProjectsListView.membersHeader'),
         accessor: 'members',
-        width: 220,
         disableFilters: true,
         Cell: (instance) => <ProjectMembersCell projectName={getProjectName(instance)} />,
       },

--- a/src/components/Projects/ProjectsListItemMenu.cy.tsx
+++ b/src/components/Projects/ProjectsListItemMenu.cy.tsx
@@ -94,6 +94,8 @@ describe('ProjectsListItemMenu', () => {
     cy.get('ui5-button[icon="overflow"]').click();
     cy.contains('Edit project').click({ force: true });
 
+    // Wait for the dialog form to be fully rendered (not in loading state)
+    cy.get('#displayName').should('not.have.attr', 'disabled');
     cy.get('#displayName').find('input[id*="inner"]').clear().type('Updated Display Name');
     cy.get('ui5-button').contains('Save').click();
 

--- a/src/views/ProjectList.tsx
+++ b/src/views/ProjectList.tsx
@@ -1,4 +1,4 @@
-import { ObjectPage, ObjectPageTitle } from '@ui5/webcomponents-react';
+import { ObjectPage, ObjectPageSection, ObjectPageTitle } from '@ui5/webcomponents-react';
 import ProjectsList from '../components/Projects/ProjectsList.tsx';
 import { BreadcrumbFeedbackHeader } from '../components/Core/BreadcrumbFeedbackHeader.tsx';
 import { ProjectListToolbar } from '../components/Projects/ProjectListToolbar.tsx';
@@ -18,7 +18,9 @@ export default function ProjectsListView() {
         />
       }
     >
-      <ProjectsList />
+      <ObjectPageSection id="projects" titleText="Projects" hideTitleText>
+        <ProjectsList />
+      </ObjectPageSection>
     </ObjectPage>
   );
 }


### PR DESCRIPTION

<img width="2956" height="1202" alt="image" src="https://github.com/user-attachments/assets/3c815614-cea8-4e34-9dd7-abc95002cbc2" />

## Summary

### Layout alignment
The project list table was rendering at a different width than the workspace panels on the project detail page. `ProjectsList` was a direct child of `ObjectPage` while workspace panels live inside `ObjectPageSection` nodes — `ObjectPage` applies different horizontal padding to each.

- Wrap `ProjectsList` in an `ObjectPageSection` (with `hideTitleText`) so it gets the same padding context as the workspace panels
- Remove manual `margin: auto` from `.table` CSS — the section container now handles horizontal spacing
- Remove fixed `width: 220` from the members column so it can flex naturally with the available space

### Flaky Cypress fix (unblocks `main` build)
`ProjectsListItemMenu > edits display name and saves` was failing on `main` because `cy.type()` hit the `#displayName` input while the edit dialog was still in its loading state (showing `BusyIndicator`). Added a `should('not.have.attr', 'disabled')` guard to wait for the form to be fully rendered before interacting.

## Test plan

- [ ] Project list page — table aligns with page margins consistently across screen sizes
- [ ] Navigate to a project detail page — workspace panels align to the same left/right edge as the project list
- [ ] `npm run test:cy -- --spec 'src/components/Projects/ProjectsListItemMenu.cy.tsx'` passes