### PR TITLE
chore: add cypress/screenshots to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ public/frontend-config.json
 .ctf/
 
 .claude/settings.local.json
+
+# Cypress
+cypress/screenshots/


### PR DESCRIPTION
## Summary

- Adds `cypress/screenshots/` to `.gitignore` to prevent test failure screenshots from being accidentally committed.