### PR TITLE
chore: rename kiosk plugin references to opencontrolplane

### DIFF
--- a/scripts/deploy-headlamp-plugins.sh
+++ b/scripts/deploy-headlamp-plugins.sh
@@ -22,13 +22,13 @@ kubectl --context "$CONTEXT" cp "${ROOT_DIR}/../crossplane-headlamp-plugin/dist/
 kubectl --context "$CONTEXT" cp "${ROOT_DIR}/../crossplane-headlamp-plugin/package.json" "${NAMESPACE}/${POD}:/headlamp/plugins/headlamp_crossplane/package.json"
 echo "✓ crossplane plugin deployed"
 
-echo "→ building kiosk plugin..."
-(cd "${ROOT_DIR}/../kiosk-headlamp-plugin" && npm run build 2>&1 | tail -3)
+echo "→ building ocp plugin..."
+(cd "${ROOT_DIR}/../opencontrolplane-headlamp-plugin" && npm run build 2>&1 | tail -3)
 
-echo "→ syncing to pod ${POD}:/headlamp/plugins/headlamp_kiosk/ ..."
-kubectl --context "$CONTEXT" cp "${ROOT_DIR}/../kiosk-headlamp-plugin/dist/main.js" "${NAMESPACE}/${POD}:/headlamp/plugins/headlamp_kiosk/main.js"
-kubectl --context "$CONTEXT" cp "${ROOT_DIR}/../kiosk-headlamp-plugin/package.json" "${NAMESPACE}/${POD}:/headlamp/plugins/headlamp_kiosk/package.json"
-echo "✓ kiosk plugin deployed"
+echo "→ syncing to pod ${POD}:/headlamp/plugins/opencontrolplane/ ..."
+kubectl --context "$CONTEXT" cp "${ROOT_DIR}/../opencontrolplane-headlamp-plugin/dist/main.js" "${NAMESPACE}/${POD}:/headlamp/plugins/opencontrolplane/main.js"
+kubectl --context "$CONTEXT" cp "${ROOT_DIR}/../opencontrolplane-headlamp-plugin/package.json" "${NAMESPACE}/${POD}:/headlamp/plugins/opencontrolplane/package.json"
+echo "✓ ocp plugin deployed"
 
 echo ""
 echo "✓ Plugins synced. Hard-refresh the browser to pick up changes."

--- a/scripts/setup-headlamp-dev.sh
+++ b/scripts/setup-headlamp-dev.sh
@@ -98,7 +98,8 @@ build_plugin() {
   plugin_name=$(node -e "process.stdout.write(require('${plugin_dir}/package.json').name)")
   plugin_version=$(node -e "process.stdout.write(require('${plugin_dir}/package.json').version)")
 
-  local cm_name="${name,,}-plugin"
+  local cm_name
+  cm_name="$(echo "${name}" | tr '[:upper:]' '[:lower:]')-plugin"
   echo "→ ${name}: writing ConfigMap ${output_yaml}..."
   python3 - "$output_yaml" "$cm_name" "$plugin_name" "$plugin_version" \
     "${plugin_dir}/package.json" "$main_js" << 'PYEOF'
@@ -130,7 +131,7 @@ PYEOF
   echo "  ✓ ${name} plugin built ($(du -sh "$main_js" | cut -f1) → ${output_yaml##*/})"
 }
 
-build_plugin "kiosk"      "${SCRIPT_DIR}/../../kiosk-headlamp-plugin"      "${SCRIPT_DIR}/configmap-kiosk-plugin.yaml"
+build_plugin "ocp"        "${SCRIPT_DIR}/../../opencontrolplane-headlamp-plugin" "${SCRIPT_DIR}/configmap-ocp-plugin.yaml"
 build_plugin "crossplane" "${SCRIPT_DIR}/../../crossplane-headlamp-plugin" "${SCRIPT_DIR}/configmap-crossplane-plugin.yaml"
 
 echo ""
@@ -163,7 +164,7 @@ echo ""
 # ── Namespace + plugin ConfigMaps ─────────────────────────────────────────────
 echo "── Deploying ConfigMaps ─────────────────────────────────────────────────────"
 kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
-kubectl apply -f "${SCRIPT_DIR}/configmap-kiosk-plugin.yaml"
+kubectl apply -f "${SCRIPT_DIR}/configmap-ocp-plugin.yaml"
 kubectl apply -f "${SCRIPT_DIR}/configmap-crossplane-plugin.yaml"
 echo ""
 
@@ -193,8 +194,8 @@ pluginsManager:
     plugins:
       - name: headlamp-flux
         source: https://artifacthub.io/packages/headlamp/headlamp-plugins/headlamp_flux
-      - name: headlamp-kiosk
-        source: https://artifacthub.io/packages/headlamp/kiosk-headlamp-plugin/headlamp_kiosk
+      - name: headlamp-ocp
+        source: https://artifacthub.io/packages/headlamp/opencontrolplane-headlamp-plugin/opencontrolplane
       - name: headlamp-crossplane
         source: https://artifacthub.io/packages/headlamp/crossplane-headlamp-plugin/headlamp_crossplane
 EOF


### PR DESCRIPTION
## Summary

- Updates `scripts/setup-headlamp-dev.sh` to build from `opencontrolplane-headlamp-plugin` (renamed repo), use `configmap-ocp-plugin.yaml`, and point the Helm pluginsManager source URL to the new ArtifactHub OCP plugin
- Updates `scripts/deploy-headlamp-plugins.sh` to build and sync from `opencontrolplane-headlamp-plugin` into the `opencontrolplane` plugin directory

## Test plan

- [ ] Run `task headlamp:dev` and confirm the OCP plugin loads correctly in the local kind cluster
- [ ] Run `task headlamp:update` and confirm hot-sync works