### PR TITLE
feat: label custom IdP entries in Connect button dropdown

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -116,6 +116,7 @@
   "ConnectButton": {
     "buttonText": "Connect",
     "defaultIdP": "default IdP",
+    "customIdP": "custom IdP",
     "downloadKubeconfig": "Download Kubeconfig"
   },
   "MCPHealthPopoverButton": {

--- a/src/components/ControlPlanes/ConnectButton/ConnectButton.tsx
+++ b/src/components/ControlPlanes/ConnectButton/ConnectButton.tsx
@@ -87,14 +87,27 @@ export default function ConnectButton({
         {t('ConnectButton.buttonText')}
       </Button>
       <Menu opener={buttonId} open={isMenuOpen} onItemClick={handleMenuAction} onClose={() => setIsMenuOpen(false)}>
-        {connectionTargets.map((target) => (
-          <MenuItem
-            key={target.name}
-            text={target.user}
-            data-target={target.url}
-            additionalText={target.isSystemIdP ? t('ConnectButton.defaultIdP') : undefined}
-          />
-        ))}
+        {connectionTargets
+          .filter((t) => t.isSystemIdP)
+          .map((target) => (
+            <MenuItem
+              key={target.name}
+              text={target.user}
+              data-target={target.url}
+              additionalText={t('ConnectButton.defaultIdP')}
+            />
+          ))}
+        {connectionTargets.some((t) => !t.isSystemIdP) && <MenuSeparator />}
+        {connectionTargets
+          .filter((t) => !t.isSystemIdP)
+          .map((target) => (
+            <MenuItem
+              key={target.name}
+              text={target.user}
+              data-target={target.url}
+              additionalText={t('ConnectButton.customIdP')}
+            />
+          ))}
         <MenuSeparator />
         <MenuItem text={t('ConnectButton.downloadKubeconfig')} data-action="download" />
       </Menu>


### PR DESCRIPTION
<img width="876" height="540" alt="image" src="https://github.com/user-attachments/assets/7a6033d9-e802-442d-ab78-784c39da6783" />


## Summary

- When multiple IdPs are available the Connect button shows a dropdown, but all entries looked the same — no way to tell the system IdP from custom ones at a glance
- Added `custom IdP` as `additionalText` on each custom IdP entry, mirroring the existing `default IdP` badge on the system entry
- Added a `MenuSeparator` between the system and custom IdP groups for visual separation

## Test plan

- [x] All Cypress component tests passing
- [x] 335 Vitest unit tests passing
- [x] Type check and lint clean