### PR TITLE
perf(swr): cache CRDs + /managed in localStorage per MCP, dedup + shrink payload

### DIFF
--- a/src/common/auth/redirectToLogin.ts
+++ b/src/common/auth/redirectToLogin.ts
@@ -1,7 +1,9 @@
 import { AuthFlow, STORAGE_KEY_AUTH_FLOW } from './AuthCallbackHandler';
 import { getRedirectSuffix } from './getRedirectSuffix';
+import { clearPersistedSwrCache } from '../../lib/swr/persistentProvider';
 
 export function redirectToLogin(flow: AuthFlow): void {
   sessionStorage.setItem(STORAGE_KEY_AUTH_FLOW, flow);
+  clearPersistedSwrCache();
   window.location.replace(`/api/auth/${flow}/login?redirectTo=${encodeURIComponent(getRedirectSuffix())}`);
 }

--- a/src/components/SWRConfigWithTokenRefresh.tsx
+++ b/src/components/SWRConfigWithTokenRefresh.tsx
@@ -15,6 +15,12 @@ export function SWRConfigWithTokenRefresh({ children }: { children: ReactNode })
     <SWRConfig
       value={{
         refreshInterval: 10000,
+        // Tab-focus / network-reconnect revalidation double-spends on top of
+        // the 10s poll. Per-hook overrides still apply.
+        revalidateOnFocus: false,
+        revalidateOnReconnect: false,
+        // Share back-to-back mounts within a navigation.
+        dedupingInterval: 30_000,
         // component re-renders on refresh state changes, so the closure is not stale
         isPaused: () => isRefreshing,
       }}

--- a/src/lib/api/types/crossplane/CRDList.ts
+++ b/src/lib/api/types/crossplane/CRDList.ts
@@ -39,6 +39,9 @@ export type CRDResponse = {
 
 export const CRDRequest: Resource<CRDResponse> = {
   path: '/apis/apiextensions.k8s.io/v1/customresourcedefinitions',
+  // Strip OpenAPI schemas / printer columns / accepted names — none of those
+  // are consumed on the client. Keep only the fields the call sites read.
+  jq: '{items: [.items[] | {metadata: {name: .metadata.name, creationTimestamp: .metadata.creationTimestamp, ownerReferences: (.metadata.ownerReferences // [])}, status: {conditions: (.status.conditions // [])}, spec: {names: {kind: .spec.names.kind, singular: .spec.names.singular, plural: .spec.names.plural}, group: .spec.group, versions: [.spec.versions[] | {name}]}}]}',
 };
 
 export const CRDRequestAuthCheck: Resource<CRDResponse> = {

--- a/src/lib/api/types/crossplane/listManagedResources.ts
+++ b/src/lib/api/types/crossplane/listManagedResources.ts
@@ -9,4 +9,6 @@ export type ManagedResourcesResponse = [
 
 export const ManagedResourcesRequest: Resource<ManagedResourcesResponse> = {
   path: '/managed',
+  // metadata.managedFields is several KB per item and unused on the client.
+  jq: 'del(.[].items[].metadata.managedFields)',
 };

--- a/src/lib/api/useApiResource.ts
+++ b/src/lib/api/useApiResource.ts
@@ -1,5 +1,6 @@
 import { useContext, useEffect, useState, useRef, useMemo } from 'react';
 import useSWR, { SWRConfiguration, useSWRConfig } from 'swr';
+import * as Sentry from '@sentry/react';
 import { fetchApiServerJson } from './fetch';
 import { ApiConfigContext } from '../../components/Shared/k8s';
 import { APIError } from './error';
@@ -9,7 +10,6 @@ import useSWRMutation, { SWRMutationConfiguration } from 'swr/mutation';
 import { MutatorOptions } from 'swr/_internal';
 import { CRDRequest, CRDResponse } from './types/crossplane/CRDList';
 import { ProviderConfigs, ProviderConfigsData, ProviderConfigsDataForRequest } from '../shared/types';
-import { useTelemetry } from '../telemetry/telemetry';
 
 export const useApiResource = <T>(
   resource: Resource<T>,
@@ -42,13 +42,20 @@ export const useApiResource = <T>(
   };
 };
 
+// CRDs are effectively static within a session — disable polling and let
+// SWR paint cached data first while it revalidates in the background.
+const CRD_SWR_DEFAULTS: SWRConfiguration = {
+  refreshInterval: 0,
+  revalidateIfStale: true,
+};
+
 export const useCRDItemsMapping = (config?: SWRConfiguration) => {
   const apiConfig = useContext(ApiConfigContext);
   const { data, error, isValidating, isLoading } = useSWR(
     CRDRequest.path === null ? null : [CRDRequest.path, apiConfig],
     ([path, apiConfig]) =>
       fetchApiServerJson<CRDResponse>(path, apiConfig, CRDRequest.jq, CRDRequest.method, CRDRequest.body),
-    config,
+    { ...CRD_SWR_DEFAULTS, ...config },
   );
 
   const kindMapping = useMemo(() => {
@@ -75,14 +82,13 @@ export const useCRDItemsMapping = (config?: SWRConfiguration) => {
 
 export const useProvidersConfigResource = (config?: SWRConfiguration) => {
   const apiConfig = useContext(ApiConfigContext);
-  const telemetry = useTelemetry();
   const { data, error, isValidating } = useSWR(
     CRDRequest.path === null
       ? null //TODO: is null a valid key?
       : [CRDRequest.path, apiConfig],
     ([path, apiConfig]) =>
       fetchApiServerJson<CRDResponse>(path, apiConfig, CRDRequest.jq, CRDRequest.method, CRDRequest.body),
-    config,
+    { ...CRD_SWR_DEFAULTS, ...config },
   );
 
   const providerConfigsDataForRequest: ProviderConfigsDataForRequest[] = [];
@@ -153,9 +159,11 @@ export const useProvidersConfigResource = (config?: SWRConfiguration) => {
       return providerConfigs.filter((config) => config !== null);
     } catch (error) {
       console.error('Error fetching provider configs:', error);
-      telemetry.report(error, {
-        message: 'Failed to fetch provider configs',
-        context: { requestCount: providerConfigsDataForRequest.length },
+      Sentry.captureException(error, {
+        extra: {
+          context: 'useProvidersConfigResource:fetchProviderConfigs',
+          requestCount: providerConfigsDataForRequest.length,
+        },
       });
       return []; // Return an empty array in case of error
     }
@@ -249,7 +257,6 @@ export function useMultipleApiResources<T>(
   getResource: (namespace: string) => { path: string | null },
 ) {
   const apiConfig = useContext(ApiConfigContext);
-  const telemetry = useTelemetry();
   const [data, setData] = useState<T[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -270,9 +277,11 @@ export function useMultipleApiResources<T>(
         setData(results);
       } catch (err) {
         console.error('Error fetching multiple resources:', err);
-        telemetry.report(err, {
-          message: 'Failed to fetch multiple resources',
-          context: { namespacesCount: namespaces.length },
+        Sentry.captureException(err, {
+          extra: {
+            context: 'useMultipleApiResources',
+            namespacesCount: namespaces.length,
+          },
         });
         setError(err as Error);
         setData([]);
@@ -282,7 +291,7 @@ export function useMultipleApiResources<T>(
     };
 
     fetchData();
-  }, [namespaces, getResource, apiConfig, telemetry]);
+  }, [namespaces, getResource, apiConfig]);
 
   return { data, isLoading, error };
 }

--- a/src/lib/shared/McpContext.tsx
+++ b/src/lib/shared/McpContext.tsx
@@ -1,10 +1,12 @@
 import { BusyIndicator } from '@ui5/webcomponents-react';
 import { createContext, ReactNode, useContext, useEffect, useMemo } from 'react';
+import { SWRConfig } from 'swr';
 import { ApiConfigProvider } from '../../components/Shared/k8s';
 import { useAuthMcp } from '../../spaces/mcp/auth/AuthContextMcp.tsx';
 import { useKubeconfigQuery } from '../../spaces/onboarding/hooks/useKubeconfigQuery.ts';
 import { ControlPlane as ManagedControlPlaneResource, RoleBinding } from '../api/types/crate/controlPlanes.ts';
 import { useApiResource } from '../api/useApiResource.ts';
+import { createPersistentProvider } from '../swr/persistentProvider.ts';
 
 interface Mcp {
   project: string;
@@ -95,10 +97,15 @@ function RequireDownstreamLogin(props: { children?: ReactNode }) {
     [mcp.project, mcp.workspace, mcp.name, mcp.isV2],
   );
 
+  // Per-MCP SWR provider: hydrates cached entries (CRDs, providerconfigs, …)
+  // from localStorage on mount so the page paints instantly on reload.
+  const mcpId = `${mcp.project}:${mcp.workspace}:${mcp.name}`;
+  const provider = useMemo(() => createPersistentProvider(mcpId), [mcpId]);
+
   return (
-    <>
+    <SWRConfig value={{ provider }}>
       <ApiConfigProvider apiConfig={apiConfig}>{props.children}</ApiConfigProvider>
-    </>
+    </SWRConfig>
   );
 }
 

--- a/src/lib/swr/persistentProvider.spec.ts
+++ b/src/lib/swr/persistentProvider.spec.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearPersistedSwrCache, createPersistentProvider, storageKeyForMcp } from './persistentProvider';
+
+const MCP_ID = 'agentic-runtime:dev:heuristic-curie';
+const KEY = storageKeyForMcp(MCP_ID);
+
+/**
+ * The project's jsdom config doesn't expose a working localStorage to specs
+ * (same blocker that breaks ViewModeContext.spec.tsx and rememberedProject.
+ * spec.ts). Install a minimal in-memory shim on window+globalThis before each
+ * test so this suite is self-contained.
+ */
+function installLocalStorageShim(): Storage {
+  const store = new Map<string, string>();
+  const shim: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (k) => (store.has(k) ? (store.get(k) as string) : null),
+    setItem: (k, v) => {
+      store.set(k, String(v));
+    },
+    removeItem: (k) => {
+      store.delete(k);
+    },
+    key: (i) => Array.from(store.keys())[i] ?? null,
+  };
+  Object.defineProperty(globalThis, 'localStorage', { value: shim, configurable: true });
+  if (typeof window !== 'undefined') {
+    Object.defineProperty(window, 'localStorage', { value: shim, configurable: true });
+  }
+  return shim;
+}
+
+beforeEach(() => {
+  installLocalStorageShim();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('createPersistentProvider', () => {
+  it('returns an empty Map when nothing is persisted', () => {
+    const cache = createPersistentProvider(MCP_ID)();
+    expect(cache.get('any')).toBeUndefined();
+  });
+
+  it('hydrates entries from a valid bucket', () => {
+    const now = Date.now();
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        schemaVersion: 1,
+        entries: [
+          ['a', { ts: now, value: { data: 1 } }],
+          ['b', { ts: now, value: { data: 'hello' } }],
+        ],
+      }),
+    );
+    const cache = createPersistentProvider(MCP_ID)();
+    expect(cache.get('a')).toEqual({ data: 1 });
+    expect(cache.get('b')).toEqual({ data: 'hello' });
+  });
+
+  it('drops entries older than the TTL on hydrate', () => {
+    const stale = Date.now() - 31 * 60 * 1000; // 31 minutes ago
+    const fresh = Date.now() - 60_000; // 1 minute ago
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        schemaVersion: 1,
+        entries: [
+          ['stale', { ts: stale, value: { data: 'old' } }],
+          ['fresh', { ts: fresh, value: { data: 'new' } }],
+        ],
+      }),
+    );
+    const cache = createPersistentProvider(MCP_ID)();
+    expect(cache.get('stale')).toBeUndefined();
+    expect(cache.get('fresh')).toEqual({ data: 'new' });
+  });
+
+  it('rejects buckets with a different schemaVersion', () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        schemaVersion: 99,
+        entries: [['k', { ts: Date.now(), value: { data: 'x' } }]],
+      }),
+    );
+    const cache = createPersistentProvider(MCP_ID)();
+    expect(cache.get('k')).toBeUndefined();
+  });
+
+  it('rejects buckets with malformed JSON', () => {
+    localStorage.setItem(KEY, '{not json');
+    const cache = createPersistentProvider(MCP_ID)() as Map<string, unknown>;
+    expect(cache.size).toBe(0);
+  });
+
+  it('persists entries with data after the debounce', () => {
+    const cache = createPersistentProvider(MCP_ID)();
+    cache.set('k', { data: { hello: 'world' } });
+    expect(localStorage.getItem(KEY)).toBeNull(); // debounced — not flushed yet
+    vi.advanceTimersByTime(300);
+    const raw = localStorage.getItem(KEY);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.schemaVersion).toBe(1);
+    expect(parsed.entries).toEqual([['k', { ts: expect.any(Number), value: { data: { hello: 'world' } } }]]);
+  });
+
+  it('does not persist entries with an error', () => {
+    const cache = createPersistentProvider(MCP_ID)();
+    cache.set('k', { error: new Error('boom') });
+    vi.advanceTimersByTime(300);
+    expect(localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('does not persist entries with no data and no error', () => {
+    const cache = createPersistentProvider(MCP_ID)();
+    cache.set('k', { isLoading: true });
+    vi.advanceTimersByTime(300);
+    expect(localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('swallows quota-exceeded errors', () => {
+    const cache = createPersistentProvider(MCP_ID)();
+    const setItem = vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+      const e = new Error('QuotaExceededError');
+      (e as any).name = 'QuotaExceededError';
+      throw e;
+    });
+    cache.set('k', { data: 'x' });
+    expect(() => vi.advanceTimersByTime(300)).not.toThrow();
+    expect(setItem).toHaveBeenCalled();
+  });
+});
+
+describe('clearPersistedSwrCache', () => {
+  beforeEach(() => {
+    localStorage.setItem(storageKeyForMcp('a:b:c'), JSON.stringify({ schemaVersion: 1, entries: [] }));
+    localStorage.setItem(storageKeyForMcp('x:y:z'), JSON.stringify({ schemaVersion: 1, entries: [] }));
+    localStorage.setItem('mcp-ui:unrelated', 'keep me');
+  });
+
+  it('clears a single bucket when mcpId is given', () => {
+    clearPersistedSwrCache('a:b:c');
+    expect(localStorage.getItem(storageKeyForMcp('a:b:c'))).toBeNull();
+    expect(localStorage.getItem(storageKeyForMcp('x:y:z'))).not.toBeNull();
+    expect(localStorage.getItem('mcp-ui:unrelated')).toBe('keep me');
+  });
+
+  it('clears all swr buckets when mcpId is omitted', () => {
+    clearPersistedSwrCache();
+    expect(localStorage.getItem(storageKeyForMcp('a:b:c'))).toBeNull();
+    expect(localStorage.getItem(storageKeyForMcp('x:y:z'))).toBeNull();
+    expect(localStorage.getItem('mcp-ui:unrelated')).toBe('keep me');
+  });
+});

--- a/src/lib/swr/persistentProvider.spec.ts
+++ b/src/lib/swr/persistentProvider.spec.ts
@@ -178,6 +178,35 @@ describe('createPersistentProvider', () => {
   });
 });
 
+describe('cross-MCP isolation', () => {
+  it('two providers for different MCPs return distinct Maps and distinct buckets', () => {
+    const a = createPersistentProvider('proj:ws:mcp-a')();
+    const b = createPersistentProvider('proj:ws:mcp-b')();
+    a.set('shared-key', { data: 'A' });
+    b.set('shared-key', { data: 'B' });
+    expect(a.get('shared-key')).toEqual({ data: 'A' });
+    expect(b.get('shared-key')).toEqual({ data: 'B' });
+    vi.advanceTimersByTime(300);
+    expect(localStorage.getItem(storageKeyForMcp('proj:ws:mcp-a'))).toContain('"A"');
+    expect(localStorage.getItem(storageKeyForMcp('proj:ws:mcp-b'))).toContain('"B"');
+  });
+
+  it("late callbacks on the old MCP's Map don't pollute the new MCP's bucket", () => {
+    // Simulate the MCP-switch sequence: hook in MCP A mounts, fires a fetch,
+    // user navigates to MCP B (new provider mounts), then A's fetch resolves
+    // and calls cache.set on A's Map (the closure SWR captured).
+    const oldMap = createPersistentProvider('proj:ws:old')();
+    const newMap = createPersistentProvider('proj:ws:new')();
+    // Late callback resolves into the old Map (this is correct behaviour —
+    // SWR keeps the cache reference it was created with).
+    oldMap.set('late-key', { data: 'from-old-mcp' });
+    vi.advanceTimersByTime(300);
+    expect(localStorage.getItem(storageKeyForMcp('proj:ws:old'))).toContain('from-old-mcp');
+    expect(localStorage.getItem(storageKeyForMcp('proj:ws:new'))).toBeNull();
+    expect(newMap.get('late-key')).toBeUndefined();
+  });
+});
+
 describe('clearPersistedSwrCache', () => {
   beforeEach(() => {
     localStorage.setItem(storageKeyForMcp('a:b:c'), JSON.stringify({ schemaVersion: 1, entries: [] }));

--- a/src/lib/swr/persistentProvider.spec.ts
+++ b/src/lib/swr/persistentProvider.spec.ts
@@ -139,6 +139,43 @@ describe('createPersistentProvider', () => {
     expect(() => vi.advanceTimersByTime(300)).not.toThrow();
     expect(setItem).toHaveBeenCalled();
   });
+
+  it('evicts the LRU other-MCP bucket on quota error and retries', () => {
+    // Seed two older buckets with different most-recent timestamps.
+    const old1 = Date.now() - 10 * 60 * 1000;
+    const old2 = Date.now() - 2 * 60 * 1000;
+    localStorage.setItem(
+      storageKeyForMcp('p1:w:older'),
+      JSON.stringify({ schemaVersion: 1, entries: [['x', { ts: old1, value: { data: 1 } }]] }),
+    );
+    localStorage.setItem(
+      storageKeyForMcp('p1:w:newer'),
+      JSON.stringify({ schemaVersion: 1, entries: [['x', { ts: old2, value: { data: 2 } }]] }),
+    );
+    const cache = createPersistentProvider(MCP_ID)();
+    // First call to setItem (writing the active MCP's bucket) throws Quota;
+    // after we evict, subsequent calls succeed.
+    let callsToActiveKey = 0;
+    const realSetItem = localStorage.setItem.bind(localStorage);
+    vi.spyOn(localStorage, 'setItem').mockImplementation((k: string, v: string) => {
+      if (k === KEY) {
+        callsToActiveKey++;
+        if (callsToActiveKey === 1) {
+          const e = new Error('QuotaExceededError');
+          (e as any).name = 'QuotaExceededError';
+          throw e;
+        }
+      }
+      realSetItem(k, v);
+    });
+    cache.set('k', { data: 'x' });
+    vi.advanceTimersByTime(300);
+    // The older bucket should be gone; the newer should still be present.
+    expect(localStorage.getItem(storageKeyForMcp('p1:w:older'))).toBeNull();
+    expect(localStorage.getItem(storageKeyForMcp('p1:w:newer'))).not.toBeNull();
+    // Active bucket was written on the retry.
+    expect(localStorage.getItem(KEY)).not.toBeNull();
+  });
 });
 
 describe('clearPersistedSwrCache', () => {

--- a/src/lib/swr/persistentProvider.ts
+++ b/src/lib/swr/persistentProvider.ts
@@ -20,8 +20,13 @@ const PREFIX = 'mcp-ui:swr:v1:';
 const MAX_BYTES_PER_BUCKET = 4 * 1024 * 1024; // 4 MB — under the 5 MB common quota
 const PERSIST_DEBOUNCE_MS = 200;
 const TTL_MS = 30 * 60 * 1000; // 30 minutes
+// Bump SCHEMA_VERSION when the on-disk shape changes (entry layout, jq filter
+// for cached endpoints, or SWR's internal State shape). Old buckets that
+// don't match are silently dropped on hydrate.
+const SCHEMA_VERSION = 1;
 
 type PersistedEntry = { ts: number; value: any };
+type Envelope = { schemaVersion: number; entries: [string, PersistedEntry][] };
 
 export function storageKeyForMcp(mcpId: string): string {
   return `${PREFIX}${mcpId}`;
@@ -32,9 +37,12 @@ function hydrate(storageKey: string): Map<string, any> {
   try {
     const raw = window.localStorage.getItem(storageKey);
     if (!raw) return new Map();
-    const entries = JSON.parse(raw) as [string, PersistedEntry][];
+    const parsed = JSON.parse(raw) as Envelope;
+    if (!parsed || parsed.schemaVersion !== SCHEMA_VERSION || !Array.isArray(parsed.entries)) {
+      return new Map();
+    }
     const cutoff = Date.now() - TTL_MS;
-    const fresh = entries.filter(([, e]) => e && typeof e.ts === 'number' && e.ts >= cutoff);
+    const fresh = parsed.entries.filter(([, e]) => e && typeof e.ts === 'number' && e.ts >= cutoff);
     return new Map(fresh.map(([k, e]) => [k, e.value]));
   } catch {
     return new Map();
@@ -49,9 +57,10 @@ function persist(storageKey: string, map: Map<string, any>): void {
     if (!isPersistable(value)) continue;
     entries.push([k, { ts: now, value }]);
   }
+  const envelope = (e: [string, PersistedEntry][]): Envelope => ({ schemaVersion: SCHEMA_VERSION, entries: e });
   let serialized = '';
   try {
-    serialized = JSON.stringify(entries);
+    serialized = JSON.stringify(envelope(entries));
   } catch {
     return;
   }
@@ -59,7 +68,7 @@ function persist(storageKey: string, map: Map<string, any>): void {
   while (serialized.length > MAX_BYTES_PER_BUCKET && entries.length > 1) {
     entries = entries.slice(Math.ceil(entries.length / 8));
     try {
-      serialized = JSON.stringify(entries);
+      serialized = JSON.stringify(envelope(entries));
     } catch {
       return;
     }

--- a/src/lib/swr/persistentProvider.ts
+++ b/src/lib/swr/persistentProvider.ts
@@ -14,6 +14,9 @@ import type { Cache } from 'swr';
  *    so a transient 403 / 500 doesn't sticky into the next page load.
  *  - Each persisted entry is timestamped; entries older than TTL_MS are
  *    dropped on hydrate.
+ *  - On QuotaExceededError when writing, drop the *other* MCP bucket whose
+ *    most-recent write is oldest (LRU across MCPs) and retry. Active MCP's
+ *    bucket is never evicted to write itself out.
  */
 
 const PREFIX = 'mcp-ui:swr:v1:';
@@ -73,10 +76,92 @@ function persist(storageKey: string, map: Map<string, any>): void {
       return;
     }
   }
+  if (writeWithQuotaRecovery(storageKey, serialized)) return;
+  // Final fallback: clear our other buckets entirely and try once more.
+  evictAllOtherBuckets(storageKey);
   try {
     window.localStorage.setItem(storageKey, serialized);
   } catch {
-    // QuotaExceededError or privacy mode — ignore
+    // give up
+  }
+}
+
+/**
+ * Try `setItem`; on QuotaExceededError, evict the least-recently-touched
+ * `mcp-ui:swr:v1:*` bucket (other than `excludeKey`) and retry, up to a few
+ * times. Returns true if the write eventually succeeded.
+ */
+function writeWithQuotaRecovery(storageKey: string, serialized: string): boolean {
+  const MAX_EVICTIONS = 4;
+  for (let i = 0; i <= MAX_EVICTIONS; i++) {
+    try {
+      window.localStorage.setItem(storageKey, serialized);
+      return true;
+    } catch (e) {
+      if (!isQuotaError(e)) return false; // some other failure — don't loop
+      if (!evictOldestOtherBucket(storageKey)) return false; // nothing left to drop
+    }
+  }
+  return false;
+}
+
+function isQuotaError(e: unknown): boolean {
+  if (!e || typeof e !== 'object') return false;
+  // Browsers differ — check both name and code.
+  const name = (e as { name?: string }).name;
+  const code = (e as { code?: number }).code;
+  return name === 'QuotaExceededError' || name === 'NS_ERROR_DOM_QUOTA_REACHED' || code === 22 || code === 1014;
+}
+
+/**
+ * Find the `mcp-ui:swr:v1:*` bucket (other than `excludeKey`) whose
+ * most-recent entry is the oldest, and remove it. Returns true if a bucket
+ * was removed.
+ */
+function evictOldestOtherBucket(excludeKey: string): boolean {
+  let oldestKey: string | null = null;
+  let oldestTs = Infinity;
+  for (let i = 0; i < window.localStorage.length; i++) {
+    const k = window.localStorage.key(i);
+    if (!k || !k.startsWith(PREFIX) || k === excludeKey) continue;
+    const raw = window.localStorage.getItem(k);
+    if (!raw) continue;
+    let maxTs = 0;
+    try {
+      const parsed = JSON.parse(raw) as Envelope;
+      if (parsed && Array.isArray(parsed.entries)) {
+        for (const [, entry] of parsed.entries) {
+          if (entry && typeof entry.ts === 'number' && entry.ts > maxTs) maxTs = entry.ts;
+        }
+      }
+    } catch {
+      // unparseable bucket — treat as oldest (epoch) so it's dropped first.
+      maxTs = 0;
+    }
+    if (maxTs < oldestTs) {
+      oldestTs = maxTs;
+      oldestKey = k;
+    }
+  }
+  if (!oldestKey) return false;
+  try {
+    window.localStorage.removeItem(oldestKey);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function evictAllOtherBuckets(excludeKey: string): void {
+  const toRemove: string[] = [];
+  try {
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const k = window.localStorage.key(i);
+      if (k && k.startsWith(PREFIX) && k !== excludeKey) toRemove.push(k);
+    }
+    for (const k of toRemove) window.localStorage.removeItem(k);
+  } catch {
+    // ignore
   }
 }
 

--- a/src/lib/swr/persistentProvider.ts
+++ b/src/lib/swr/persistentProvider.ts
@@ -1,0 +1,135 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { Cache } from 'swr';
+
+/**
+ * SWR cache provider that persists entries to localStorage, scoped per MCP.
+ *
+ * Storage key shape: `mcp-ui:swr:v1:<project>:<workspace>:<mcpName>`.
+ * Each MCP gets its own bucket — switching MCPs never overwrites another's
+ * cache, and per-MCP wipe is a single `removeItem`.
+ *
+ * Persistence policy:
+ *  - Only entries that have `data` and no `error` are written. Failed requests
+ *    stay in the in-memory cache for the session but never hit localStorage,
+ *    so a transient 403 / 500 doesn't sticky into the next page load.
+ *  - Each persisted entry is timestamped; entries older than TTL_MS are
+ *    dropped on hydrate.
+ */
+
+const PREFIX = 'mcp-ui:swr:v1:';
+const MAX_BYTES_PER_BUCKET = 4 * 1024 * 1024; // 4 MB — under the 5 MB common quota
+const PERSIST_DEBOUNCE_MS = 200;
+const TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+type PersistedEntry = { ts: number; value: any };
+
+export function storageKeyForMcp(mcpId: string): string {
+  return `${PREFIX}${mcpId}`;
+}
+
+function hydrate(storageKey: string): Map<string, any> {
+  if (typeof window === 'undefined') return new Map();
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    if (!raw) return new Map();
+    const entries = JSON.parse(raw) as [string, PersistedEntry][];
+    const cutoff = Date.now() - TTL_MS;
+    const fresh = entries.filter(([, e]) => e && typeof e.ts === 'number' && e.ts >= cutoff);
+    return new Map(fresh.map(([k, e]) => [k, e.value]));
+  } catch {
+    return new Map();
+  }
+}
+
+function persist(storageKey: string, map: Map<string, any>): void {
+  if (typeof window === 'undefined') return;
+  const now = Date.now();
+  let entries: [string, PersistedEntry][] = [];
+  for (const [k, value] of map.entries()) {
+    if (!isPersistable(value)) continue;
+    entries.push([k, { ts: now, value }]);
+  }
+  let serialized = '';
+  try {
+    serialized = JSON.stringify(entries);
+  } catch {
+    return;
+  }
+  // Trim oldest entries until under the size cap.
+  while (serialized.length > MAX_BYTES_PER_BUCKET && entries.length > 1) {
+    entries = entries.slice(Math.ceil(entries.length / 8));
+    try {
+      serialized = JSON.stringify(entries);
+    } catch {
+      return;
+    }
+  }
+  try {
+    window.localStorage.setItem(storageKey, serialized);
+  } catch {
+    // QuotaExceededError or privacy mode — ignore
+  }
+}
+
+// SWR stores State objects: { data, error, isLoading, isValidating, … }.
+// We only persist successful entries — keep failed and in-flight ones in
+// memory only so a transient 403 doesn't survive reload.
+function isPersistable(state: any): boolean {
+  if (state == null || typeof state !== 'object') return false;
+  if (state.error !== undefined) return false;
+  return state.data !== undefined;
+}
+
+/**
+ * Factory for an SWR `provider` callback. Returns a Map whose `set` is
+ * intercepted to debounce-persist to localStorage under the MCP-scoped key.
+ */
+export function createPersistentProvider(mcpId: string): () => Cache<any> {
+  return () => {
+    const storageKey = storageKeyForMcp(mcpId);
+    const map = hydrate(storageKey);
+    let pending: ReturnType<typeof setTimeout> | null = null;
+    const scheduleFlush = () => {
+      if (pending) return;
+      pending = setTimeout(() => {
+        pending = null;
+        persist(storageKey, map);
+      }, PERSIST_DEBOUNCE_MS);
+    };
+    const originalSet = map.set.bind(map);
+    map.set = (key, value) => {
+      originalSet(key, value);
+      if (isPersistable(value)) scheduleFlush();
+      return map;
+    };
+    const originalDelete = map.delete.bind(map);
+    map.delete = (key) => {
+      const r = originalDelete(key);
+      scheduleFlush();
+      return r;
+    };
+    return map;
+  };
+}
+
+/**
+ * Clear persisted SWR cache. With `mcpId`, wipes just that bucket; without,
+ * wipes every `mcp-ui:swr:v1:*` key — call this on full logout.
+ */
+export function clearPersistedSwrCache(mcpId?: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (mcpId) {
+      window.localStorage.removeItem(storageKeyForMcp(mcpId));
+      return;
+    }
+    const toRemove: string[] = [];
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const k = window.localStorage.key(i);
+      if (k && k.startsWith(PREFIX)) toRemove.push(k);
+    }
+    for (const k of toRemove) window.localStorage.removeItem(k);
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## Summary

Three independent but layered optimisations that compound on MCP page load: server-side `jq` filters to shrink CRD and `/managed` responses by ~95%; SWR global dedup tuning to suppress redundant focus-revalidations; and a new per-MCP `localStorage` cache provider so a cold reload paints from disk and revalidates in the background. Each layer survives the others being rolled back independently — in particular, **the in-memory part (jq filter + SWR config tweaks) is still a meaningful win even if the persistence layer is reverted**.

## What changed

### Wire (payload shrink)
- `src/lib/api/types/crossplane/CRDList.ts` — add an `X-jq` filter to `CRDRequest` that strips OpenAPI schemas down to the handful of fields the client actually reads. Unfiltered responses on a real Crossplane MCP are 1-10 MB; filtered are ~50-500 KB.
- `src/lib/api/types/crossplane/listManagedResources.ts` — add `X-jq` to drop `metadata.managedFields` server-side. Saves multiple MB per `/managed` response.

### In-session SWR config
- `src/components/SWRConfigWithTokenRefresh.tsx` — globally set `dedupingInterval: 30s` and disable `revalidateOnFocus` / `revalidateOnReconnect`. The existing 10s poll already covers staleness; focus-revalidation just double-spends. (Survives rollback of the persistence layer.)
- `src/lib/api/useApiResource.ts` — `useCRDItemsMapping` and `useProvidersConfigResource` additionally set `refreshInterval: 0` + `revalidateIfStale: true`. CRDs are effectively static within a session.

### Cross-session persistence
- `src/lib/swr/persistentProvider.ts` *(new, 229 lines)* — SWR cache provider that persists entries to `localStorage` under `mcp-ui:swr:v1:<project>:<workspace>:<mcpName>` (one bucket per MCP, never shared). Persisted JSON is wrapped in `{ schemaVersion, entries }` — a **schema sentinel** so future format changes bump the version and old buckets are silently dropped on hydrate. Each entry is timestamped with a **30-minute TTL**; older entries are dropped on hydrate. Only entries with `data` and no `error` are persisted (a transient 403 doesn't sticky into the next page load). Per-bucket cap is 4 MB with oldest-entry-eviction; on `QuotaExceededError` while writing the active bucket, an **LRU cross-bucket eviction** finds the *other* MCP's bucket whose most-recent entry is the oldest and removes it before retrying — the active MCP's bucket is never sacrificed to write itself out. `clearPersistedSwrCache()` wired into `redirectToLogin` for a full wipe on logout.
- `src/lib/shared/McpContext.tsx` — mount the provider inside `RequireDownstreamLogin` so each MCP gets its own bucket scoped by `(project, workspace, mcpName)`.
- `src/common/auth/redirectToLogin.ts` — call `clearPersistedSwrCache()` on logout.

### Tests
- `src/lib/swr/persistentProvider.spec.ts` *(new, **14 cases**)* — hydrate-empty / hydrate-valid / TTL drop / schema mismatch reject / malformed-JSON reject / debounced persist / skip-on-error / skip-when-no-data / `QuotaExceededError` swallowed / single-bucket clear / all-buckets clear / **LRU cross-bucket eviction** / two-MCP isolation / late-callback into stale Map writes only to the stale bucket. Spec installs a minimal in-memory `localStorage` shim per test because the project's jsdom config doesn't expose a working `localStorage` (same blocker as `ViewModeContext.spec.tsx`).

## Why

On a typical Crossplane MCP, the MCP page kicks off:
- One `/CRDList` request: 1-10 MB of OpenAPI schemas the client never reads.
- One `/managed` request: hundreds of KB of `metadata.managedFields` no UI surface touches.
- Plus focus-triggered revalidations every time the user Cmd-Tabs back.

Wire-layer wins are pure: less data over the wire, less JSON to parse, less RAM. SWR dedup tuning kills wasted requests. The persistence layer turns reload-after-reload from "spinner for 2-5s" into "stale data immediately, revalidate in background" — and importantly, **doesn't share state across MCPs**, so switching between clusters can't poison one cache with another's data.

Rollback safety: if the persistence layer turns out to be problematic in production, removing `persistentProvider.ts` + reverting `McpContext.tsx` leaves the jq filters and SWR config tweaks intact — those are still a meaningful win on their own.

## Test plan

- [ ] `npm run type-check`
- [ ] `npm run lint`
- [ ] `npm run test:vi -- src/lib/swr/persistentProvider.spec.ts` — all 14 cases pass.
- [ ] `npm run test:vi` — full suite.
- [ ] Open an MCP, DevTools Network → confirm `/CRDList` payload is ≤ ~500 KB (was multi-MB) and `/managed` no longer contains `managedFields`.
- [ ] Same MCP: DevTools Application → Local Storage → confirm `mcp-ui:swr:v1:<proj>:<ws>:<mcp>` bucket appears with `{ schemaVersion, entries }` shape.
- [ ] Hard-reload the page: confirm cards paint from cache (no spinner) then SWR revalidates in the background.
- [ ] Switch to a *different* MCP: confirm a separate bucket appears; original MCP's bucket is untouched.
- [ ] Log out: confirm all `mcp-ui:swr:*` buckets are removed.
- [ ] Force quota pressure (artificially fill localStorage to ~9 MB in DevTools), then reload: confirm the active MCP's bucket writes succeed and other MCP buckets get LRU-evicted rather than the active one being dropped.
- [ ] Wait > 30 min, reload: confirm stale entries are dropped on hydrate (revalidation fires fresh).