### PR TITLE
feat: add search bar to project list

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -278,6 +278,9 @@
     "namespaceHeader": "Namespace",
     "deleteConfirmationDialog": "Project deletion triggered. The list will refresh automatically once completed."
   },
+  "ResourceSearchBar": {
+    "placeholder": "Search"
+  },
   "McpPage": {
     "accessError": "Control Plane does not have access information yet",
     "overviewTitle": "Overview",

--- a/src/components/Projects/ProjectsList.cy.tsx
+++ b/src/components/Projects/ProjectsList.cy.tsx
@@ -1,0 +1,68 @@
+import '@ui5/webcomponents-cypress-commands';
+import { useProjectMembers as _useProjectMembers } from '../../spaces/onboarding/hooks/useProjectMembers';
+import { useProjectsQuery as _useProjectsQuery } from '../../spaces/onboarding/hooks/useProjectsQuery';
+import ProjectsList from './ProjectsList';
+
+const projects = ['alpha-project', 'beta-project', 'gamma-project'];
+
+const fakeUseProjectsQuery: typeof _useProjectsQuery = () => ({
+  data: projects,
+  isLoading: false,
+  error: null,
+  refetch: () => Promise.resolve([] as string[]),
+});
+
+const fakeUseProjectMembers: typeof _useProjectMembers = (projectName: string) => ({
+  members: [],
+  displayName:
+    projectName === 'alpha-project'
+      ? 'Alpha Display'
+      : projectName === 'beta-project'
+        ? 'Beta Display'
+        : 'Gamma Display',
+  creationTimestamp: '2024-01-01T00:00:00Z',
+  isLoading: false,
+});
+
+const mount = () =>
+  cy.mount(<ProjectsList useProjectsQuery={fakeUseProjectsQuery} useProjectMembers={fakeUseProjectMembers} />);
+
+describe('ProjectsList search', () => {
+  it('shows all projects when search is empty', () => {
+    mount();
+    cy.contains('alpha-project').should('exist');
+    cy.contains('beta-project').should('exist');
+    cy.contains('gamma-project').should('exist');
+  });
+
+  it('filters by project name', () => {
+    mount();
+    cy.get('ui5-input').typeIntoUi5Input('alpha');
+    cy.contains('alpha-project').should('exist');
+    cy.contains('beta-project').should('not.exist');
+    cy.contains('gamma-project').should('not.exist');
+  });
+
+  it('filters by display name', () => {
+    mount();
+    cy.get('ui5-input').typeIntoUi5Input('Beta Display');
+    cy.contains('beta-project').should('exist');
+    cy.contains('alpha-project').should('not.exist');
+    cy.contains('gamma-project').should('not.exist');
+  });
+
+  it('is case-insensitive', () => {
+    mount();
+    cy.get('ui5-input').typeIntoUi5Input('GAMMA');
+    cy.contains('gamma-project').should('exist');
+    cy.contains('alpha-project').should('not.exist');
+  });
+
+  it('shows no results for unmatched query', () => {
+    mount();
+    cy.get('ui5-input').typeIntoUi5Input('zzznomatch');
+    cy.contains('alpha-project').should('not.exist');
+    cy.contains('beta-project').should('not.exist');
+    cy.contains('gamma-project').should('not.exist');
+  });
+});

--- a/src/components/Projects/ProjectsList.cy.tsx
+++ b/src/components/Projects/ProjectsList.cy.tsx
@@ -1,4 +1,7 @@
 import '@ui5/webcomponents-cypress-commands';
+import { MockedProvider } from '@apollo/client/testing/react';
+import { MemoryRouter } from 'react-router-dom';
+import { SplitterProvider } from '../Splitter/SplitterContext.tsx';
 import { useProjectMembers as _useProjectMembers } from '../../spaces/onboarding/hooks/useProjectMembers';
 import { useProjectsQuery as _useProjectsQuery } from '../../spaces/onboarding/hooks/useProjectsQuery';
 import ProjectsList from './ProjectsList';
@@ -25,7 +28,15 @@ const fakeUseProjectMembers: typeof _useProjectMembers = (projectName: string) =
 });
 
 const mount = () =>
-  cy.mount(<ProjectsList useProjectsQuery={fakeUseProjectsQuery} useProjectMembers={fakeUseProjectMembers} />);
+  cy.mount(
+    <MockedProvider mocks={[]}>
+      <MemoryRouter>
+        <SplitterProvider>
+          <ProjectsList useProjectsQuery={fakeUseProjectsQuery} useProjectMembers={fakeUseProjectMembers} />
+        </SplitterProvider>
+      </MemoryRouter>
+    </MockedProvider>,
+  );
 
 describe('ProjectsList search', () => {
   it('shows all projects when search is empty', () => {

--- a/src/components/Projects/ProjectsList.tsx
+++ b/src/components/Projects/ProjectsList.tsx
@@ -2,14 +2,15 @@ import { AnalyticalTable, AnalyticalTableColumnDefinition, BusyIndicator, Link }
 
 import '@ui5/webcomponents-icons/dist/copy';
 import { t } from 'i18next';
-import { useMemo } from 'react';
-import { useProjectMembers } from '../../spaces/onboarding/hooks/useProjectMembers';
-import { useProjectsQuery } from '../../spaces/onboarding/hooks/useProjectsQuery';
+import { useMemo, useRef, useState } from 'react';
+import { useProjectMembers as _useProjectMembers } from '../../spaces/onboarding/hooks/useProjectMembers';
+import { useProjectsQuery as _useProjectsQuery } from '../../spaces/onboarding/hooks/useProjectsQuery';
 import { projectnameToNamespace } from '../../utils';
 import { formatDateAsTimeAgo } from '../../utils/i18n/timeAgo';
 import { CopyButton } from '../Shared/CopyButton.tsx';
 import IllustratedError from '../Shared/IllustratedError.tsx';
 import Loading from '../Shared/Loading.tsx';
+import { ResourceSearchBar } from '../Shared/ResourceSearchBar.tsx';
 import useLuigiNavigate from '../Shared/useLuigiNavigate.tsx';
 import { FadeIn } from '../Ui/FadeIn/FadeIn.tsx';
 import { YamlViewButton } from '../Yaml/YamlViewButton.tsx';
@@ -27,7 +28,7 @@ function getProjectName(instance: { cell: { row: { original: unknown } } }): str
 }
 
 function CreatedAtCell({ projectName }: { projectName: string }) {
-  const { creationTimestamp, isLoading } = useProjectMembers(projectName);
+  const { creationTimestamp, isLoading } = _useProjectMembers(projectName);
   if (isLoading || !creationTimestamp) return null;
   return (
     <FadeIn>
@@ -36,26 +37,61 @@ function CreatedAtCell({ projectName }: { projectName: string }) {
   );
 }
 
-function ProjectDisplayNameCell({ projectName }: { projectName: string }) {
+function ProjectDisplayNameCell({
+  projectName,
+  onDisplayName,
+  useProjectMembers,
+}: {
+  projectName: string;
+  onDisplayName: (name: string, displayName: string) => void;
+  useProjectMembers: typeof _useProjectMembers;
+}) {
   const { displayName, isLoading } = useProjectMembers(projectName);
+  if (!isLoading && displayName) onDisplayName(projectName, displayName);
   if (isLoading) return <BusyIndicator active size="S" />;
   return <FadeIn>{displayName ?? ''}</FadeIn>;
 }
 
-export default function ProjectsList() {
+interface Props {
+  useProjectsQuery?: typeof _useProjectsQuery;
+  useProjectMembers?: typeof _useProjectMembers;
+}
+
+export default function ProjectsList({
+  useProjectsQuery = _useProjectsQuery,
+  useProjectMembers = _useProjectMembers,
+}: Props = {}) {
   const navigate = useLuigiNavigate();
   const { data, error, isLoading } = useProjectsQuery();
+  const displayNamesRef = useRef<Map<string, string>>(new Map());
+  const [search, setSearch] = useState('');
+  const [displayNamesVersion, setDisplayNamesVersion] = useState(0);
 
-  const rows = useMemo<ProjectListRow[]>(
-    () =>
+  const handleDisplayName = (name: string, displayName: string) => {
+    if (displayNamesRef.current.get(name) === displayName) return;
+    displayNamesRef.current.set(name, displayName);
+    setDisplayNamesVersion((v) => v + 1);
+  };
+
+  const rows = useMemo<ProjectListRow[]>(() => {
+    const query = search.trim().toLowerCase();
+    return (
       data
         ?.map((projectName) => ({
           projectName,
           nameSpace: projectnameToNamespace(projectName),
         }))
-        .sort((a, b) => a.projectName.localeCompare(b.projectName)) ?? [],
-    [data],
-  );
+        // eslint-disable-next-line react-hooks/refs
+        .filter(({ projectName }) => {
+          if (!query) return true;
+          if (projectName.toLowerCase().includes(query)) return true;
+          const dn = displayNamesRef.current.get(projectName)?.toLowerCase() ?? '';
+          return dn.includes(query);
+        })
+        .sort((a, b) => a.projectName.localeCompare(b.projectName)) ?? []
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, search, displayNamesVersion]);
 
   const columns: AnalyticalTableColumnDefinition[] = useMemo(
     () => [
@@ -81,7 +117,13 @@ export default function ProjectsList() {
       {
         Header: t('ProjectsListView.displayNameHeader'),
         accessor: 'displayName',
-        Cell: (instance) => <ProjectDisplayNameCell projectName={getProjectName(instance)} />,
+        Cell: (instance) => (
+          <ProjectDisplayNameCell
+            projectName={getProjectName(instance)}
+            useProjectMembers={useProjectMembers}
+            onDisplayName={handleDisplayName}
+          />
+        ),
       },
       {
         Header: t('ProjectsListView.namespaceHeader'),
@@ -146,7 +188,7 @@ export default function ProjectsList() {
         ),
       },
     ],
-    [navigate],
+    [navigate, useProjectMembers],
   );
 
   if (isLoading) {
@@ -158,6 +200,7 @@ export default function ProjectsList() {
 
   return (
     <FadeIn>
+      <ResourceSearchBar value={search} onChange={setSearch} />
       <AnalyticalTable
         style={{
           maxWidth: '1280px',

--- a/src/components/Projects/ProjectsList.tsx
+++ b/src/components/Projects/ProjectsList.tsx
@@ -9,6 +9,7 @@ import {
 import '@ui5/webcomponents-icons/dist/copy';
 import { t } from 'i18next';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTelemetry } from '../../lib/telemetry/telemetry.ts';
 import { useRememberedProject } from '../../hooks/useRememberedProject.ts';
 import { useProjectMembers as _useProjectMembers } from '../../spaces/onboarding/hooks/useProjectMembers';
 import { useProjectsQuery as _useProjectsQuery } from '../../spaces/onboarding/hooks/useProjectsQuery';
@@ -85,6 +86,7 @@ export default function ProjectsList({
   const [search, setSearch] = useState('');
   const [displayNamesVersion, setDisplayNamesVersion] = useState(0);
 
+  const telemetry = useTelemetry();
   const { setRememberedProject } = useRememberedProject();
   const [setAsDefault, setSetAsDefault] = useState(false);
   const setAsDefaultRef = useRef(false);
@@ -129,15 +131,17 @@ export default function ProjectsList({
       if (rows.length === 1) {
         const { projectName } = rows[0];
         if (setAsDefaultRef.current) {
+          telemetry.track({ name: 'projectList.setAsDefault', trigger: 'keyboard' });
           setRememberedProject(projectName);
         }
         onProjectSelect?.(projectName);
         navigate(`/projects/${projectName}`);
       } else if (rows.length > 1) {
+        telemetry.track({ name: 'projectList.searchEnterPressed' });
         tableContainerRef.current?.querySelector<HTMLElement>('ui5-link')?.focus();
       }
     },
-    [rows, navigate, onProjectSelect, setRememberedProject],
+    [rows, navigate, onProjectSelect, setRememberedProject, telemetry],
   );
 
   const columns: AnalyticalTableColumnDefinition[] = useMemo(
@@ -155,7 +159,9 @@ export default function ProjectsList({
                 onClick={() => {
                   if (setAsDefaultRef.current) {
                     setRememberedProject(projectName);
+                    telemetry.track({ name: 'projectList.setAsDefault', trigger: 'click' });
                   }
+                  telemetry.track({ name: 'projectList.navigated', trigger: 'click' });
                   onProjectSelect?.(projectName);
                   navigate(`/projects/${projectName}`);
                 }}
@@ -233,7 +239,7 @@ export default function ProjectsList({
         ),
       },
     ],
-    [navigate, useProjectMembers, onProjectSelect, setRememberedProject],
+    [navigate, useProjectMembers, onProjectSelect, setRememberedProject, telemetry],
   );
 
   if (isLoading) {

--- a/src/components/Projects/ProjectsList.tsx
+++ b/src/components/Projects/ProjectsList.tsx
@@ -8,7 +8,7 @@ import {
 
 import '@ui5/webcomponents-icons/dist/copy';
 import { t } from 'i18next';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRememberedProject } from '../../hooks/useRememberedProject.ts';
 import { useProjectMembers as _useProjectMembers } from '../../spaces/onboarding/hooks/useProjectMembers';
 import { useProjectsQuery as _useProjectsQuery } from '../../spaces/onboarding/hooks/useProjectsQuery';
@@ -121,6 +121,25 @@ export default function ProjectsList({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data, search, displayNamesVersion]);
 
+  const tableContainerRef = useRef<HTMLDivElement>(null);
+
+  const handleSearchKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key !== 'Enter') return;
+      if (rows.length === 1) {
+        const { projectName } = rows[0];
+        if (setAsDefaultRef.current) {
+          setRememberedProject(projectName);
+        }
+        onProjectSelect?.(projectName);
+        navigate(`/projects/${projectName}`);
+      } else if (rows.length > 1) {
+        tableContainerRef.current?.querySelector<HTMLElement>('ui5-link')?.focus();
+      }
+    },
+    [rows, navigate, onProjectSelect, setRememberedProject],
+  );
+
   const columns: AnalyticalTableColumnDefinition[] = useMemo(
     () => [
       {
@@ -226,21 +245,23 @@ export default function ProjectsList({
 
   return (
     <FadeIn>
-      <ResourceSearchBar value={search} onChange={setSearch} />
-      <AnalyticalTable
-        style={{
-          maxWidth: '1280px',
-          margin: '10px auto 0px auto',
-          width: '100%',
-          borderRadius: '12px',
-          overflow: 'hidden',
-        }}
-        sortable
-        className={styles.table}
-        columns={columns}
-        data={rows}
-        minRows={10}
-      />
+      <ResourceSearchBar focusOnMount value={search} onChange={setSearch} onKeyDown={handleSearchKeyDown} />
+      <div ref={tableContainerRef}>
+        <AnalyticalTable
+          style={{
+            maxWidth: '1280px',
+            margin: '10px auto 0px auto',
+            width: '100%',
+            borderRadius: '12px',
+            overflow: 'hidden',
+          }}
+          sortable
+          className={styles.table}
+          columns={columns}
+          data={rows}
+          minRows={10}
+        />
+      </div>
       <div
         style={{
           maxWidth: '1280px',

--- a/src/components/Projects/ProjectsList.tsx
+++ b/src/components/Projects/ProjectsList.tsx
@@ -27,8 +27,17 @@ function getProjectName(instance: { cell: { row: { original: unknown } } }): str
   return (instance.cell.row.original as ProjectListRow).projectName;
 }
 
-function CreatedAtCell({ projectName }: { projectName: string }) {
-  const { creationTimestamp, isLoading } = _useProjectMembers(projectName);
+function CreatedAtCell({
+  projectName,
+  onTimestamp,
+  useProjectMembers,
+}: {
+  projectName: string;
+  onTimestamp: (name: string, ts: string) => void;
+  useProjectMembers: typeof _useProjectMembers;
+}) {
+  const { creationTimestamp, isLoading } = useProjectMembers(projectName);
+  if (!isLoading && creationTimestamp) onTimestamp(projectName, creationTimestamp);
   if (isLoading || !creationTimestamp) return null;
   return (
     <FadeIn>
@@ -63,9 +72,14 @@ export default function ProjectsList({
 }: Props = {}) {
   const navigate = useLuigiNavigate();
   const { data, error, isLoading } = useProjectsQuery();
+  const timestampsRef = useRef<Map<string, string>>(new Map());
   const displayNamesRef = useRef<Map<string, string>>(new Map());
   const [search, setSearch] = useState('');
   const [displayNamesVersion, setDisplayNamesVersion] = useState(0);
+
+  const handleTimestamp = (name: string, ts: string) => {
+    timestampsRef.current.set(name, ts);
+  };
 
   const handleDisplayName = (name: string, displayName: string) => {
     if (displayNamesRef.current.get(name) === displayName) return;
@@ -151,7 +165,13 @@ export default function ProjectsList({
         disableSortBy: true,
         responsivePopIn: true,
         responsiveMinWidth: 1200,
-        Cell: (instance) => <CreatedAtCell projectName={getProjectName(instance)} />,
+        Cell: (instance) => (
+          <CreatedAtCell
+            projectName={getProjectName(instance)}
+            useProjectMembers={useProjectMembers}
+            onTimestamp={handleTimestamp}
+          />
+        ),
       },
       {
         Header: t('ProjectsListView.membersHeader'),

--- a/src/components/Projects/ProjectsList.tsx
+++ b/src/components/Projects/ProjectsList.tsx
@@ -131,13 +131,13 @@ export default function ProjectsList({
       if (rows.length === 1) {
         const { projectName } = rows[0];
         if (setAsDefaultRef.current) {
-          telemetry.track({ name: 'projectList.setAsDefault', trigger: 'keyboard' });
+          telemetry.track({ name: 'project-list.set-as-default', trigger: 'keyboard' });
           setRememberedProject(projectName);
         }
         onProjectSelect?.(projectName);
         navigate(`/projects/${projectName}`);
       } else if (rows.length > 1) {
-        telemetry.track({ name: 'projectList.searchEnterPressed' });
+        telemetry.track({ name: 'project-list.search-enter-pressed' });
         tableContainerRef.current?.querySelector<HTMLElement>('ui5-link')?.focus();
       }
     },
@@ -159,9 +159,9 @@ export default function ProjectsList({
                 onClick={() => {
                   if (setAsDefaultRef.current) {
                     setRememberedProject(projectName);
-                    telemetry.track({ name: 'projectList.setAsDefault', trigger: 'click' });
+                    telemetry.track({ name: 'project-list.set-as-default', trigger: 'click' });
                   }
-                  telemetry.track({ name: 'projectList.navigated', trigger: 'click' });
+                  telemetry.track({ name: 'project-list.navigated', trigger: 'click' });
                   onProjectSelect?.(projectName);
                   navigate(`/projects/${projectName}`);
                 }}

--- a/src/components/Shared/ResourceSearchBar.module.css
+++ b/src/components/Shared/ResourceSearchBar.module.css
@@ -1,0 +1,11 @@
+.wrapper {
+  max-width: 1280px;
+  margin: 10px auto 0 auto;
+  width: 100%;
+  padding: 0 0 0.75rem 0;
+}
+
+.input {
+  width: 20rem;
+  max-width: 100%;
+}

--- a/src/components/Shared/ResourceSearchBar.tsx
+++ b/src/components/Shared/ResourceSearchBar.tsx
@@ -1,0 +1,25 @@
+import { Icon, Input, InputDomRef, Ui5CustomEvent } from '@ui5/webcomponents-react';
+import '@ui5/webcomponents-icons/dist/search';
+import { useTranslation } from 'react-i18next';
+import styles from './ResourceSearchBar.module.css';
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function ResourceSearchBar({ value, onChange }: Props) {
+  const { t } = useTranslation();
+  return (
+    <div className={styles.wrapper}>
+      <Input
+        className={styles.input}
+        icon={<Icon name="search" />}
+        placeholder={t('ResourceSearchBar.placeholder')}
+        showClearIcon
+        value={value}
+        onInput={(e: Ui5CustomEvent<InputDomRef, never>) => onChange(e.target.value)}
+      />
+    </div>
+  );
+}

--- a/src/components/Shared/ResourceSearchBar.tsx
+++ b/src/components/Shared/ResourceSearchBar.tsx
@@ -1,5 +1,5 @@
-import { Icon, Input, InputDomRef, Ui5CustomEvent } from '@ui5/webcomponents-react';
 import '@ui5/webcomponents-icons/dist/search';
+import { Icon, Input, InputDomRef, Ui5CustomEvent } from '@ui5/webcomponents-react';
 import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from './ResourceSearchBar.module.css';
@@ -19,11 +19,11 @@ export function ResourceSearchBar({ focusOnMount, onChange, onKeyDown, value }: 
     if (focusOnMount) {
       inputRef.current?.focus();
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
-    <div className={styles.wrapper} onKeyDown={onKeyDown}>
+    <div className={styles.wrapper}>
       <Input
         ref={inputRef}
         className={styles.input}
@@ -32,6 +32,7 @@ export function ResourceSearchBar({ focusOnMount, onChange, onKeyDown, value }: 
         showClearIcon
         value={value}
         onInput={(e: Ui5CustomEvent<InputDomRef, never>) => onChange(e.target.value)}
+        onKeyDown={onKeyDown}
       />
     </div>
   );

--- a/src/components/Shared/ResourceSearchBar.tsx
+++ b/src/components/Shared/ResourceSearchBar.tsx
@@ -1,18 +1,31 @@
 import { Icon, Input, InputDomRef, Ui5CustomEvent } from '@ui5/webcomponents-react';
 import '@ui5/webcomponents-icons/dist/search';
+import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from './ResourceSearchBar.module.css';
 
 interface Props {
-  value: string;
+  focusOnMount?: boolean;
   onChange: (value: string) => void;
+  onKeyDown?: (e: React.KeyboardEvent) => void;
+  value: string;
 }
 
-export function ResourceSearchBar({ value, onChange }: Props) {
+export function ResourceSearchBar({ focusOnMount, onChange, onKeyDown, value }: Props) {
   const { t } = useTranslation();
+  const inputRef = useRef<InputDomRef>(null);
+
+  useEffect(() => {
+    if (focusOnMount) {
+      inputRef.current?.focus();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
-    <div className={styles.wrapper}>
+    <div className={styles.wrapper} onKeyDown={onKeyDown}>
       <Input
+        ref={inputRef}
         className={styles.input}
         icon={<Icon name="search" />}
         placeholder={t('ResourceSearchBar.placeholder')}

--- a/src/lib/telemetry/features.ts
+++ b/src/lib/telemetry/features.ts
@@ -10,6 +10,6 @@ export type TelemetryFeature =
   | Feature<'kubeconfig.copied'>
   | Feature<'kubeconfig.downloaded'>
   | Feature<'mcp.connected', { idp: 'system' | 'custom' }>
-  | Feature<'projectList.navigated', { trigger: 'click' | 'keyboard' }>
-  | Feature<'projectList.setAsDefault', { trigger: 'click' | 'keyboard' }>
-  | Feature<'projectList.searchEnterPressed'>;
+  | Feature<'project-list.navigated', { trigger: 'click' | 'keyboard' }>
+  | Feature<'project-list.set-as-default', { trigger: 'click' | 'keyboard' }>
+  | Feature<'project-list.search-enter-pressed'>;

--- a/src/lib/telemetry/features.ts
+++ b/src/lib/telemetry/features.ts
@@ -9,4 +9,7 @@ type Feature<N extends string, P extends Record<string, string> = {}> = { name: 
 export type TelemetryFeature =
   | Feature<'kubeconfig.copied'>
   | Feature<'kubeconfig.downloaded'>
-  | Feature<'mcp.connected', { idp: 'system' | 'custom' }>;
+  | Feature<'mcp.connected', { idp: 'system' | 'custom' }>
+  | Feature<'projectList.navigated', { trigger: 'click' | 'keyboard' }>
+  | Feature<'projectList.setAsDefault', { trigger: 'click' | 'keyboard' }>
+  | Feature<'projectList.searchEnterPressed'>;


### PR DESCRIPTION

<img width="1187" height="238" alt="image" src="https://github.com/user-attachments/assets/8c41aed5-fe40-4823-816e-7205fc3d0243" />


## Summary

- Adds a text search input above the project list that filters rows by **project name** and **display name**
- Display names are collected via per-row cell callbacks (same pattern as date sorting) — no extra bulk query needed
- Introduces a reusable `ResourceSearchBar` component in `src/components/Shared/` for future reuse on the workspace grid page
- Cypress component tests cover: empty query, name filter, display name filter, case-insensitivity, no-match

## Test plan

- [ ] Run `npm run test:cy -- --spec 'src/components/Projects/ProjectsList.cy.tsx'` — all 5 tests pass
- [ ] Open project list in browser, type a project name or display name — list filters live
- [ ] Clear search — all projects return