### PR TITLE
feat: show Request access button on workspace 403 errors

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -99,9 +99,12 @@
   },
   "ControlPlaneListWorkspaceGridTile": {
     "deleteConfirmationDialog": "Workspace deletion triggered. The list will refresh automatically once completed.",
-    "permissionErrorMessage": "Not permitted to list mcps in workspace",
-    "permissionErrorMessageSubtitle": "Ask a workspace admin to grant you access.",
-    "loadingErrorMessage": "Failed to list mcps in workspace"
+    "permissionErrorMessage": "Not permitted to list control planes in workspace",
+    "permissionErrorMessageSubtitle": "You need workspace membership to see control planes here.",
+    "askAdminButton": "Request access",
+    "accessRequestSubject": "Access request: workspace {{workspaceName}} in project {{projectName}}",
+    "accessRequestBody": "Hi,\n\nI would like to request access to the workspace \"{{workspaceName}}\" in project \"{{projectName}}\".\n\nCould you please add me as a member?\n\nThank you.",
+    "loadingErrorMessage": "Failed to list control planes in workspace"
   },
   "ControlPlaneCard": {
     "deleteConfirmationDialog": "Control plane deletion triggered. The list will refresh automatically once completed.",

--- a/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.cy.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.cy.tsx
@@ -3,6 +3,7 @@ import '@ui5/webcomponents-cypress-commands';
 import TimeAgo from 'javascript-time-ago';
 import en from 'javascript-time-ago/locale/en';
 import { MemoryRouter } from 'react-router-dom';
+import { APIError } from '../../../lib/api/error.ts';
 import { FeatureToggleProvider } from '../../../context/FeatureToggleContext.tsx';
 import { FrontendConfigContext } from '../../../context/FrontendConfigContext.tsx';
 import { useDeleteWorkspace } from '../../../spaces/onboarding/hooks/useDeleteWorkspace.ts';
@@ -81,6 +82,87 @@ describe('ControlPlaneListWorkspaceGridTile', () => {
 
   beforeEach(() => {
     deleteWorkspaceCalled = false;
+  });
+
+  const fakeUseMCPsForbiddenQuery: typeof useMcpsQuery = () => ({
+    data: [],
+    error: new APIError('Forbidden', 403),
+    isPending: false,
+  });
+
+  function mountTile(workspace: Workspace) {
+    cy.mount(
+      <MockedProvider mocks={[]}>
+        <MemoryRouter>
+          <FrontendConfigContext.Provider
+            value={{
+              documentationBaseUrl: '',
+              githubBaseUrl: '',
+              featureToggles: { markMcpV1asDeprecated: false, enableMcpV2: false },
+            }}
+          >
+            <SplitterProvider>
+              <FeatureToggleProvider>
+                <ControlPlaneListWorkspaceGridTile
+                  workspace={workspace}
+                  projectName="some-project"
+                  useMcpsQuery={fakeUseMCPsForbiddenQuery}
+                  useDeleteWorkspace={fakeUseDeleteWorkspace}
+                />
+              </FeatureToggleProvider>
+            </SplitterProvider>
+          </FrontendConfigContext.Provider>
+        </MemoryRouter>
+      </MockedProvider>,
+    );
+  }
+
+  it('shows Request access button with admin member email as mailto recipient on 403', () => {
+    const workspace: Workspace = {
+      metadata: {
+        name: 'workspaceName',
+        namespace: 'project-webapp-playground',
+        annotations: {},
+      },
+      spec: {
+        members: [{ kind: 'User', name: 'admin@example.com', roles: ['admin'] }],
+      },
+    };
+
+    mountTile(workspace);
+
+    cy.contains('Request access')
+      .closest('a')
+      .should('have.attr', 'href')
+      .and('include', 'mailto:admin@example.com')
+      .and('include', 'workspaceName')
+      .and('include', 'some-project');
+  });
+
+  it('falls back to created-by annotation when no admin members present on 403', () => {
+    const workspace: Workspace = {
+      metadata: {
+        name: 'workspaceName',
+        namespace: 'project-webapp-playground',
+        annotations: { 'core.openmcp.cloud/created-by': 'creator@example.com' },
+      },
+      spec: { members: [] },
+    };
+
+    mountTile(workspace);
+
+    cy.contains('Request access').closest('a').should('have.attr', 'href').and('include', 'mailto:creator@example.com');
+  });
+
+  it('shows Request access button with empty mailto when no emails available on 403', () => {
+    const workspace: Workspace = {
+      metadata: { name: 'workspaceName', namespace: 'project-webapp-playground', annotations: {} },
+      spec: { members: [] },
+    };
+
+    mountTile(workspace);
+
+    cy.contains('Request access').should('exist');
   });
 
   it('deletes the workspace', () => {

--- a/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
@@ -7,7 +7,8 @@ import { useMemo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFeatureToggle } from '../../../context/FeatureToggleContext.tsx';
 import { isForbiddenError } from '../../../lib/api/error.ts';
-import { DISPLAY_NAME_ANNOTATION } from '../../../lib/api/types/shared/keyNames.ts';
+import { CREATED_BY_ANNOTATION, DISPLAY_NAME_ANNOTATION } from '../../../lib/api/types/shared/keyNames.ts';
+import { MemberRoles } from '../../../lib/api/types/shared/members.ts';
 import { useLink } from '../../../lib/shared/useLink.ts';
 import { useDeleteWorkspace as _useDeleteWorkspace } from '../../../spaces/onboarding/hooks/useDeleteWorkspace.ts';
 import { useMcpsQuery as _useMcpsQuery } from '../../../spaces/onboarding/hooks/useMcpsQuery.ts';
@@ -66,7 +67,16 @@ export function ControlPlaneListWorkspaceGridTile({
   } = useMcpsQuery(`project-${projectName}--ws-${workspaceName}`);
   const { deleteWorkspace } = useDeleteWorkspace(projectNamespace, workspaceName);
   const { mcpCreationGuide } = useLink();
-  const errorView = createErrorView(cpsError);
+  const workspaceAdminEmails = useMemo(() => {
+    const adminMembers = (workspace.spec.members ?? [])
+      .filter((m) => m.kind === 'User' && m.roles.includes(MemberRoles.admin))
+      .map((m) => m.name);
+    if (adminMembers.length > 0) return adminMembers;
+    const createdBy = workspace.metadata.annotations?.[CREATED_BY_ANNOTATION];
+    return createdBy ? [createdBy] : [];
+  }, [workspace.spec.members, workspace.metadata.annotations]);
+
+  const errorView = createErrorView(cpsError, workspaceAdminEmails);
   const shouldCollapsePanel = !isExpanded;
 
   useEffect(() => {
@@ -77,14 +87,29 @@ export function ControlPlaneListWorkspaceGridTile({
     return currentWorkspace.status != null && currentWorkspace.status.namespace != null;
   }
 
-  function createErrorView(error: Error | undefined) {
+  function createErrorView(error: Error | undefined, adminEmails: string[]) {
     if (error) {
       if (isForbiddenError(error)) {
+        const subject = encodeURIComponent(
+          t('ControlPlaneListWorkspaceGridTile.accessRequestSubject', { workspaceName, projectName }),
+        );
+        const body = encodeURIComponent(
+          t('ControlPlaneListWorkspaceGridTile.accessRequestBody', { workspaceName, projectName }),
+        );
+        const mailtoHref = `mailto:${adminEmails.join(',')}?subject=${subject}&body=${body}`;
+
         return (
           <IllustratedError
             title={t('ControlPlaneListWorkspaceGridTile.permissionErrorMessage')}
             details={t('ControlPlaneListWorkspaceGridTile.permissionErrorMessageSubtitle')}
             compact={true}
+            button={
+              <a href={mailtoHref}>
+                <Button design="Transparent" icon="email">
+                  {t('ControlPlaneListWorkspaceGridTile.askAdminButton')}
+                </Button>
+              </a>
+            }
           />
         );
       } else {

--- a/src/components/Shared/IllustratedError.tsx
+++ b/src/components/Shared/IllustratedError.tsx
@@ -1,4 +1,5 @@
 import '@ui5/webcomponents-fiori/dist/illustrations/SimpleError';
+import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IllustratedBanner } from '../Ui/IllustratedBanner/IllustratedBanner';
 import IllustrationMessageType from '@ui5/webcomponents-fiori/dist/types/IllustrationMessageType.js';
@@ -7,9 +8,10 @@ interface Props {
   title?: string;
   details?: string;
   compact?: boolean;
+  button?: ReactElement;
 }
 
-export default function IllustratedError({ title, details, compact }: Props) {
+export default function IllustratedError({ title, details, compact, button }: Props) {
   const { t } = useTranslation();
 
   return (
@@ -18,6 +20,7 @@ export default function IllustratedError({ title, details, compact }: Props) {
       title={title ?? t('IllustratedError.titleText')}
       subtitle={details ?? t('IllustratedError.subtitleText')}
       compact={compact}
+      button={button}
     />
   );
 }

--- a/src/lib/api/types/shared/keyNames.ts
+++ b/src/lib/api/types/shared/keyNames.ts
@@ -4,3 +4,4 @@ export const CHARGING_TARGET_TYPE_LABEL: string = 'openmcp.cloud.sap/charging-ta
 export const PROJECT_NAME_LABEL: string = 'openmcp.cloud/mcp-project';
 export const WORKSPACE_LABEL: string = 'openmcp.cloud/mcp-workspace';
 export const LAST_APPLIED_CONFIGURATION_ANNOTATION = 'kubectl.kubernetes.io/last-applied-configuration';
+export const CREATED_BY_ANNOTATION = 'core.openmcp.cloud/created-by';

--- a/src/spaces/mcp/pages/McpPage.tsx
+++ b/src/spaces/mcp/pages/McpPage.tsx
@@ -146,6 +146,7 @@ export default function McpPage() {
     error,
     isLoading,
   } = useApiResource(ControlPlaneResource(projectName, workspaceName, controlPlaneName));
+
   const { markMcpV1asDeprecated } = useFeatureToggle();
   const displayName =
     mcp?.metadata?.annotations && typeof mcp.metadata.annotations === 'object'


### PR DESCRIPTION
<img width="2400" height="698" alt="image" src="https://github.com/user-attachments/assets/8c42fc18-b12c-4f63-a29d-e0f2fe9b6ee8" />


## Summary

- When a user hits a 403 on a workspace, the error state now shows a **"Request access"** button (transparent design) that opens a pre-filled `mailto:` with subject and body asking for workspace membership
- Admin recipients are resolved from `spec.members` (users with `admin` role), falling back to the `core.openmcp.cloud/created-by` annotation — so there's always a contact available
- Added `CREATED_BY_ANNOTATION` constant to `keyNames.ts`
- Extended `IllustratedError` with an optional `button` prop (passes through to `IllustratedBanner`)

## Test plan

- [x] Cypress: "Request access" button appears on 403 with admin email pre-filled in mailto
- [x] Cypress: Falls back to `created-by` annotation when no admin members present
- [x] Cypress: Button renders even when no emails are available (empty mailto)
- [x] Existing "deletes the workspace" test still passes
- [x] Type check and lint clean