### PR TITLE
perf(swr): fix SWR dedup bugs in useApiResource + ApiConfigWrapper

### DIFF
--- a/src/components/Core/ApiConfigWrapper.tsx
+++ b/src/components/Core/ApiConfigWrapper.tsx
@@ -1,14 +1,17 @@
+import { useMemo } from 'react';
 import { ApiConfigProvider } from '../Shared/k8s/index.ts';
 import { Outlet } from 'react-router-dom';
 import { generateCrateAPIConfig } from '../../lib/api/types/apiConfig.ts';
 
 // ApiConfigWrapper is a component that provides the ApiConfigProvider with the oidc access token from the oidc context.
 export default function ApiConfigWrapper() {
+  // Memoise so the context value is referentially stable across re-renders;
+  // a fresh object would invalidate every downstream useMemo/useEffect that
+  // depends on apiConfig. See issue #653.
+  const apiConfig = useMemo(() => generateCrateAPIConfig(), []);
   return (
-    <>
-      <ApiConfigProvider apiConfig={generateCrateAPIConfig()}>
-        <Outlet />
-      </ApiConfigProvider>
-    </>
+    <ApiConfigProvider apiConfig={apiConfig}>
+      <Outlet />
+    </ApiConfigProvider>
   );
 }

--- a/src/lib/api/useApiResource.ts
+++ b/src/lib/api/useApiResource.ts
@@ -44,8 +44,9 @@ export const useApiResource = <T>(
 
 export const useCRDItemsMapping = (config?: SWRConfiguration) => {
   const apiConfig = useContext(ApiConfigContext);
+  // key shape must match across hooks — see issue #653
   const { data, error, isValidating, isLoading } = useSWR(
-    CRDRequest.path === null ? null : [CRDRequest.path, apiConfig],
+    CRDRequest.path === null ? null : [CRDRequest.path, apiConfig, undefined],
     ([path, apiConfig]) =>
       fetchApiServerJson<CRDResponse>(path, apiConfig, CRDRequest.jq, CRDRequest.method, CRDRequest.body),
     config,
@@ -76,10 +77,11 @@ export const useCRDItemsMapping = (config?: SWRConfiguration) => {
 export const useProvidersConfigResource = (config?: SWRConfiguration) => {
   const apiConfig = useContext(ApiConfigContext);
   const telemetry = useTelemetry();
+  // key shape must match across hooks — see issue #653
   const { data, error, isValidating } = useSWR(
     CRDRequest.path === null
       ? null //TODO: is null a valid key?
-      : [CRDRequest.path, apiConfig],
+      : [CRDRequest.path, apiConfig, undefined],
     ([path, apiConfig]) =>
       fetchApiServerJson<CRDResponse>(path, apiConfig, CRDRequest.jq, CRDRequest.method, CRDRequest.body),
     config,
@@ -111,25 +113,6 @@ export const useProvidersConfigResource = (config?: SWRConfiguration) => {
       });
     });
   }
-
-  const fetchProviderConfigsData = async () => {
-    const promises = providerConfigsDataForRequest.map(async (item) => {
-      const data = await fetchApiServerJson<ProviderConfigs>(
-        `/apis/${item.url ?? ''}/${item.version}/providerconfigs`,
-        apiConfig,
-        CRDRequest.jq,
-        CRDRequest.method,
-        CRDRequest.body,
-      );
-      if (data) {
-        providerConfigs.push(data);
-      }
-    });
-
-    await Promise.all(promises);
-  };
-
-  const providerConfigs: ProviderConfigs[] = [];
 
   const fetchProviderConfigs = async () => {
     try {
@@ -168,7 +151,6 @@ export const useProvidersConfigResource = (config?: SWRConfiguration) => {
     const fetchDataAndUpdateState = async () => {
       if (!initialLoaded.current) setIsLoading(true);
       try {
-        await fetchProviderConfigsData();
         const finalData = await fetchProviderConfigs();
 
         setConfigs(finalData);
@@ -232,10 +214,11 @@ export function useRevalidateApiResource<T>(resource: Resource<T>) {
   const apiConfig = useContext(ApiConfigContext);
 
   const onRevalidate = (options?: MutatorOptions) => {
+    // key shape must match across hooks — see issue #653
     return mutate(
       resource.path === null
         ? null //TODO: is null a valid key?
-        : [resource.path, apiConfig],
+        : [resource.path, apiConfig, undefined],
       undefined,
       options,
     );


### PR DESCRIPTION
## Summary

Three small, independent fixes for the redundant-fetch bugs documented in [issue #653](https://github.com/openmcp-project/ui-frontend/issues/653). On a typical MCP page load this eliminates the duplicate `customresourcedefinitions` and `providerconfigs` requests that issue #653 measured.

## What changed

### `src/lib/api/useApiResource.ts`

- **Delete the dead first-pass loop** in `useProvidersConfigResource`. `fetchProviderConfigsData` walked every providerconfigs URL and pushed results into a `const providerConfigs: ProviderConfigs[]` array that was never read — leftover from a refactor that introduced the second loop (`fetchProviderConfigs`) without removing the first. Net effect: every provider group was fetched twice on every mount.
- **Align SWR key shape**. `useApiResource` keys SWR with a **3-tuple** `[path, apiConfig, overrideMcpConfig]`; the helper hooks (`useCRDItemsMapping`, `useProvidersConfigResource`, `useRevalidateApiResource`) used a **2-tuple** `[path, apiConfig]`. SWR's `stable-hash` includes the array length, so 2-tuple and 3-tuple hash to different cache buckets even when the contents are identical — meaning CRD reads via different hooks never deduped, and `useRevalidateApiResource` calls would silently miss their target. All helpers now use `[path, apiConfig, undefined]` and carry a `// key shape must match across hooks — see issue #653` comment above the key.

### `src/components/Core/ApiConfigWrapper.tsx`

- **Memoise the outer `apiConfig`**. Was calling `generateCrateAPIConfig()` inline on every render, producing a fresh `{ mcpConfig: undefined }` object each time. `stable-hash` treats those as equal for SWR keying, but every consumer of `ApiConfigContext` sees a new identity, invalidating any `useMemo`/`useEffect` dep that includes `apiConfig`. Wrapping in `useMemo(..., [])` matches the pattern the inner provider in `lib/shared/McpContext.tsx` already uses.

## Why

Issue #653 measured **10+ redundant HTTP requests on every cold MCP page load** — 3× `customresourcedefinitions`, 2× per provider group, 3× the MCP object. The duplicates were caused by three distinct mechanisms (dead loop, key-shape mismatch, identity churn) all in this file. These fixes are independent and each can ship alone; combined they should drop the duplicate count significantly. (The MCP `/managedcontrolplanes/<name>` ×3 case is partly upstream and not in scope here.)

## Test plan

- [x] `npm run type-check` — clean
- [x] `npx eslint src/lib/api/useApiResource.ts src/components/Core/ApiConfigWrapper.tsx --max-warnings 0` — clean
- [x] `npx vitest run` — 335/362 pass; the 27 failures are pre-existing jsdom localStorage env issues (`ViewModeContext.spec.tsx`, `rememberedProject.spec.ts`, `ProjectPage.spec.tsx`, `ProjectList.spec.tsx`), unrelated to this change
- [ ] Manual: reload an MCP page with DevTools Network filtered to XHR. Count the rows for the three URLs in issue #653's evidence table. Expectation: providerconfigs goes from 8 → 4 (one per group), CRDs from 3 → 1

Refs #653