### PR TITLE
fix(monaco,csp): drop basic-languages YAML + allow blob: workers

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -147,6 +147,9 @@ fastify.addHook('onSend', async (req, reply, payload) => {
     isLocalDev
       ? `script-src 'self' 'unsafe-inline' 'unsafe-eval' ${sentryHost} ${dynatraceOrigin}`
       : `script-src 'self' ${sentryHost} ${dynatraceOrigin}`,
+    // Monaco workers are loaded via Vite's ?worker import, which materializes
+    // as blob: URLs at runtime. Without this they fall back to main-thread.
+    "worker-src 'self' blob:",
     "frame-src 'self'",
     `frame-ancestors 'self' ${frameAncestors}`,
     "base-uri 'self'",

--- a/src/lib/monaco.ts
+++ b/src/lib/monaco.ts
@@ -2,8 +2,6 @@
 import { loader } from '@monaco-editor/react';
 import * as monaco from 'monaco-editor';
 
-import 'monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution.js';
-
 import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
 
 import YamlWorker from 'monaco-yaml/yaml.worker?worker';


### PR DESCRIPTION
## Summary

Two small changes that together restore real web-worker execution for the YAML editor: stop registering the basic-languages YAML contribution (which collides with `monaco-yaml`'s worker), and add `worker-src 'self' blob:` to the BFF Content-Security-Policy so Vite's `?worker`-emitted blob URLs aren't rejected by Chrome. Without these, Monaco logs `Missing requestHandler` errors and falls back to running the worker code on the main thread — visible as a multi-second UI freeze whenever the YAML editor opens.

## What changed

- `src/lib/monaco.ts` — drop the `monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution.js` import. `monaco-yaml` already registers the YAML language and provides its own worker. The basic-languages contribution registers `DocumentSymbol` / `FoldingRange` / `DocumentLinks` providers that delegate to a *different* worker for the same language label, which produced `Missing requestHandler or method: findDocumentSymbols / getFoldingRanges / findLinks` errors at runtime.
- `server.ts` — append `worker-src 'self' blob:` to the BFF's `Content-Security-Policy`. **No other directive is changed.**

## Why

Vite's `?worker` import (used by `monaco-yaml` and Monaco's editor worker) materialises a worker module as a runtime-generated **blob: URL**. Chrome's default CSP doesn't allow `blob:` for `worker-src`, so without the directive the worker constructor throws, Monaco catches the error and logs:

> Could not create web worker(s). Falling back to loading web worker code in main thread, which might cause UI freezes.

…which is exactly what we were seeing on the YAML preview/copy path.

This is a **deliberate, narrowly-scoped CSP loosening**: it relaxes `worker-src` only, and only to `'self' blob:` (i.e. same-origin + Vite's runtime workers). `script-src`, `default-src`, `connect-src`, `style-src` etc. are untouched. The alternative — Vite-bundling the worker as a real same-origin URL — would require either ejecting from `?worker` to manual MonacoEnvironment wiring or relaxing `script-src 'unsafe-eval'`, both worse trade-offs.

## Test plan

- [ ] `npm run type-check`
- [ ] `npm run lint`
- [ ] `npm run test:vi`
- [ ] `npm run dev`, open an MCP, click a resource's YAML button: confirm **no** `Missing requestHandler` errors in the console.
- [ ] Same flow: confirm **no** `Could not create web worker(s). Falling back to loading web worker code in main thread` warning.
- [ ] Network tab → confirm a `blob:` worker request appears and is **not** blocked by CSP (no `Refused to create a worker from 'blob:...' because it violates the following Content Security Policy directive` errors).
- [ ] Open the YAML editor for a large resource (e.g. a CRD); confirm the main thread isn't pegged during open (DevTools Performance: scripting time on the main thread stays low).