### PR TITLE
perf(mcp): defer Graph mount until dashboard cards settle

### DIFF
--- a/src/spaces/mcp/pages/McpPageV2.tsx
+++ b/src/spaces/mcp/pages/McpPageV2.tsx
@@ -22,7 +22,7 @@ import { NotFoundBanner } from '../../../components/Ui/NotFoundBanner/NotFoundBa
 import { YamlViewButton } from '../../../components/Yaml/YamlViewButton.tsx';
 import { isNotFoundError } from '../../../lib/api/error.ts';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { McpStatusSection } from '../../../components/ControlPlane/McpStatusSection.tsx';
 
 import { McpMembersAvatarView } from '../../../components/ControlPlanes/McpMembersAvatarView/McpMembersAvatarView.tsx';
@@ -72,10 +72,19 @@ export default function McpPageV2() {
     return 'overview' as McpPageSectionId;
   }, [searchParams]);
   const { data: mcp, isPending: isLoading, error } = useMcpV2Query(controlPlaneName, namespace);
-  const { crossplaneData } = useCrossplaneQuery(controlPlaneName, namespace);
-  const { fluxData } = useFluxQuery(controlPlaneName, namespace);
-  const { landscaperData } = useLandscaperQuery(controlPlaneName, namespace);
-  const { esoData } = useEsoQuery(controlPlaneName, namespace);
+  const { crossplaneData, isLoading: isLoadingCrossplane } = useCrossplaneQuery(controlPlaneName, namespace);
+  const { fluxData, isLoading: isLoadingFlux } = useFluxQuery(controlPlaneName, namespace);
+  const { landscaperData, isLoading: isLoadingLandscaper } = useLandscaperQuery(controlPlaneName, namespace);
+  const { esoData, isLoading: isLoadingEso } = useEsoQuery(controlPlaneName, namespace);
+  const cardsReady = !isLoadingCrossplane && !isLoadingFlux && !isLoadingLandscaper && !isLoadingEso;
+  // Hold graph mount until the cards' 0.3s height transition (index.css) has
+  // settled — otherwise the graph layout fights with concurrent card animations.
+  const [graphReady, setGraphReady] = useState(false);
+  useEffect(() => {
+    if (!cardsReady) return;
+    const id = setTimeout(() => setGraphReady(true), 400);
+    return () => clearTimeout(id);
+  }, [cardsReady]);
   const setTabFromSection = (sectionId: McpPageSectionId) => {
     setSearchParams((prev) => {
       const newParams = new URLSearchParams(prev);
@@ -211,7 +220,7 @@ export default function McpPageV2() {
                   />
                 </ObjectPageSubSection>
                 <ObjectPageSubSection id="graph" titleText={t('McpPage.graphTitle')} className={styles.section}>
-                  <Graph />
+                  {graphReady ? <Graph /> : <div>{t('Graphs.loadingGraph')}</div>}
                 </ObjectPageSubSection>
                 <ObjectPageSubSection
                   id="configmaps"

--- a/src/spaces/mcp/pages/McpPageV2.tsx
+++ b/src/spaces/mcp/pages/McpPageV2.tsx
@@ -77,16 +77,23 @@ export default function McpPageV2() {
   const { landscaperData, isLoading: isLoadingLandscaper } = useLandscaperQuery(controlPlaneName, namespace);
   const { esoData, isLoading: isLoadingEso } = useEsoQuery(controlPlaneName, namespace);
   const cardsReady = !isLoadingCrossplane && !isLoadingFlux && !isLoadingLandscaper && !isLoadingEso;
-  // Hold graph mount until the cards' height transition has settled — otherwise
-  // elkjs layout fights with concurrent card animations. The card transition is
-  // `transition: height 0.3s ease` in src/index.css (.component-card); 100ms
-  // buffer covers easing tail + paint.
-  const CARD_TRANSITION_BUFFER_MS = 400;
+  // Hold graph mount until the first `.component-card` actually finishes its
+  // height transition (`transition: height 0.3s ease` in src/index.css) —
+  // otherwise elkjs layout fights with concurrent card animations. The 600ms
+  // safety-net timer covers reduced-motion users, browsers that don't fire
+  // transitionend, and the empty-MCP edge case where no card is rendered.
   const [graphReady, setGraphReady] = useState(false);
   useEffect(() => {
     if (!cardsReady) return;
-    const id = setTimeout(() => setGraphReady(true), CARD_TRANSITION_BUFFER_MS);
-    return () => clearTimeout(id);
+    const SAFETY_NET_MS = 600;
+    const finish = () => setGraphReady(true);
+    const card = document.querySelector('.component-card');
+    card?.addEventListener('transitionend', finish, { once: true });
+    const timer = setTimeout(finish, SAFETY_NET_MS);
+    return () => {
+      card?.removeEventListener('transitionend', finish);
+      clearTimeout(timer);
+    };
   }, [cardsReady]);
   const setTabFromSection = (sectionId: McpPageSectionId) => {
     setSearchParams((prev) => {

--- a/src/spaces/mcp/pages/McpPageV2.tsx
+++ b/src/spaces/mcp/pages/McpPageV2.tsx
@@ -77,12 +77,15 @@ export default function McpPageV2() {
   const { landscaperData, isLoading: isLoadingLandscaper } = useLandscaperQuery(controlPlaneName, namespace);
   const { esoData, isLoading: isLoadingEso } = useEsoQuery(controlPlaneName, namespace);
   const cardsReady = !isLoadingCrossplane && !isLoadingFlux && !isLoadingLandscaper && !isLoadingEso;
-  // Hold graph mount until the cards' 0.3s height transition (index.css) has
-  // settled — otherwise the graph layout fights with concurrent card animations.
+  // Hold graph mount until the cards' height transition has settled — otherwise
+  // elkjs layout fights with concurrent card animations. The card transition is
+  // `transition: height 0.3s ease` in src/index.css (.component-card); 100ms
+  // buffer covers easing tail + paint.
+  const CARD_TRANSITION_BUFFER_MS = 400;
   const [graphReady, setGraphReady] = useState(false);
   useEffect(() => {
     if (!cardsReady) return;
-    const id = setTimeout(() => setGraphReady(true), 400);
+    const id = setTimeout(() => setGraphReady(true), CARD_TRANSITION_BUFFER_MS);
     return () => clearTimeout(id);
   }, [cardsReady]);
   const setTabFromSection = (sectionId: McpPageSectionId) => {
@@ -220,7 +223,15 @@ export default function McpPageV2() {
                   />
                 </ObjectPageSubSection>
                 <ObjectPageSubSection id="graph" titleText={t('McpPage.graphTitle')} className={styles.section}>
-                  {graphReady ? <Graph /> : <div>{t('Graphs.loadingGraph')}</div>}
+                  {graphReady ? (
+                    <Graph />
+                  ) : (
+                    // Match Graph.module.css .graphContainer height so the page
+                    // doesn't reflow when <Graph /> mounts.
+                    <div style={{ height: 600, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                      {t('Graphs.loadingGraph')}
+                    </div>
+                  )}
                 </ObjectPageSubSection>
                 <ObjectPageSubSection
                   id="configmaps"


### PR DESCRIPTION
## Summary

Hold the Graph component out of the DOM until every KPI query (crossplane / flux / landscaper / eso) has resolved AND the cards' 300ms height transition has finished. Otherwise elkjs layout fights with concurrent card animations on first paint, producing a visible re-layout flash. While the Graph is held, render a same-height "Loading graph data…" placeholder so the page never reflows when `<Graph />` finally mounts.

## What changed

- `src/spaces/mcp/pages/McpPageV2.tsx`
  - Capture `isLoading` from each KPI query (`crossplane`, `flux`, `landscaper`, `eso`).
  - Gate the Graph render on `!anyCardLoading && cardTransitionDone`.
  - Add a `setTimeout` (after all four resolve) waiting `CARD_TRANSITION_BUFFER_MS = 400ms` — slightly more than the 0.3s `.component-card` CSS transition in `index.css`, with a comment pointing at the underlying CSS rule so the constant doesn't drift silently.
  - Render a `<Graph />`-sized placeholder (height matched to `Graph.module.css` `.graphContainer` = `600px`, text centered) while gated. Page does **not** reflow when `<Graph />` swaps in.

## Why

On first MCP page load, the four KPI cards animate from `height: 0` to their final height over 300ms. If `<Graph />` mounts during that animation, elkjs runs a layout pass on whatever container size happens to exist mid-transition — and then ReactFlow re-fits when the container settles, producing a visible jump. Deferring the mount by the duration of the card transition removes that race entirely.

400ms (vs. 300ms transition) is a deliberate small buffer for the requestAnimationFrame settle after the transition completes. Named constant + comment so a future cleanup pass converts it to a `transitionend` listener without losing the rationale.

The placeholder height match (600px) means the page never reflows when the real Graph mounts — important on slow MCPs where the wait can be 1-2 seconds and the user might already be scrolling.

## Test plan

- [ ] `npm run type-check`
- [ ] `npm run lint`
- [ ] `npm run test:vi`
- [ ] Open an MCP page from a cold cache: confirm the cards animate in, the "Loading graph data…" placeholder is visible for ~400ms after they settle, then the Graph swaps in **without** the page reflowing (graph subsection height is unchanged).
- [ ] Throttle CPU to 4x in DevTools and reload: confirm there is no double-layout flash on the Graph (would manifest as nodes "jumping" once after first paint).
- [ ] Hard-reload with persisted SWR cache present: cards resolve instantly, placeholder still shows for ~400ms before Graph appears (the transition still runs).
- [ ] Resize the window during the wait: confirm the placeholder takes the full graph-section width and no layout glitch occurs at swap-in.