### PR TITLE
Adjust react routes to OpenControlPlane naming convention

### DIFF
--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -1,5 +1,6 @@
 import { Navigate, Route, HashRouter as Router } from 'react-router-dom';
 import GlobalProviderOutlet from './components/Core/ApiConfigWrapper.tsx';
+import { ParamRedirect } from './components/Core/ParamRedirect.tsx';
 import { ShellBarComponent } from './components/Core/ShellBar.tsx';
 import { SearchParamToggleVisibility } from './components/Helper/FeatureToggleExistance.tsx';
 import { SplitterProvider } from './components/Splitter/SplitterContext.tsx';
@@ -28,24 +29,62 @@ function AppRouter() {
         <SplitterLayout>
           <Router>
             <SentryRoutes>
-              <Route path="/mcp" element={<GlobalProviderOutlet />}>
+              <Route element={<GlobalProviderOutlet />}>
                 <Route path="projects" element={<ProjectListView />} />
                 <Route path="projects/:projectName" element={<ProjectPage />} />
                 <Route
-                  path="projects/:projectName/workspaces/:workspaceName/mcpsv2/:controlPlaneName"
+                  path="projects/:projectName/workspaces/:workspaceName/controlplane/:controlPlaneName"
                   element={<McpPageV2 />}
                 />
                 <Route
-                  path="projects/:projectName/workspaces/:workspaceName/mcpsv2/:controlPlaneName/headlamp"
+                  path="projects/:projectName/workspaces/:workspaceName/controlplane/:controlPlaneName/headlamp"
                   element={<HeadlampPage />}
                 />
                 <Route
-                  path="projects/:projectName/workspaces/:workspaceName/mcps/:controlPlaneName"
+                  path="projects/:projectName/workspaces/:workspaceName/managedcontrolplane/:controlPlaneName"
                   element={<McpPage />}
                 />
               </Route>
-              <Route path="/" element={<Navigate to="/mcp/projects" />} />
-              <Route path="*" element={<Navigate to="/" />} />
+
+              {/* backward-compat: /mcp prefix + old segment names */}
+              <Route path="/mcp/projects" element={<Navigate to="/projects" replace />} />
+              <Route
+                path="/mcp/projects/:projectName"
+                element={<ParamRedirect to={({ projectName }) => `/projects/${projectName}`} />}
+              />
+              <Route
+                path="/mcp/projects/:projectName/workspaces/:workspaceName/mcpsv2/:controlPlaneName"
+                element={
+                  <ParamRedirect
+                    to={({ projectName, workspaceName, controlPlaneName }) =>
+                      `/projects/${projectName}/workspaces/${workspaceName}/controlplane/${controlPlaneName}`
+                    }
+                  />
+                }
+              />
+              <Route
+                path="/mcp/projects/:projectName/workspaces/:workspaceName/mcpsv2/:controlPlaneName/headlamp"
+                element={
+                  <ParamRedirect
+                    to={({ projectName, workspaceName, controlPlaneName }) =>
+                      `/projects/${projectName}/workspaces/${workspaceName}/controlplane/${controlPlaneName}/headlamp`
+                    }
+                  />
+                }
+              />
+              <Route
+                path="/mcp/projects/:projectName/workspaces/:workspaceName/mcps/:controlPlaneName"
+                element={
+                  <ParamRedirect
+                    to={({ projectName, workspaceName, controlPlaneName }) =>
+                      `/projects/${projectName}/workspaces/${workspaceName}/managedcontrolplane/${controlPlaneName}`
+                    }
+                  />
+                }
+              />
+
+              <Route path="/" element={<Navigate to="/projects" replace />} />
+              <Route path="*" element={<Navigate to="/" replace />} />
             </SentryRoutes>
           </Router>
         </SplitterLayout>

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -47,6 +47,7 @@ function AppRouter() {
               </Route>
 
               {/* backward-compat: /mcp prefix + old segment names */}
+              <Route path="/mcp" element={<Navigate to="/projects" replace />} />
               <Route path="/mcp/projects" element={<Navigate to="/projects" replace />} />
               <Route
                 path="/mcp/projects/:projectName"

--- a/src/Routes.ts
+++ b/src/Routes.ts
@@ -3,4 +3,5 @@ export const Routes = {
   Projects: '/projects',
   Project: '/projects/:projectName',
   Mcp: '/projects/:projectName/workspaces/:workspaceName/managedcontrolplane/:controlPlaneName',
+  McpV2: '/projects/:projectName/workspaces/:workspaceName/controlplane/:controlPlaneName',
 } as const;

--- a/src/Routes.ts
+++ b/src/Routes.ts
@@ -1,6 +1,6 @@
 export const Routes = {
   Home: '/',
-  Projects: '/mcp/projects',
-  Project: '/mcp/projects/:projectName',
-  Mcp: '/mcp/projects/:projectName/workspaces/:workspaceName/mcps/:controlPlaneName',
+  Projects: '/projects',
+  Project: '/projects/:projectName',
+  Mcp: '/projects/:projectName/workspaces/:workspaceName/managedcontrolplane/:controlPlaneName',
 } as const;

--- a/src/common/auth/getRedirectSuffix.ts
+++ b/src/common/auth/getRedirectSuffix.ts
@@ -3,10 +3,10 @@
  *
  * @example
  * ```ts
- * // Current URL: https://example.com/?sap-theme=sap_horizon#/mcp/projects
+ * // Current URL: https://example.com/?sap-theme=sap_horizon#/projects
  *
  * const redirectTo = getRedirectSuffix();
- * // redirectTo -> "/?sap-theme=sap_horizon#/mcp/projects"
+ * // redirectTo -> "/?sap-theme=sap_horizon#/projects"
  * ```
  */
 export function getRedirectSuffix() {

--- a/src/components/ControlPlanes/ConnectButton/ConnectButton.cy.tsx
+++ b/src/components/ControlPlanes/ConnectButton/ConnectButton.cy.tsx
@@ -92,7 +92,7 @@ describe('ConnectButton', () => {
     cy.get('@navigateSpy').should('have.been.calledOnce');
     cy.get('@navigateSpy').should(
       'have.been.calledWith',
-      '/mcp/projects/my-project/workspaces/my-workspace/mcps/my-mcp',
+      '/projects/my-project/workspaces/my-workspace/managedcontrolplane/my-mcp',
     );
   });
 
@@ -120,7 +120,7 @@ describe('ConnectButton', () => {
     cy.get('@navigateSpy').should('have.been.calledOnce');
     cy.get('@navigateSpy').should(
       'have.been.calledWith',
-      '/mcp/projects/my-project/workspaces/my-workspace/mcps/my-mcp?idp=custom-user',
+      '/projects/my-project/workspaces/my-workspace/managedcontrolplane/my-mcp?idp=custom-user',
     );
   });
 
@@ -156,7 +156,7 @@ describe('ConnectButton', () => {
     cy.get('@navigateSpy').should('have.been.calledOnce');
     cy.get('@navigateSpy').should(
       'have.been.calledWith',
-      '/mcp/projects/my-project/workspaces/my-workspace/mcps/my-mcp',
+      '/projects/my-project/workspaces/my-workspace/managedcontrolplane/my-mcp',
     );
 
     // Reset spy for next assertion
@@ -168,7 +168,7 @@ describe('ConnectButton', () => {
     cy.get('@navigateSpy').should('have.been.calledOnce');
     cy.get('@navigateSpy').should(
       'have.been.calledWith',
-      '/mcp/projects/my-project/workspaces/my-workspace/mcps/my-mcp?idp=custom-user',
+      '/projects/my-project/workspaces/my-workspace/managedcontrolplane/my-mcp?idp=custom-user',
     );
   });
 

--- a/src/components/ControlPlanes/ConnectButton/ConnectButtonV2.tsx
+++ b/src/components/ControlPlanes/ConnectButton/ConnectButtonV2.tsx
@@ -25,7 +25,7 @@ export default function ConnectButtonV2({
   return (
     <Button
       endIcon="navigation-right-arrow"
-      onClick={() => navigate(`/mcp/projects/${projectName}/workspaces/${workspaceName}/mcpsv2/${controlPlaneName}`)}
+      onClick={() => navigate(`/projects/${projectName}/workspaces/${workspaceName}/controlplane/${controlPlaneName}`)}
     >
       {t('ConnectButton.buttonText')}
     </Button>

--- a/src/components/ControlPlanes/ConnectButton/ConnectButtonV2.tsx
+++ b/src/components/ControlPlanes/ConnectButton/ConnectButtonV2.tsx
@@ -1,9 +1,9 @@
 import { Button } from '@ui5/webcomponents-react';
 
 import { useTranslation } from 'react-i18next';
-import { useNavigate as _useNavigate } from 'react-router-dom';
+import { generatePath, useNavigate as _useNavigate } from 'react-router-dom';
 
-import { useApiResource as _useApiResource } from '../../../lib/api/useApiResource.ts';
+import { Routes } from '../../../Routes.ts';
 
 interface ConnectButtonProps {
   projectName: string;
@@ -25,7 +25,7 @@ export default function ConnectButtonV2({
   return (
     <Button
       endIcon="navigation-right-arrow"
-      onClick={() => navigate(`/projects/${projectName}/workspaces/${workspaceName}/controlplane/${controlPlaneName}`)}
+      onClick={() => navigate(generatePath(Routes.McpV2, { projectName, workspaceName, controlPlaneName }))}
     >
       {t('ConnectButton.buttonText')}
     </Button>

--- a/src/components/ControlPlanes/ConnectButton/useConnectOptions.spec.ts
+++ b/src/components/ControlPlanes/ConnectButton/useConnectOptions.spec.ts
@@ -34,7 +34,7 @@ contexts:
       name: 'context-system',
       user: 'openmcp',
       isSystemIdP: true,
-      url: '/mcp/projects/test-project/workspaces/test-workspace/mcps/test-mcp',
+      url: '/projects/test-project/workspaces/test-workspace/managedcontrolplane/test-mcp',
     });
   });
 
@@ -87,15 +87,19 @@ contexts:
       name: 'context-system',
       user: 'openmcp',
       isSystemIdP: true,
-      url: '/mcp/projects/test-project/workspaces/test-workspace/mcps/test-mcp',
+      url: '/projects/test-project/workspaces/test-workspace/managedcontrolplane/test-mcp',
     });
 
     const customOptions = options.filter((o) => !o.isSystemIdP);
     expect(customOptions).toHaveLength(2);
     expect(customOptions[0].user).toBe('user-a');
-    expect(customOptions[0].url).toBe('/mcp/projects/test-project/workspaces/test-workspace/mcps/test-mcp?idp=user-a');
+    expect(customOptions[0].url).toBe(
+      '/projects/test-project/workspaces/test-workspace/managedcontrolplane/test-mcp?idp=user-a',
+    );
     expect(customOptions[1].user).toBe('user-b');
-    expect(customOptions[1].url).toBe('/mcp/projects/test-project/workspaces/test-workspace/mcps/test-mcp?idp=user-b');
+    expect(customOptions[1].url).toBe(
+      '/projects/test-project/workspaces/test-workspace/managedcontrolplane/test-mcp?idp=user-b',
+    );
   });
 
   it('should handle kubeconfig without system IdP', () => {
@@ -116,7 +120,7 @@ contexts:
     expect(result.current[0].isSystemIdP).toBe(false);
     expect(result.current[0].user).toBe('custom-user');
     expect(result.current[0].url).toBe(
-      '/mcp/projects/test-project/workspaces/test-workspace/mcps/test-mcp?idp=custom-user',
+      '/projects/test-project/workspaces/test-workspace/managedcontrolplane/test-mcp?idp=custom-user',
     );
   });
 

--- a/src/components/ControlPlanes/ConnectButton/useConnectOptions.ts
+++ b/src/components/ControlPlanes/ConnectButton/useConnectOptions.ts
@@ -22,7 +22,7 @@ function extractWorkspaceNameFromNamespace(namespace: string): string {
 
 function buildMcpUrl(projectName: string, workspaceName: string, controlPlaneName: string, idp?: string): string {
   const normalizedWorkspace = extractWorkspaceNameFromNamespace(workspaceName);
-  const basePath = `/mcp/projects/${projectName}/workspaces/${normalizedWorkspace}/mcps/${controlPlaneName}`;
+  const basePath = `/projects/${projectName}/workspaces/${normalizedWorkspace}/managedcontrolplane/${controlPlaneName}`;
   return idp ? `${basePath}?idp=${encodeURIComponent(idp)}` : basePath;
 }
 

--- a/src/components/Core/ParamRedirect.tsx
+++ b/src/components/Core/ParamRedirect.tsx
@@ -1,0 +1,10 @@
+import { Navigate, useParams } from 'react-router-dom';
+
+interface ParamRedirectProps {
+  to: (params: Record<string, string>) => string;
+}
+
+export function ParamRedirect({ to }: ParamRedirectProps) {
+  const params = useParams();
+  return <Navigate to={to(params as Record<string, string>)} replace />;
+}

--- a/src/components/Core/ParamRedirect.tsx
+++ b/src/components/Core/ParamRedirect.tsx
@@ -6,5 +6,8 @@ interface ParamRedirectProps {
 
 export function ParamRedirect({ to }: ParamRedirectProps) {
   const params = useParams();
+  if (Object.values(params).some((v) => v === undefined)) {
+    return <Navigate to="/projects" replace />;
+  }
   return <Navigate to={to(params as Record<string, string>)} replace />;
 }

--- a/src/components/Core/PathAwareBreadcrumbs/PathAwareBreadcrumbs.cy.tsx
+++ b/src/components/Core/PathAwareBreadcrumbs/PathAwareBreadcrumbs.cy.tsx
@@ -32,19 +32,19 @@ describe('PathAwareBreadcrumbs', () => {
     // Navigate to projects list with noRedirect param
     cy.contains('[LOCAL] Projects').click();
     cy.wrap(null).then(() => {
-      expect(lastNavigatedPath).to.equal('/mcp/projects?noRedirect=true');
+      expect(lastNavigatedPath).to.equal('/projects?noRedirect=true');
     });
 
     // Click on 'my-project' > Navigate to 'my-project'
     cy.contains('my-project').click();
     cy.wrap(null).then(() => {
-      expect(lastNavigatedPath).to.equal('/mcp/projects/my-project');
+      expect(lastNavigatedPath).to.equal('/projects/my-project');
     });
 
     // Click on 'my-workspace' > Navigate to 'my-project' since workspaces don’t expose a direct path
     cy.contains('my-workspace').click();
     cy.wrap(null).then(() => {
-      expect(lastNavigatedPath).to.equal('/mcp/projects/my-project');
+      expect(lastNavigatedPath).to.equal('/projects/my-project');
     });
   });
 

--- a/src/components/Projects/ProjectChooser.tsx
+++ b/src/components/Projects/ProjectChooser.tsx
@@ -26,7 +26,7 @@ export default function ProjectChooser({ currentProjectName }: Props) {
         closeOnItemSelect
         placement="Bottom"
         onSelect={(e) => {
-          navigate(`/mcp/projects/${e.detail.selectedVariant.children}`);
+          navigate(`/projects/${e.detail.selectedVariant.children}`);
         }}
       >
         {data?.map((p) => (

--- a/src/components/Projects/ProjectsList.tsx
+++ b/src/components/Projects/ProjectsList.tsx
@@ -105,7 +105,7 @@ export default function ProjectsList({
                     setRememberedProject(projectName);
                   }
                   onProjectSelect?.(projectName);
-                  navigate(`/mcp/projects/${projectName}`);
+                  navigate(`/projects/${projectName}`);
                 }}
               >
                 {projectName}

--- a/src/components/Ui/NotFoundBanner/NotFoundBanner.cy.tsx
+++ b/src/components/Ui/NotFoundBanner/NotFoundBanner.cy.tsx
@@ -20,9 +20,9 @@ describe('<NotFoundBanner />', () => {
         <Routes>
           <Route
             path="/not-found"
-            element={<NotFoundBanner entityType="Project" homePath="/mcp/projects?noRedirect=true" />}
+            element={<NotFoundBanner entityType="Project" homePath="/projects?noRedirect=true" />}
           />
-          <Route path="/mcp/projects" element={<div data-testid="projects-page" />} />
+          <Route path="/projects" element={<div data-testid="projects-page" />} />
         </Routes>
       </MemoryRouter>,
     );

--- a/src/spaces/onboarding/pages/ProjectPage.spec.tsx
+++ b/src/spaces/onboarding/pages/ProjectPage.spec.tsx
@@ -73,9 +73,9 @@ const NOT_FOUND_ERROR = new APIError('not found', 404);
 
 const renderPage = (projectName = 'deleted-project') =>
   render(
-    <MemoryRouter initialEntries={[`/mcp/projects/${projectName}`]}>
+    <MemoryRouter initialEntries={[`/projects/${projectName}`]}>
       <Routes>
-        <Route path="/mcp/projects/:projectName" element={<ProjectPage />} />
+        <Route path="/projects/:projectName" element={<ProjectPage />} />
       </Routes>
     </MemoryRouter>,
   );
@@ -113,7 +113,7 @@ describe('ProjectPage', () => {
     const { getByTestId } = renderPage('deleted-project');
 
     const homePath = getByTestId('not-found-banner').getAttribute('data-home-path');
-    expect(homePath).toBe('/mcp/projects?noRedirect=true');
+    expect(homePath).toBe('/projects?noRedirect=true');
   });
 
   it('does not clear the remembered project when a different project returns 404', () => {

--- a/src/views/ProjectList.spec.tsx
+++ b/src/views/ProjectList.spec.tsx
@@ -65,7 +65,7 @@ describe('ProjectsListView', () => {
       setRememberedProject('my-project');
       renderView();
 
-      expect(mockNavigate).toHaveBeenCalledWith('/mcp/projects/my-project', { replace: true });
+      expect(mockNavigate).toHaveBeenCalledWith('/projects/my-project', { replace: true });
     });
 
     it('does not redirect when no project is remembered', () => {


### PR DESCRIPTION
**What this PR does / why we need it**:
Renames frontend routes to align with OpenControlPlane (OCP) terminology. The /mcp prefix is dropped and segment names are updated: 
mcps → managedcontrolplane, 
mcpsv2/controlplane → controlplane. 

A new ParamRedirect component plus a set of backward-compatibility routes preserve old links by redirecting them (with replace) to the new paths. 
