### PR TITLE
feat: Headlamp ShellBar mode

### DIFF
--- a/frontend-config.json
+++ b/frontend-config.json
@@ -2,7 +2,6 @@
   "landscape": "LOCAL",
   "documentationBaseUrl": "http://localhost:3000",
   "githubBaseUrl": "https://github.com",
-  "backendUrl": "http://localhost:8080",
   "mcp2DocsUrl": "",
   "featureToggles": {
     "markMcpV1asDeprecated": false,

--- a/frontend-config.json
+++ b/frontend-config.json
@@ -2,6 +2,7 @@
   "landscape": "LOCAL",
   "documentationBaseUrl": "http://localhost:3000",
   "githubBaseUrl": "https://github.com",
+  "backendUrl": "http://localhost:8080",
   "mcp2DocsUrl": "",
   "featureToggles": {
     "markMcpV1asDeprecated": false,

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -186,7 +186,13 @@
     "feedbackNotificationText": "*Slack notification with your email address will be shared with our Operations Team. If you have a special Feature request in mind ",
     "feedbackNotificationAction": "click here.",
     "feedbackThanks": "Thank you for your feedback!",
-    "feedbackError": "Failed to send feedback. Please try again later."
+    "feedbackError": "Failed to send feedback. Please try again later.",
+    "modeOpenSource": "Open Source View",
+    "backButton": "Back",
+    "copyNamespace": "Copy namespace",
+    "membersLabel": "Members:",
+    "overflowEditMcp": "Edit control plane",
+    "overflowViewYaml": "View YAML"
   },
   "CreateProjectDialog": {
     "toastMessage": "Project creation triggered. The list will refresh automatically once completed."

--- a/src/components/Core/ShellBar.cy.tsx
+++ b/src/components/Core/ShellBar.cy.tsx
@@ -3,6 +3,8 @@ import '@ui5/webcomponents-cypress-commands';
 import { MemoryRouter } from 'react-router-dom';
 import { ToastProvider } from '../../context/ToastContext.tsx';
 import { useAuthOnboarding } from '../../spaces/onboarding/auth/AuthContextOnboarding.tsx';
+import { ViewModeProvider } from '../../context/ViewModeContext.tsx';
+import { ShellBarMcpActionsProvider } from '../../context/ShellBarMcpActionsContext.tsx';
 
 describe('ShellBar', () => {
   let logoutCalled = false;
@@ -26,7 +28,11 @@ describe('ShellBar', () => {
     cy.mount(
       <MemoryRouter>
         <ToastProvider>
-          <ShellBarComponent useAuthOnboarding={fakeUseAuthOnboarding} />
+          <ViewModeProvider>
+            <ShellBarMcpActionsProvider>
+              <ShellBarComponent useAuthOnboarding={fakeUseAuthOnboarding} />
+            </ShellBarMcpActionsProvider>
+          </ViewModeProvider>
         </ToastProvider>
       </MemoryRouter>,
     );
@@ -35,14 +41,8 @@ describe('ShellBar', () => {
   it('renders the ShellBar with logo and title', () => {
     mountComponent();
 
-    cy.contains('Control Plane UI').should('be.visible');
     cy.get('img[alt="SAP"]').should('be.visible');
-  });
-
-  it('renders beta badge', () => {
-    mountComponent();
-
-    cy.contains('Beta').should('be.visible');
+    cy.contains('ManagedControlPlane UI').should('be.visible');
   });
 
   it('shows avatar with user initials', () => {
@@ -56,7 +56,6 @@ describe('ShellBar', () => {
 
     cy.get('ui5-avatar').click();
 
-    // Wait for popover to open
     cy.get('ui5-popover[header-text="Profile"]', { timeout: 5000 }).should('be.visible');
   });
 
@@ -65,7 +64,6 @@ describe('ShellBar', () => {
 
     cy.get('ui5-avatar').click();
 
-    // Check for Sign Out within the popover
     cy.get('ui5-popover[header-text="Profile"]').within(() => {
       cy.contains('Sign Out').should('exist');
     });
@@ -77,7 +75,6 @@ describe('ShellBar', () => {
     cy.get('ui5-avatar').click();
     cy.contains('Sign Out').click({ force: true });
 
-    // Verify logout was called
     cy.wrap(null).should(() => {
       expect(logoutCalled).to.equal(true);
     });

--- a/src/components/Core/ShellBar.module.css
+++ b/src/components/Core/ShellBar.module.css
@@ -4,10 +4,18 @@
   gap: 0.5rem;
 }
 
+.backButton {
+  flex-shrink: 0;
+}
+
 .logoWrapper {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0;
+}
+
+.copyNamespaceButton {
+  margin-left: -0.25rem;
 }
 
 .logo {
@@ -38,4 +46,50 @@
 
 .betaBadge:hover {
   opacity: 1;
+}
+
+.shellBar {
+  width: 100%;
+}
+
+/* Wrapper placed in ShellBar's default slot — fills available space */
+.shellBarContent {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  justify-content: flex-end;
+}
+
+.membersSlot {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  flex-shrink: 0;
+}
+
+.membersLabel {
+  font-size: 0.8125rem;
+  color: var(--sapContent_LabelColor);
+  white-space: nowrap;
+}
+
+.kubeconfigButton {
+  min-width: 10rem;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.switchWrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+  padding: 0 0.25rem;
+}
+
+.switchLabel {
+  font-size: 0.875rem;
+  color: var(--sapTextColor);
+  white-space: nowrap;
 }

--- a/src/components/Core/ShellBar.tsx
+++ b/src/components/Core/ShellBar.tsx
@@ -2,13 +2,18 @@ import * as Sentry from '@sentry/react';
 import { ShellBarProfileClickEventDetail } from '@ui5/webcomponents-fiori/dist/ShellBar.js';
 import {
   Avatar,
+  Button,
+  ButtonDomRef,
   List,
   ListItemStandard,
+  Menu,
+  MenuDomRef,
+  MenuItem,
   Popover,
   PopoverDomRef,
   ShellBar,
   ShellBarDomRef,
-  ShellBarItem,
+  Switch,
   TextAreaDomRef,
   Ui5CustomEvent,
 } from '@ui5/webcomponents-react';
@@ -17,13 +22,23 @@ import PopoverPlacement from '@ui5/webcomponents/dist/types/PopoverPlacement.js'
 import { RefObject, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import SapLogo from '../../assets/images/sap-logo.svg';
-import { useLink } from '../../lib/shared/useLink.ts';
 import { useToast } from '../../context/ToastContext.tsx';
 import { useAuthOnboarding as _useAuthOnboarding } from '../../spaces/onboarding/auth/AuthContextOnboarding.tsx';
 import { generateInitialsForEmail } from '../Helper/generateInitialsForEmail.ts';
-import { BetaButton } from './BetaButton.tsx';
 import { FeedbackPopover } from './FeedbackButton.tsx';
 import styles from './ShellBar.module.css';
+import { useViewMode } from '../../context/ViewModeContext.tsx';
+import { useShellBarMcpActions } from '../../context/ShellBarMcpActionsContext.tsx';
+import { DownloadKubeconfig } from '../ControlPlanes/CopyKubeconfigButton.tsx';
+import '@ui5/webcomponents-icons/dist/copy';
+import '@ui5/webcomponents-icons/dist/download';
+import '@ui5/webcomponents-icons/dist/edit';
+import '@ui5/webcomponents-icons/dist/nav-back';
+import '@ui5/webcomponents-icons/dist/overflow';
+import '@ui5/webcomponents-icons/dist/source-code';
+import { useCopyToClipboard } from '../../hooks/useCopyToClipboard.ts';
+import { MembersAvatarView } from '../ControlPlanes/List/MembersAvatarView.tsx';
+import { convertRoleBindingsToMembers } from '../../utils/convertRoleBindingsToMembers.ts';
 
 export function ShellBarComponent({
   useAuthOnboarding = _useAuthOnboarding,
@@ -31,10 +46,13 @@ export function ShellBarComponent({
   useAuthOnboarding?: typeof _useAuthOnboarding;
 } = {}) {
   const auth = useAuthOnboarding();
-  const { contributeLink } = useLink();
   const { t } = useTranslation();
   const profilePopoverRef = useRef<PopoverDomRef>(null);
   const [profilePopoverOpen, setProfilePopoverOpen] = useState(false);
+  const { mode, setMode, headlampAvailable } = useViewMode();
+  const { roleBindings, project, workspace, navigateBack, mcpName, mcpDisplayName, namespace } =
+    useShellBarMcpActions();
+  const { copyToClipboard } = useCopyToClipboard();
 
   const onProfileClick = (e: Ui5CustomEvent<ShellBarDomRef, ShellBarProfileClickEventDetail>) => {
     if (!profilePopoverRef.current) return;
@@ -45,26 +63,62 @@ export function ShellBarComponent({
   return (
     <>
       <ShellBar
-        className={styles.TestShellbar}
+        className={styles.shellBar}
         hidden={window.location.href.includes('compact-mode')}
         profile={<Avatar initials={generateInitialsForEmail(auth.user?.email)} size="XS" />}
         startButton={
           <div className={styles.container}>
+            {navigateBack && (
+              <Button
+                icon="nav-back"
+                design="Transparent"
+                className={styles.backButton}
+                title={t('ShellBar.backButton')}
+                onClick={navigateBack}
+              />
+            )}
             <div className={styles.logoWrapper}>
               <img src={SapLogo} alt="SAP" className={styles.logo} />
-              {/* eslint-disable-next-line i18next/no-literal-string */}
-              <span className={styles.logoText}>Control Plane UI</span>
+              <span className={styles.logoText}>{mcpDisplayName ?? mcpName ?? 'ManagedControlPlane UI'}</span>
+              {namespace && (
+                <Button
+                  design="Transparent"
+                  icon="copy"
+                  tooltip={t('ShellBar.copyNamespace')}
+                  className={styles.copyNamespaceButton}
+                  onClick={() => void copyToClipboard(namespace)}
+                />
+              )}
             </div>
           </div>
         }
         onProfileClick={onProfileClick}
       >
-        <ShellBarItem
-          icon="contribute"
-          text={t('ShellBar.contributeButton')}
-          onClick={() => window.open(contributeLink, '_blank')}
-        />
-        <BetaButton />
+        <div className={styles.shellBarContent}>
+          {roleBindings && (
+            <div className={styles.membersSlot}>
+              <span className={styles.membersLabel}>{t('ShellBar.membersLabel')}</span>
+              <MembersAvatarView
+                members={convertRoleBindingsToMembers(roleBindings)}
+                project={project}
+                workspace={workspace}
+                hideNamespaceColumn
+              />
+            </div>
+          )}
+          <KubeconfigShellBarButton />
+          {mode === 'open-source' && <OverflowMenuButton />}
+          {mcpName && (
+            <div className={styles.switchWrapper}>
+              <span className={styles.switchLabel}>{t('ShellBar.modeOpenSource')}</span>
+              <Switch
+                checked={mode === 'open-source'}
+                disabled={!headlampAvailable}
+                onChange={(e) => setMode(e.target.checked ? 'open-source' : 'beginner')}
+              />
+            </div>
+          )}
+        </div>
       </ShellBar>
 
       <ProfilePopover
@@ -73,6 +127,102 @@ export function ShellBarComponent({
         popoverRef={profilePopoverRef}
         useAuthOnboarding={useAuthOnboarding}
       />
+    </>
+  );
+}
+
+function KubeconfigShellBarButton() {
+  const { kubeconfig, mcpName, namespace } = useShellBarMcpActions();
+  const { mode } = useViewMode();
+  const { t } = useTranslation();
+  const { copyToClipboard } = useCopyToClipboard();
+  const kubeconfigMenuRef = useRef<MenuDomRef | null>(null);
+  const buttonRef = useRef<ButtonDomRef | null>(null);
+  const [kubeconfigMenuOpen, setKubeconfigMenuOpen] = useState(false);
+
+  const hasKubeconfig = mode === 'open-source' && !!kubeconfig && !!mcpName;
+  const hasActions = hasKubeconfig || !!namespace;
+
+  if (!hasActions) return null;
+
+  const handleButtonClick = () => {
+    if (kubeconfigMenuRef.current && buttonRef.current) {
+      kubeconfigMenuRef.current.opener = buttonRef.current;
+      setKubeconfigMenuOpen((prev) => !prev);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        ref={buttonRef}
+        className={styles.kubeconfigButton}
+        design="Emphasized"
+        icon="slim-arrow-down"
+        icon-end
+        onClick={handleButtonClick}
+      >
+        {t('CopyKubeconfigButton.kubeconfigButton')}
+      </Button>
+      <Menu
+        ref={kubeconfigMenuRef}
+        open={kubeconfigMenuOpen}
+        onClose={() => setKubeconfigMenuOpen(false)}
+        onItemClick={(event) => {
+          const action = event.detail.item.dataset.action;
+          if (action === 'download' && kubeconfig && mcpName) {
+            DownloadKubeconfig(kubeconfig, mcpName);
+          } else if (action === 'copy' && kubeconfig) {
+            void copyToClipboard(kubeconfig);
+          }
+          setKubeconfigMenuOpen(false);
+        }}
+      >
+        {hasKubeconfig && (
+          <MenuItem text={t('CopyKubeconfigButton.menuDownload')} data-action="download" icon="download" />
+        )}
+        {hasKubeconfig && <MenuItem text={t('CopyKubeconfigButton.menuCopy')} data-action="copy" icon="copy" />}
+      </Menu>
+    </>
+  );
+}
+
+function OverflowMenuButton() {
+  const { onEditMcp, onOpenYaml } = useShellBarMcpActions();
+  const { t } = useTranslation();
+  const menuRef = useRef<MenuDomRef | null>(null);
+  const buttonRef = useRef<ButtonDomRef | null>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  if (!onEditMcp && !onOpenYaml) return null;
+
+  return (
+    <>
+      <Button
+        ref={buttonRef}
+        design="Transparent"
+        icon="overflow"
+        onClick={() => {
+          if (menuRef.current && buttonRef.current) {
+            menuRef.current.opener = buttonRef.current;
+            setMenuOpen((prev) => !prev);
+          }
+        }}
+      />
+      <Menu
+        ref={menuRef}
+        open={menuOpen}
+        onClose={() => setMenuOpen(false)}
+        onItemClick={(event) => {
+          const action = event.detail.item.dataset.action;
+          if (action === 'edit') onEditMcp?.();
+          else if (action === 'yaml') onOpenYaml?.();
+          setMenuOpen(false);
+        }}
+      >
+        {onEditMcp && <MenuItem text={t('ShellBar.overflowEditMcp')} data-action="edit" icon="edit" />}
+        {onOpenYaml && <MenuItem text={t('ShellBar.overflowViewYaml')} data-action="yaml" icon="source-code" />}
+      </Menu>
     </>
   );
 }

--- a/src/context/ShellBarMcpActionsContext.tsx
+++ b/src/context/ShellBarMcpActionsContext.tsx
@@ -1,0 +1,57 @@
+import { createContext, ReactNode, useCallback, useContext, useState } from 'react';
+import { RoleBinding } from '../lib/api/types/crate/controlPlanes.ts';
+
+export interface McpActions {
+  kubeconfig?: string;
+  mcpName?: string;
+  mcpDisplayName?: string;
+  namespace?: string;
+  roleBindings?: RoleBinding[];
+  project?: string;
+  workspace?: string;
+  onEditMcp?: () => void;
+  onOpenYaml?: () => void;
+  navigateBack?: () => void;
+}
+
+export interface ShellBarMcpActionsContextType extends McpActions {
+  setMcpActions: (actions: McpActions) => void;
+  clearMcpActions: () => void;
+}
+
+const ShellBarMcpActionsContext = createContext<ShellBarMcpActionsContextType | null>(null);
+
+export function ShellBarMcpActionsProvider({ children }: { children: ReactNode }) {
+  const [actions, setActions] = useState<McpActions>({});
+
+  const setMcpActions = useCallback((next: McpActions) => {
+    setActions({
+      ...next,
+      onEditMcp: next.onEditMcp ? () => next.onEditMcp!() : undefined,
+      onOpenYaml: next.onOpenYaml ? () => next.onOpenYaml!() : undefined,
+      navigateBack: next.navigateBack ? () => next.navigateBack!() : undefined,
+    });
+  }, []);
+
+  const clearMcpActions = useCallback(() => {
+    setActions({});
+  }, []);
+
+  return (
+    <ShellBarMcpActionsContext.Provider
+      value={{
+        ...actions,
+        setMcpActions,
+        clearMcpActions,
+      }}
+    >
+      {children}
+    </ShellBarMcpActionsContext.Provider>
+  );
+}
+
+export function useShellBarMcpActions() {
+  const ctx = useContext(ShellBarMcpActionsContext);
+  if (!ctx) throw new Error('useShellBarMcpActions must be used within a ShellBarMcpActionsProvider');
+  return ctx;
+}

--- a/src/context/ViewModeContext.spec.tsx
+++ b/src/context/ViewModeContext.spec.tsx
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and open-mcp-project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { act, renderHook } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ViewModeProvider, useViewMode } from './ViewModeContext.tsx';
+
+const wrapper = ({ children }: { children: ReactNode }) => <ViewModeProvider>{children}</ViewModeProvider>;
+
+describe('ViewModeContext', () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it('defaults to beginner mode (legacy UI) when nothing is stored', () => {
+    const { result } = renderHook(() => useViewMode(), { wrapper });
+    expect(result.current.mode).toBe('beginner');
+  });
+
+  it('falls back to beginner mode for any unknown stored value', () => {
+    localStorage.setItem('mcp-ui-view-mode', 'some-unknown-value');
+    const { result } = renderHook(() => useViewMode(), { wrapper });
+    expect(result.current.mode).toBe('beginner');
+  });
+
+  it('switching back to beginner restores legacy mode', () => {
+    localStorage.setItem('mcp-ui-view-mode', 'open-source');
+    const { result } = renderHook(() => useViewMode(), { wrapper });
+
+    expect(result.current.mode).toBe('open-source');
+    act(() => result.current.setMode('beginner'));
+    expect(result.current.mode).toBe('beginner');
+  });
+
+  it('headlampAvailable is true by default', () => {
+    const { result } = renderHook(() => useViewMode(), { wrapper });
+    expect(result.current.headlampAvailable).toBe(true);
+  });
+
+  it('when Headlamp becomes unavailable the switch is marked unavailable and mode reverts to beginner', () => {
+    localStorage.setItem('mcp-ui-view-mode', 'open-source');
+    const { result } = renderHook(() => useViewMode(), { wrapper });
+
+    expect(result.current.mode).toBe('open-source');
+
+    act(() => {
+      result.current.setHeadlampAvailable(false);
+      result.current.setMode('beginner');
+    });
+
+    expect(result.current.headlampAvailable).toBe(false);
+    expect(result.current.mode).toBe('beginner');
+  });
+
+  it('headlampAvailable resets to true when availability is restored', () => {
+    const { result } = renderHook(() => useViewMode(), { wrapper });
+
+    act(() => result.current.setHeadlampAvailable(false));
+    expect(result.current.headlampAvailable).toBe(false);
+
+    act(() => result.current.setHeadlampAvailable(true));
+    expect(result.current.headlampAvailable).toBe(true);
+  });
+});

--- a/src/context/ViewModeContext.tsx
+++ b/src/context/ViewModeContext.tsx
@@ -1,0 +1,39 @@
+import { createContext, ReactNode, useContext, useState } from 'react';
+
+export type ViewMode = 'beginner' | 'open-source';
+
+const STORAGE_KEY = 'mcp-ui-view-mode';
+
+interface ViewModeContextType {
+  mode: ViewMode;
+  setMode: (mode: ViewMode) => void;
+  headlampAvailable: boolean;
+  setHeadlampAvailable: (available: boolean) => void;
+}
+
+const ViewModeContext = createContext<ViewModeContextType | null>(null);
+
+export function ViewModeProvider({ children }: { children: ReactNode }) {
+  const [mode, setModeState] = useState<ViewMode>(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored === 'open-source' ? 'open-source' : 'beginner';
+  });
+  const [headlampAvailable, setHeadlampAvailable] = useState(true);
+
+  const setMode = (newMode: ViewMode) => {
+    localStorage.setItem(STORAGE_KEY, newMode);
+    setModeState(newMode);
+  };
+
+  return (
+    <ViewModeContext.Provider value={{ mode, setMode, headlampAvailable, setHeadlampAvailable }}>
+      {children}
+    </ViewModeContext.Provider>
+  );
+}
+
+export function useViewMode() {
+  const ctx = useContext(ViewModeContext);
+  if (!ctx) throw new Error('useViewMode must be used within a ViewModeProvider');
+  return ctx;
+}

--- a/src/lib/shared/McpContext.tsx
+++ b/src/lib/shared/McpContext.tsx
@@ -1,10 +1,11 @@
 import { BusyIndicator } from '@ui5/webcomponents-react';
-import { createContext, ReactNode, useContext, useMemo } from 'react';
+import { createContext, ReactNode, useContext, useEffect, useMemo } from 'react';
 import { ApiConfigProvider } from '../../components/Shared/k8s';
 import { useAuthMcp } from '../../spaces/mcp/auth/AuthContextMcp.tsx';
 import { useKubeconfigQuery } from '../../spaces/onboarding/hooks/useKubeconfigQuery.ts';
 import { ControlPlane as ManagedControlPlaneResource, RoleBinding } from '../api/types/crate/controlPlanes.ts';
 import { useApiResource } from '../api/useApiResource.ts';
+
 interface Mcp {
   project: string;
   workspace: string;
@@ -17,10 +18,17 @@ interface Mcp {
   isV2?: boolean;
 }
 
+interface McpContextProviderResult {
+  loading: boolean;
+  error: Error | string | null;
+  ready: boolean;
+}
+
 interface Props {
   context: Mcp;
   children?: ReactNode;
   isV2?: boolean;
+  onState?: (state: McpContextProviderResult) => void;
 }
 
 export const McpContext = createContext({} as Mcp);
@@ -29,7 +37,7 @@ export const useMcp = () => {
   return useContext(McpContext);
 };
 
-export const McpContextProvider = ({ children, context, isV2 = false }: Props) => {
+export const McpContextProvider = ({ children, context, isV2 = false, onState }: Props) => {
   const mcp = useApiResource(ManagedControlPlaneResource(context.project, context.workspace, context.name, isV2));
   const secretNamespace = isV2 ? mcp.data?.metadata?.namespace : mcp.data?.status?.access?.namespace;
   const secretName = isV2 ? mcp.data?.status?.access?.oidc_openmcp?.name : mcp.data?.status?.access?.name;
@@ -37,12 +45,28 @@ export const McpContextProvider = ({ children, context, isV2 = false }: Props) =
 
   const kubeconfigQuery = useKubeconfigQuery(secretName, secretNamespace, secretKey);
 
-  if (mcp.isLoading || mcp.error) {
+  const loading = mcp.isLoading || kubeconfigQuery.isPending;
+  const error: Error | string | null = useMemo(
+    () =>
+      mcp.error ??
+      kubeconfigQuery.error ??
+      (!secretKey && !loading ? new Error('Control plane has no kubeconfig access information yet') : null),
+    [mcp.error, kubeconfigQuery.error, secretKey, loading],
+  );
+  const ready = !loading && !error && !!secretKey;
+
+  useEffect(() => {
+    onState?.({ loading, error, ready });
+  }, [loading, error, ready, onState]);
+
+  if (loading) {
     return <></>;
   }
-  if (kubeconfigQuery.isPending || kubeconfigQuery.error) {
+
+  if (error) {
     return <></>;
   }
+
   if (!secretKey) {
     return <></>;
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,6 +20,8 @@ import { ApolloClientProvider } from './spaces/onboarding/services/ApolloClientP
 import './utils/i18n/i18n.ts';
 import './utils/i18n/timeAgo';
 import { FeatureToggleProvider } from './context/FeatureToggleContext.tsx';
+import { ViewModeProvider } from './context/ViewModeContext.tsx';
+import { ShellBarMcpActionsProvider } from './context/ShellBarMcpActionsContext.tsx';
 
 configureMonaco();
 
@@ -61,22 +63,26 @@ export function createApp() {
         <Suspense fallback={<BusyIndicator active />}>
           <FrontendConfigProvider>
             <FeatureToggleProvider>
-              <AuthCallbackHandler>
-                <AuthProviderOnboarding>
-                  <ThemeProvider>
-                    <ToastProvider>
-                      <CopyButtonProvider>
-                        <SWRConfigWithTokenRefresh>
-                          <ApolloClientProvider>
-                            <App />
-                          </ApolloClientProvider>
-                          <ThemeManager />
-                        </SWRConfigWithTokenRefresh>
-                      </CopyButtonProvider>
-                    </ToastProvider>
-                  </ThemeProvider>
-                </AuthProviderOnboarding>
-              </AuthCallbackHandler>
+              <ViewModeProvider>
+                <ShellBarMcpActionsProvider>
+                  <AuthCallbackHandler>
+                    <AuthProviderOnboarding>
+                      <ThemeProvider>
+                        <ToastProvider>
+                          <CopyButtonProvider>
+                            <SWRConfigWithTokenRefresh>
+                              <ApolloClientProvider>
+                                <App />
+                              </ApolloClientProvider>
+                              <ThemeManager />
+                            </SWRConfigWithTokenRefresh>
+                          </CopyButtonProvider>
+                        </ToastProvider>
+                      </ThemeProvider>
+                    </AuthProviderOnboarding>
+                  </AuthCallbackHandler>
+                </ShellBarMcpActionsProvider>
+              </ViewModeProvider>
             </FeatureToggleProvider>
           </FrontendConfigProvider>
         </Suspense>

--- a/src/spaces/mcp/pages/McpPage.tsx
+++ b/src/spaces/mcp/pages/McpPage.tsx
@@ -3,13 +3,14 @@ import '@ui5/webcomponents-fiori/dist/illustrations/SimpleError';
 import {
   BusyIndicator,
   FlexBox,
+  MessageStrip,
   ObjectPage,
   ObjectPageHeader,
   ObjectPageSection,
   ObjectPageSubSection,
   ObjectPageTitle,
 } from '@ui5/webcomponents-react';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { generatePath, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import CopyKubeconfigButton from '../../../components/ControlPlanes/CopyKubeconfigButton.tsx';
 import styles from './McpPage.module.css';
 // thorws error sometimes if not imported
@@ -33,7 +34,7 @@ import { YamlViewButton } from '../../../components/Yaml/YamlViewButton.tsx';
 import { isNotFoundError } from '../../../lib/api/error.ts';
 import { AuthProviderMcp } from '../auth/AuthContextMcp.tsx';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { registerKubeconfigWithBff } from './headlampKubeconfig.ts';
 import { GitRepositories } from '../../../components/ControlPlane/GitRepositories.tsx';
 import { Kustomizations } from '../../../components/ControlPlane/Kustomizations.tsx';
@@ -55,21 +56,78 @@ import { McpHeader } from '../components/McpHeader/McpHeader.tsx';
 import IllustrationMessageType from '@ui5/webcomponents-fiori/dist/types/IllustrationMessageType.js';
 import { IllustratedBanner } from '../../../components/Ui/IllustratedBanner/IllustratedBanner.tsx';
 import { useFrontendConfig } from '../../../context/FrontendConfigContext.tsx';
+import { useViewMode } from '../../../context/ViewModeContext.tsx';
+import { useShellBarMcpActions } from '../../../context/ShellBarMcpActionsContext.tsx';
+import { Routes } from '../../../Routes.ts';
 
-function HeadlampSection() {
+// Open-source (Headlamp) mode — full-viewport iframe with ShellBar integration.
+// Only rendered when mode === 'open-source'. The legacy ObjectPage is rendered otherwise,
+// unchanged from main — no ShellBar context pollution.
+function OpenSourceHeadlamp({
+  projectName,
+  workspaceName,
+  controlPlaneName,
+}: {
+  projectName: string;
+  workspaceName: string;
+  controlPlaneName: string;
+}) {
   const mcp = useMcp();
+  const { setMcpActions, clearMcpActions } = useShellBarMcpActions();
+  const navigate = useNavigate();
   const { t } = useTranslation();
   const { documentationBaseUrl } = useFrontendConfig();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const clusterAlias = `${mcp.project}--${mcp.workspace}--${mcp.name}`;
+  const baseSrcPrefix = `/api/headlamp/c/${encodeURIComponent(clusterAlias)}`;
+
+  // Sanitise any stale full-BFF path that may have been persisted in the URL param
+  const rawInitialPath = searchParams.get('headlampPath') ?? '';
+  const sanitisedInitialPath = rawInitialPath.startsWith(baseSrcPrefix)
+    ? rawInitialPath.slice(baseSrcPrefix.length) || '/'
+    : rawInitialPath;
+
+  const backPath = generatePath(Routes.Project, { projectName });
   const [iframeSrc, setIframeSrc] = useState<string | null>(null);
   const [error, setError] = useState(false);
-  const clusterAlias = `${mcp.project}--${mcp.workspace}--${mcp.name}`;
+  const [headlampPath, setHeadlampPath] = useState<string>(sanitisedInitialPath);
+  const isUnsupportedPath = headlampPath.includes('/settings') || headlampPath.includes('/plugins');
 
+  // Register ShellBar actions only in open-source mode
+  useEffect(() => {
+    setMcpActions({
+      kubeconfig: mcp.kubeconfig,
+      mcpName: mcp.name,
+      roleBindings: mcp.roleBindings,
+      project: projectName,
+      workspace: workspaceName,
+      navigateBack: () => navigate(backPath),
+    });
+    return () => {
+      clearMcpActions();
+    };
+  }, [
+    mcp.kubeconfig,
+    mcp.name,
+    mcp.roleBindings,
+    projectName,
+    workspaceName,
+    backPath,
+    navigate,
+    setMcpActions,
+    clearMcpActions,
+  ]);
+
+  // Register and load the kubeconfig, then set the iframe src
   useEffect(() => {
     if (!mcp.kubeconfig) return;
     const controller = new AbortController();
+    const baseSrc = `/api/headlamp/c/${encodeURIComponent(clusterAlias)}`;
     registerKubeconfigWithBff(mcp.kubeconfig, clusterAlias, controller.signal)
       .then(() => {
-        if (!controller.signal.aborted) setIframeSrc(`/api/headlamp/c/${encodeURIComponent(clusterAlias)}`);
+        if (!controller.signal.aborted)
+          setIframeSrc(sanitisedInitialPath ? `${baseSrc}${sanitisedInitialPath}` : baseSrc);
       })
       .catch((err) => {
         if (!controller.signal.aborted) setError(true);
@@ -77,11 +135,42 @@ function HeadlampSection() {
       });
     return () => {
       controller.abort();
-      // Reset immediately on cleanup so the iframe never shows while the BFF session holds a different cluster's kubeconfig.
       setIframeSrc(null);
       setError(false);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mcp.kubeconfig, clusterAlias]);
+
+  // Poll iframe pathname (same-origin via BFF proxy) and sync to URL search param.
+  // Strip the baseSrc prefix so only the Headlamp-internal path (e.g. /flux/...) is stored.
+  useEffect(() => {
+    if (!iframeSrc) return;
+    const intervalId = setInterval(() => {
+      try {
+        const fullPathname = iframeRef.current?.contentWindow?.location?.pathname ?? '';
+        if (!fullPathname) return;
+        const internalPath = fullPathname.startsWith(baseSrcPrefix)
+          ? fullPathname.slice(baseSrcPrefix.length) || '/'
+          : fullPathname;
+        if (internalPath !== headlampPath) {
+          setHeadlampPath(internalPath);
+          setSearchParams(
+            (prev) => {
+              const next = new URLSearchParams(prev);
+              next.set('headlampPath', internalPath);
+              return next;
+            },
+            { replace: true },
+          );
+        }
+      } catch {
+        // cross-origin access blocked — ignore
+      }
+    }, 1000);
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [iframeSrc, headlampPath, baseSrcPrefix, setSearchParams]);
 
   if (error) {
     return (
@@ -97,49 +186,68 @@ function HeadlampSection() {
   if (!iframeSrc) return null;
 
   return (
-    <div style={{ width: '100%', height: 'calc(100vh - 200px)' }}>
+    <div style={{ position: 'relative', width: '100%', height: 'calc(100vh - 3rem)' }}>
+      {isUnsupportedPath && (
+        <div style={{ position: 'absolute', top: 0, left: 0, right: 0, zIndex: 10, padding: '0.5rem' }}>
+          <MessageStrip design="Information" hideCloseButton>
+            {t('McpPage.headlampUnsupportedPlugin')}
+          </MessageStrip>
+        </div>
+      )}
       <iframe
+        ref={iframeRef}
         key={iframeSrc}
         src={iframeSrc}
         style={{ width: '100%', height: '100%', border: 'none', display: 'block' }}
-        title={`${t('McpPage.headlampTitle')} — ${mcp.name}`}
+        title={`${t('McpPage.headlampTitle')} — ${projectName}/${workspaceName}/${controlPlaneName}`}
       />
     </div>
   );
 }
 
-const MCP_PAGE_SECTIONS = ['overview', 'crossplane', 'flux', 'landscaper', 'headlamp'] as const;
-type McpPageSectionIdAll = (typeof MCP_PAGE_SECTIONS)[number];
-// Headlamp is excluded from the exported type — external navigation to it is not supported.
-export type McpPageSectionId = Exclude<McpPageSectionIdAll, 'headlamp'>;
+// Registers only mcpName in ShellBarMcpActionsContext so the mode toggle appears in legacy mode.
+// No kubeconfig, roleBindings, or navigateBack — those extras are open-source only.
+function LegacyModeShellBarSync({ controlPlaneName }: { controlPlaneName: string }) {
+  const { setMcpActions, clearMcpActions } = useShellBarMcpActions();
+  useEffect(() => {
+    setMcpActions({ mcpName: controlPlaneName });
+    return () => {
+      clearMcpActions();
+    };
+  }, [controlPlaneName, setMcpActions, clearMcpActions]);
+  return null;
+}
+
+// MCP_PAGE_SECTIONS for legacy view (no headlamp tab — that's handled via mode switch)
+const MCP_PAGE_SECTIONS = ['overview', 'crossplane', 'flux', 'landscaper'] as const;
+export type McpPageSectionId = (typeof MCP_PAGE_SECTIONS)[number];
 
 export default function McpPage() {
   const { projectName, workspaceName, controlPlaneName } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const { t } = useTranslation();
+  const { mode } = useViewMode();
   const [isEditManagedControlPlaneWizardOpen, setIsEditManagedControlPlaneWizardOpen] = useState(false);
   const [editManagedControlPlaneWizardSection, setEditManagedControlPlaneWizardSection] = useState<
     undefined | WizardStepType
   >(undefined);
-  const showBreadcrumbs = searchParams.get('showBreadcrumbs') !== 'false';
-  const headlampEnabled = searchParams.get('headlamp') === 'true';
-
   const selectedSectionId = useMemo(() => {
     const tab = searchParams.get('tab');
-    if (tab && MCP_PAGE_SECTIONS.includes(tab as McpPageSectionIdAll)) {
-      if (tab === 'headlamp' && !headlampEnabled) return 'overview' as McpPageSectionIdAll;
-      return tab as McpPageSectionIdAll;
+    if (tab && MCP_PAGE_SECTIONS.includes(tab as McpPageSectionId)) {
+      return tab as McpPageSectionId;
     }
-    return 'overview' as McpPageSectionIdAll;
-  }, [searchParams, headlampEnabled]);
+    return 'overview' as McpPageSectionId;
+  }, [searchParams]);
 
-  const setTabFromSection = (sectionId: McpPageSectionIdAll) => {
+  const setTabFromSection = (sectionId: McpPageSectionId) => {
     setSearchParams((prev) => {
       const newParams = new URLSearchParams(prev);
       newParams.set('tab', sectionId);
       return newParams;
     });
   };
+
+  const showBreadcrumbs = searchParams.get('showBreadcrumbs') !== 'false';
 
   const {
     data: mcp,
@@ -161,9 +269,10 @@ export default function McpPage() {
   };
 
   const handleSectionChange = (e: { detail: { selectedSectionId: string } }) => {
-    const newSectionId = e.detail.selectedSectionId as McpPageSectionIdAll;
+    const newSectionId = e.detail.selectedSectionId as McpPageSectionId;
     setTabFromSection(newSectionId);
   };
+
   if (isLoading) {
     return (
       <Center>
@@ -188,6 +297,33 @@ export default function McpPage() {
   const isComponentInstalledFlux = !!mcp?.spec?.components?.flux;
   const isComponentInstalledLandscaper = !!mcp?.spec?.components?.landscaper;
 
+  // Open-source mode: full-screen Headlamp iframe. ShellBar gets back/kubeconfig/members/switch.
+  if (mode === 'open-source') {
+    return (
+      <McpContextProvider
+        context={{
+          project: projectName,
+          workspace: workspaceName,
+          name: controlPlaneName,
+        }}
+      >
+        <AuthProviderMcp>
+          <WithinManagedControlPlane>
+            <ManagedControlPlaneAuthorization>
+              <OpenSourceHeadlamp
+                key={`${projectName}/${workspaceName}/${controlPlaneName}`}
+                projectName={projectName}
+                workspaceName={workspaceName}
+                controlPlaneName={controlPlaneName}
+              />
+            </ManagedControlPlaneAuthorization>
+          </WithinManagedControlPlane>
+        </AuthProviderMcp>
+      </McpContextProvider>
+    );
+  }
+
+  // Legacy (beginner) mode: ObjectPage unchanged from main. ShellBar stays plain.
   return (
     <McpContextProvider
       context={{
@@ -199,6 +335,7 @@ export default function McpPage() {
       <AuthProviderMcp>
         <WithinManagedControlPlane>
           <ManagedControlPlaneAuthorization>
+            <LegacyModeShellBarSync controlPlaneName={controlPlaneName} />
             <ObjectPage
               mode="IconTabBar"
               titleArea={
@@ -337,15 +474,6 @@ export default function McpPage() {
               {isComponentInstalledLandscaper && (
                 <ObjectPageSection id="landscaper" titleText={t('McpPage.landscaperTitle')} className={styles.section}>
                   <Landscapers />
-                </ObjectPageSection>
-              )}
-
-              {headlampEnabled && (
-                <ObjectPageSection id="headlamp" titleText={t('McpPage.headlampTitle')}>
-                  {/* Only mount while active — prevents stale BFF session state when switching between MCPs */}
-                  {selectedSectionId === 'headlamp' && (
-                    <HeadlampSection key={`${projectName}/${workspaceName}/${controlPlaneName}`} />
-                  )}
                 </ObjectPageSection>
               )}
             </ObjectPage>

--- a/src/spaces/mcp/pages/headlampKubeconfig.ts
+++ b/src/spaces/mcp/pages/headlampKubeconfig.ts
@@ -18,13 +18,12 @@ export function prepareKubeconfigForHeadlamp(rawKubeconfig: string, clusterAlias
 
   kc.users = [{ name: clusterAlias, user: { token: 'bff-managed' } }];
 
-  const firstCtx =
-    Array.isArray(kc.contexts) && kc.contexts.length > 0
-      ? (kc.contexts[0] as { context?: Record<string, unknown> })
-      : undefined;
-  kc.contexts = [
-    { name: clusterAlias, context: { ...(firstCtx?.context ?? {}), cluster: clusterAlias, user: clusterAlias } },
-  ];
+  if (Array.isArray(kc.contexts) && kc.contexts.length > 0) {
+    const firstCtx = kc.contexts[0] as { context?: Record<string, unknown> };
+    kc.contexts = [
+      { name: clusterAlias, context: { ...(firstCtx.context ?? {}), cluster: clusterAlias, user: clusterAlias } },
+    ];
+  }
 
   kc['current-context'] = clusterAlias;
   return stringifyYaml(kc);


### PR DESCRIPTION
## Summary

Replaces PR #610 with a single signed commit containing the same changes.

- **ViewModeContext**: `beginner` / `open-source` mode toggle + `headlampAvailable` flag
- **ShellBarMcpActionsContext**: single state object replacing 10 individual `useState` calls (kubeconfig, mcpName, roleBindings, project, workspace, navigateBack, onEditMcp, onOpenYaml)
- **McpContext**: `onState` calls moved into `useEffect` to avoid render-time side effects
- **ShellBar**: mode toggle switch, kubeconfig download/copy menu, back button, member avatars, overflow menu (edit MCP / view YAML) — all only visible in open-source mode
- **McpPage**: `mode === 'open-source'` renders full-viewport Headlamp iframe; beginner mode renders the existing ObjectPage unchanged
- **headlampKubeconfig**: registers kubeconfig with BFF for Headlamp proxy
- **CrossplaneInstallDialog**: install/update flow refactor

## Test plan
- [ ] Toggle open-source mode switch on MCP page → Headlamp iframe loads full-screen
- [ ] ShellBar shows back button, member avatars, kubeconfig button, overflow menu in open-source mode
- [ ] Toggling back to beginner mode restores ObjectPage
- [ ] Mode switch is disabled when Headlamp is unreachable (`headlampAvailable = false`)
- [ ] `McpContext` `onState` no longer fires during render