### PR TITLE
fix(test): stabilize CreateManagedControlPlane wizard test — eliminate key ordering flakiness

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,7 +1,15 @@
 import '@ui5/webcomponents-cypress-commands';
 import '../../src/utils/i18n/i18n';
 
-const toPlain = <T>(o: T): T => JSON.parse(JSON.stringify(o));
+// Sort object keys recursively so deep equality is key-order-insensitive
+const toPlain = <T>(o: T): T => {
+  const json = JSON.stringify(o, (_, v) =>
+    v && typeof v === 'object' && !Array.isArray(v)
+      ? Object.fromEntries(Object.entries(v).sort(([a], [b]) => a.localeCompare(b)))
+      : v,
+  );
+  return JSON.parse(json) as T;
+};
 
 Cypress.Commands.add('deepEqualJson', { prevSubject: true }, (subject, expected) => {
   expect(toPlain(subject)).to.deep.equal(toPlain(expected));


### PR DESCRIPTION
## Summary

- `deepEqualJson` was failing intermittently because the `components` object in the MCP spec was serialized with non-deterministic key order (e.g. `flux` before `apiServer`, or vice versa), causing deep equality to fail even though the data was semantically identical.
- Fixed by recursively sorting all object keys before comparison in the `toPlain` helper inside `cypress/support/commands.ts`.

## Root cause

Observed in CI run https://github.com/openmcp-project/ui-frontend/actions/runs/28110045432/job/83234674874?pr=648:

```
- components: { flux: [Object], apiServer: [Object], crossplane: [Object] },
+ components: { apiServer: [Object], flux: [Object], crossplane: [Object] },
```

The `CreateManagedControlPlaneWizardContainer` tests (`creates an MCP with installed components, members, and optional fields` and `edits an existing MCP with changes`) both failed because of this ordering difference.

## Fix

```ts
const toPlain = <T>(o: T): T => {
  const json = JSON.stringify(o, (_, v) =>
    v && typeof v === 'object' && !Array.isArray(v)
      ? Object.fromEntries(Object.entries(v).sort(([a], [b]) => a.localeCompare(b)))
      : v,
  );
  return JSON.parse(json) as T;
};
```

`JSON.stringify`'s replacer normalizes every plain object's keys into alphabetical order before serialization, making `deepEqualJson` key-order-insensitive.

## Test plan

- [ ] Confirm the two previously-failing Cypress component tests now pass in CI