### PR TITLE
feat(shellbar): show Hello, <name> in profile popover header

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -189,6 +189,7 @@
     "feedbackThanks": "Thank you for your feedback!",
     "feedbackError": "Failed to send feedback. Please try again later.",
     "modeOpenSource": "Open Source View",
+    "hello": "Hello, {{name}}",
     "backButton": "Back",
     "copyNamespace": "Copy namespace",
     "membersLabel": "Members:",

--- a/src/components/Core/ShellBar.cy.tsx
+++ b/src/components/Core/ShellBar.cy.tsx
@@ -67,7 +67,7 @@ describe('ShellBar', () => {
 
     cy.get('ui5-avatar').click();
 
-    cy.get('ui5-popover[header-text="Profile"]', { timeout: 5000 }).should('be.visible');
+    cy.get('ui5-popover[header-text="Hello, test"]', { timeout: 5000 }).should('be.visible');
   });
 
   it('shows sign out option in profile menu', () => {
@@ -75,7 +75,7 @@ describe('ShellBar', () => {
 
     cy.get('ui5-avatar').click();
 
-    cy.get('ui5-popover[header-text="Profile"]').within(() => {
+    cy.get('ui5-popover[header-text="Hello, test"]').within(() => {
       cy.contains('Sign Out').should('exist');
     });
   });
@@ -96,7 +96,7 @@ describe('ShellBar', () => {
     mountComponent();
 
     cy.get('ui5-avatar').click();
-    cy.get('ui5-popover[header-text="Profile"]').within(() => {
+    cy.get('ui5-popover[header-text="Hello, test"]').within(() => {
       cy.contains('Clear remembered project').should('not.exist');
     });
   });
@@ -106,7 +106,7 @@ describe('ShellBar', () => {
     mountComponent();
 
     cy.get('ui5-avatar').click();
-    cy.get('ui5-popover[header-text="Profile"]').within(() => {
+    cy.get('ui5-popover[header-text="Hello, test"]').within(() => {
       cy.contains('Clear remembered project').should('exist');
     });
 

--- a/src/components/Core/ShellBar.tsx
+++ b/src/components/Core/ShellBar.tsx
@@ -303,7 +303,7 @@ const ProfilePopover = ({
         ref={popoverRef}
         placement={PopoverPlacement.Bottom}
         open={open}
-        headerText="Profile"
+        headerText={t('ShellBar.hello', { name: auth.user?.email?.split('@')[0] ?? '' })}
         onClose={() => setOpen(false)}
       >
         <List>

--- a/src/components/Dialogs/CreateWorkspaceDialogContainer.cy.tsx
+++ b/src/components/Dialogs/CreateWorkspaceDialogContainer.cy.tsx
@@ -98,6 +98,7 @@ describe('CreateWorkspaceDialogContainer', () => {
     cy.get('#name').typeIntoUi5Input('test-workspace');
     cy.get('#chargingTargetType').openDropDownByClick();
     cy.get('#chargingTargetType').clickDropdownMenuItemByText<Cypress.TriggerOptions>('BTP');
+    cy.get('#chargingTarget').should('not.have.attr', 'disabled');
     cy.get('#chargingTarget').typeIntoUi5Input('12345678-1234-1234-1234-123456789abc').type('{enter}');
 
     goToMembers();


### PR DESCRIPTION
## Summary

- Replaces the static "Profile" header in the ShellBar profile popover with a personalised greeting: **"Hello, \<local-part>"** derived from the local part of the user's email address
- Adds `ShellBar.hello` i18n key
- Updates Cypress tests to match the new header text

## Test plan

- [ ] Click the profile avatar in the shell bar — popover header reads "Hello, \<your-name>"
- [ ] Run `npm run test:cy -- --spec 'src/components/Core/ShellBar.cy.tsx'`