### PR TITLE
feat: rename Connect button to View and make it primary

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -115,7 +115,7 @@
     "emptyListSubtitleMessage": "Create a workspace to get started"
   },
   "ConnectButton": {
-    "buttonText": "Connect",
+    "buttonText": "View",
     "defaultIdP": "default IdP",
     "downloadKubeconfig": "Download Kubeconfig"
   },

--- a/src/components/ControlPlanes/ConnectButton/ConnectButton.tsx
+++ b/src/components/ControlPlanes/ConnectButton/ConnectButton.tsx
@@ -81,7 +81,12 @@ export default function ConnectButton({
   if (connectionTargets.length === 1) {
     const directTarget = connectionTargets[0];
     return (
-      <Button design="Emphasized" endIcon="navigation-right-arrow" disabled={disabled} onClick={() => connectTo(directTarget)}>
+      <Button
+        design="Emphasized"
+        endIcon="navigation-right-arrow"
+        disabled={disabled}
+        onClick={() => connectTo(directTarget)}
+      >
         {t('ConnectButton.buttonText')}
       </Button>
     );

--- a/src/components/ControlPlanes/ConnectButton/ConnectButton.tsx
+++ b/src/components/ControlPlanes/ConnectButton/ConnectButton.tsx
@@ -72,7 +72,7 @@ export default function ConnectButton({
 
   if (isLoading || error || connectionTargets.length === 0) {
     return (
-      <Button endIcon="navigation-right-arrow" disabled={true}>
+      <Button design="Emphasized" endIcon="navigation-right-arrow" disabled={true}>
         {t('ConnectButton.buttonText')}
       </Button>
     );
@@ -81,7 +81,7 @@ export default function ConnectButton({
   if (connectionTargets.length === 1) {
     const directTarget = connectionTargets[0];
     return (
-      <Button endIcon="navigation-right-arrow" disabled={disabled} onClick={() => connectTo(directTarget)}>
+      <Button design="Emphasized" endIcon="navigation-right-arrow" disabled={disabled} onClick={() => connectTo(directTarget)}>
         {t('ConnectButton.buttonText')}
       </Button>
     );
@@ -90,6 +90,7 @@ export default function ConnectButton({
   return (
     <div>
       <Button
+        design="Emphasized"
         id={buttonId}
         disabled={disabled}
         endIcon="slim-arrow-down"

--- a/src/components/ControlPlanes/ConnectButton/ConnectButtonV2.tsx
+++ b/src/components/ControlPlanes/ConnectButton/ConnectButtonV2.tsx
@@ -24,6 +24,7 @@ export default function ConnectButtonV2({
 
   return (
     <Button
+      design="Emphasized"
       endIcon="navigation-right-arrow"
       onClick={() => navigate(generatePath(Routes.McpV2, { projectName, workspaceName, controlPlaneName }))}
     >


### PR DESCRIPTION
## Summary

- Renames the "Connect" button label to "View" across all control plane card variants
- Makes the button `design="Emphasized"` (filled, primary) so it stands out as the main action

## Test plan

- [ ] Open the control plane list and confirm the button reads "View"
- [ ] Confirm the button renders as emphasized (filled) in all three states: loading/error, single target, multi-target dropdown