### PR TITLE
fix: wait for edit project dialog before typing in Cypress test

### DIFF
--- a/src/components/Projects/ProjectsListItemMenu.cy.tsx
+++ b/src/components/Projects/ProjectsListItemMenu.cy.tsx
@@ -94,6 +94,8 @@ describe('ProjectsListItemMenu', () => {
     cy.get('ui5-button[icon="overflow"]').click();
     cy.contains('Edit project').click({ force: true });
 
+    // Wait for the dialog form to be fully rendered (not in loading state)
+    cy.get('#displayName').should('not.have.attr', 'disabled');
     cy.get('#displayName').find('input[id*="inner"]').clear().type('Updated Display Name');
     cy.get('ui5-button').contains('Save').click();
 


### PR DESCRIPTION
## Summary

Fixes a flaky Cypress failure on `main` in `ProjectsListItemMenu > edits display name and saves`.

The `EditProjectDialogContainer` shows a `BusyIndicator` while `useGetProject` fetches — during this loading phase the `#displayName` input is absent from the DOM. When `cy.type()` ran immediately after clicking "Edit project", it hit the input before the form had finished populating.

**Fix:** add `cy.get('#displayName').should('not.have.attr', 'disabled')` before the `clear().type()` to wait until the form is ready.

## Root cause

`EditProjectDialogContainer` renders:
- Loading state → `<BusyIndicator>` (no form inputs)
- Loaded state → `<CreateProjectWorkspaceDialog>` with `isEditMode`

The fake `useGetProject` in the test returns data synchronously, but React still needs a render cycle to switch from loading → loaded state. The guard ensures Cypress waits for that transition.

## Test plan

- [x] `npm run test:cy -- --spec 'src/components/Projects/ProjectsListItemMenu.cy.tsx'` passes locally