### PR TITLE
test(cypress): stabilize flaky component tests by replacing force/wait anti-patterns

### DIFF
--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -9,6 +9,36 @@ declare global {
        *   cy.wrap(actual).deepEqualJson(expected)
        */
       deepEqualJson(expected: unknown): Chainable<Subject>;
+
+      /**
+       * Click after asserting the element is visible AND not `[disabled]`.
+       * Replaces `.click({ force: true })` — `force` masks real bugs
+       * (overlay, still-animating dialog, form not yet initialised).
+       *
+       * @example
+       *   cy.get('[data-testid="save"]').clickEnabled();
+       */
+      clickEnabled(): Chainable<Subject>;
+
+      /**
+       * Type into a `<ui5-input>` after asserting it is visible AND not
+       * disabled. Prevents `cy.type() failed because it targeted a
+       * disabled element` in edit-dialog forms that populate lazily via
+       * `useEffect` + `react-hook-form.reset()`.
+       *
+       * @example
+       *   cy.get('ui5-dialog[open] ui5-input').typeIntoEnabledUi5Input('foo');
+       */
+      typeIntoEnabledUi5Input(text: string): Chainable<Subject>;
+
+      /**
+       * Wait for a `<ui5-dialog>` to finish opening before interacting with
+       * its contents. Defaults selector to `ui5-dialog[open]`.
+       *
+       * @example
+       *   cy.openedDialog().find('ui5-input').typeIntoEnabledUi5Input('foo');
+       */
+      openedDialog(selector?: string): Chainable<JQuery<HTMLElement>>;
     }
   }
 }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -15,3 +15,62 @@ Cypress.Commands.add('deepEqualJson', { prevSubject: true }, (subject, expected)
   expect(toPlain(subject)).to.deep.equal(toPlain(expected));
   return subject;
 });
+
+/**
+ * Click an element only after asserting it is visible AND not `disabled`.
+ *
+ * The default `.click()` retries the query, but once it hits an element it
+ * fires the click regardless of whether the element is disabled — that's what
+ * produces the intermittent `cy.type() failed because it targeted a disabled
+ * element` (and the click-noop equivalents). This helper gates on both
+ * visibility and enablement before dispatching, which is what almost every
+ * `.click({ force: true })` in this repo was papering over.
+ *
+ * Prefer this over `.click({ force: true })` — `force` bypasses the checks
+ * that would otherwise catch a real bug (element under an overlay, dialog
+ * animation still running, form still initialising, etc.).
+ */
+Cypress.Commands.add('clickEnabled', { prevSubject: 'element' }, (subject) => {
+  return cy
+    .wrap(subject)
+    .should('be.visible')
+    .should('not.have.attr', 'disabled')
+    .click();
+});
+
+/**
+ * Type into a UI5 input only after asserting it is visible AND not disabled.
+ *
+ * `typeIntoUi5Input` from `@ui5/webcomponents-cypress-commands` reaches into
+ * the shadow DOM `<input>` and calls `.type()` — if the outer `<ui5-input>`
+ * is disabled the inner input is disabled too, and Cypress fails hard with
+ * `cy.type() failed because it targeted a disabled element`. Most of our
+ * flakes are edit-dialog forms that render empty on mount and get populated
+ * a tick later by `react-hook-form.reset()` inside a `useEffect`.
+ *
+ * Gate on `not.have.attr('disabled')` here so the assertion retries until
+ * the form is ready.
+ */
+Cypress.Commands.add('typeIntoEnabledUi5Input', { prevSubject: 'element' }, (subject, text: string) => {
+  return cy
+    .wrap(subject)
+    .should('be.visible')
+    .should('not.have.attr', 'disabled')
+    .typeIntoUi5Input(text);
+});
+
+/**
+ * Wait for a `<ui5-dialog>` to finish opening before letting the caller
+ * interact with its contents. UI5 dialogs animate in; a `.find('ui5-input')`
+ * immediately after the trigger click can resolve before the input mounts.
+ *
+ * Use as the entry point for any dialog interaction:
+ *
+ *     cy.openedDialog().find('ui5-input').typeIntoEnabledUi5Input('foo');
+ *
+ * The selector defaults to `ui5-dialog[open]`; pass one when a page has
+ * multiple dialogs and you need to disambiguate.
+ */
+Cypress.Commands.add('openedDialog', (selector: string = 'ui5-dialog[open]') => {
+  return cy.get(selector).should('be.visible');
+});

--- a/src/components/ControlPlane/ManagedResources.cy.tsx
+++ b/src/components/ControlPlane/ManagedResources.cy.tsx
@@ -106,12 +106,12 @@ describe('ManagedResources - Delete Resource', () => {
     );
 
     // Expand resource group
-    cy.get('button[aria-label*="xpand"]').first().click({ force: true });
+    cy.get('button[aria-label*="xpand"]').first().clickEnabled();
     cy.contains('test-subaccount').should('be.visible');
 
     // Open actions menu and click Delete
-    cy.get('[data-testid="ActionsMenu-opener"]').first().click({ force: true });
-    cy.contains('Delete').click({ force: true });
+    cy.get('[data-testid="ActionsMenu-opener"]').first().clickEnabled();
+    cy.contains('Delete').clickEnabled();
 
     // Type confirmation text and verify it was accepted
     cy.get('ui5-dialog[open]').find('ui5-input').typeIntoUi5InputWithDelay('test-subaccount');
@@ -143,16 +143,19 @@ describe('ManagedResources - Delete Resource', () => {
     );
 
     // Expand resource group
-    cy.get('button[aria-label*="xpand"]').first().click({ force: true });
+    cy.get('button[aria-label*="xpand"]').first().clickEnabled();
     cy.contains('test-subaccount').should('be.visible');
 
     // Open actions menu and click Delete
-    cy.get('[data-testid="ActionsMenu-opener"]').first().click({ force: true });
-    cy.contains('Delete').click({ force: true });
+    cy.get('[data-testid="ActionsMenu-opener"]').first().clickEnabled();
+    cy.contains('Delete').clickEnabled();
 
-    // Wait for dialog open animation to complete (onOpen fires resetForm which clears state)
-    cy.get('ui5-dialog[open]').should('be.visible');
-    cy.wait(500);
+    // Wait for dialog open animation to complete (onOpen fires resetForm
+    // which clears state). Gate on the Advanced section being interactable
+    // rather than a fixed cy.wait(500) — the timing depends on the animation
+    // budget which varies across machines/CI.
+    cy.openedDialog();
+    cy.contains('Advanced').should('be.visible');
 
     // Expand Advanced section and enable force deletion checkbox
     cy.contains('Advanced').click();
@@ -191,12 +194,12 @@ describe('ManagedResources - Delete Resource', () => {
     );
 
     // Expand resource group
-    cy.get('button[aria-label*="xpand"]').first().click({ force: true });
+    cy.get('button[aria-label*="xpand"]').first().clickEnabled();
     cy.contains('test-subaccount').should('be.visible');
 
     // Open actions menu and click Delete
-    cy.get('[data-testid="ActionsMenu-opener"]').first().click({ force: true });
-    cy.contains('Delete').click({ force: true });
+    cy.get('[data-testid="ActionsMenu-opener"]').first().clickEnabled();
+    cy.contains('Delete').clickEnabled();
 
     // Delete button should be disabled initially
     cy.get('ui5-dialog[open]').find('ui5-button').contains('Delete').should('have.attr', 'disabled');
@@ -305,22 +308,22 @@ describe('ManagedResources - Edit Resource', () => {
     );
 
     // Expand resource group
-    cy.get('button[aria-label*="xpand"]').first().click({ force: true });
+    cy.get('button[aria-label*="xpand"]').first().clickEnabled();
     cy.contains('test-subaccount').should('be.visible');
 
     // Open actions menu and click Edit
-    cy.get('[data-testid="ActionsMenu-opener"]').first().click({ force: true });
-    cy.contains('Edit').click({ force: true });
+    cy.get('[data-testid="ActionsMenu-opener"]').first().clickEnabled();
+    cy.contains('Edit').clickEnabled();
 
     // Wait for YAML panel and Monaco editor to fully load (schema loader async re-renders)
     cy.contains('YAML').should('be.visible');
     cy.get('.monaco-editor', { timeout: 10000 }).should('exist');
 
     // Click Apply button — use force to avoid detached-DOM race from SWR revalidation re-renders
-    cy.get('[data-testid="yaml-apply-button"]').click({ force: true });
+    cy.get('[data-testid="yaml-apply-button"]').clickEnabled();
 
     // Confirm in dialog
-    cy.get('[data-testid="yaml-confirm-button"]', { timeout: 10000 }).should('be.visible').click({ force: true });
+    cy.get('[data-testid="yaml-confirm-button"]', { timeout: 10000 }).should('be.visible').clickEnabled();
 
     // Wait for success message
     cy.contains('Update submitted', { timeout: 10000 }).should('be.visible');
@@ -401,11 +404,11 @@ describe('ManagedResources - Without Admin Rights', () => {
     );
 
     // Expand resource group
-    cy.get('button[aria-label*="xpand"]').first().click({ force: true });
+    cy.get('button[aria-label*="xpand"]').first().clickEnabled();
     cy.contains('test-subaccount').should('be.visible');
 
     // Open actions menu
-    cy.get('[data-testid="ActionsMenu-opener"]').first().click({ force: true });
+    cy.get('[data-testid="ActionsMenu-opener"]').first().clickEnabled();
 
     // Verify Delete action is disabled by checking the ui5-menu-item element
     cy.get('ui5-menu-item[data-action-key="delete"]').should('have.attr', 'disabled');
@@ -472,7 +475,7 @@ describe('ManagedResources', () => {
     );
 
     // Expand resource group (same pattern as other tests)
-    cy.get('button[aria-label*="xpand"]').first().click({ force: true });
+    cy.get('button[aria-label*="xpand"]').first().clickEnabled();
     cy.contains('some-resource').should('be.visible');
 
     // Link with label value should be rendered (ui5-link)

--- a/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCard.cy.tsx
+++ b/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCard.cy.tsx
@@ -78,10 +78,10 @@ describe('ControlPlaneCard', () => {
     );
 
     cy.get("[data-testid='ControlPlaneCardMenu-opener']").click();
-    cy.contains('Delete').click({ force: true });
-    cy.get('ui5-dialog[open]').find('ui5-input').typeIntoUi5Input('mcp-name');
+    cy.contains('Delete').clickEnabled();
+    cy.openedDialog().find('ui5-input').typeIntoEnabledUi5Input('mcp-name');
     cy.then(() => cy.wrap(deleteManagedControlPlaneCalled).should('equal', false));
-    cy.get('ui5-dialog[open]').find('ui5-button').contains('Delete').click();
+    cy.openedDialog().find('ui5-button').contains('Delete').clickEnabled();
     cy.then(() => cy.wrap(deleteManagedControlPlaneCalled).should('equal', true));
   });
 });

--- a/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.cy.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.cy.tsx
@@ -121,10 +121,10 @@ describe('ControlPlaneListWorkspaceGridTile', () => {
     );
 
     cy.get("[data-testid='ControlPlanesListMenu-opener']").click();
-    cy.contains('Delete workspace').click({ force: true });
-    cy.get('ui5-dialog[open]').find('ui5-input').typeIntoUi5Input('workspaceName');
+    cy.contains('Delete workspace').clickEnabled();
+    cy.openedDialog().find('ui5-input').typeIntoEnabledUi5Input('workspaceName');
     cy.then(() => cy.wrap(deleteWorkspaceCalled).should('equal', false));
-    cy.get('ui5-dialog[open]').find('ui5-button').contains('Delete').click();
+    cy.openedDialog().find('ui5-button').contains('Delete').clickEnabled();
     cy.then(() => cy.wrap(deleteWorkspaceCalled).should('equal', true));
   });
 });

--- a/src/components/Core/ShellBar.cy.tsx
+++ b/src/components/Core/ShellBar.cy.tsx
@@ -24,6 +24,9 @@ describe('ShellBar', () => {
 
   beforeEach(() => {
     logoutCalled = false;
+    // Reset remembered-project state so a test that pins a project doesn't
+    // leak that state into the next test's mount.
+    clearRememberedProject();
   });
 
   const mountComponent = ({ enableHeadlamp = true }: { enableHeadlamp?: boolean } = {}) => {
@@ -84,7 +87,7 @@ describe('ShellBar', () => {
     mountComponent();
 
     cy.get('ui5-avatar').click();
-    cy.contains('Sign Out').click({ force: true });
+    cy.contains('Sign Out').clickEnabled();
 
     cy.wrap(null).should(() => {
       expect(logoutCalled).to.equal(true);
@@ -118,7 +121,7 @@ describe('ShellBar', () => {
     mountComponent();
 
     cy.get('ui5-avatar').click();
-    cy.contains('Clear remembered project').click({ force: true });
+    cy.contains('Clear remembered project').clickEnabled();
 
     cy.wrap(null).should(() => {
       expect(localStorage.getItem('rememberedProject')).to.equal(null);

--- a/src/components/Dialogs/DeleteConfirmationDialog.cy.tsx
+++ b/src/components/Dialogs/DeleteConfirmationDialog.cy.tsx
@@ -47,7 +47,7 @@ describe('DeleteConfirmationDialog', () => {
   it('should enable Delete button when correct resource name is typed', () => {
     mountDialog();
 
-    cy.get('ui5-input[id*="delete-confirm-input"]').find(' input[id*="inner"]').type('test-resource', { force: true });
+    cy.get('ui5-input[id*="delete-confirm-input"]').typeIntoEnabledUi5Input('test-resource');
 
     cy.get('ui5-button').contains('Delete').should('not.have.attr', 'disabled');
   });
@@ -55,7 +55,7 @@ describe('DeleteConfirmationDialog', () => {
   it('should keep Delete button disabled when incorrect name is typed', () => {
     mountDialog();
 
-    cy.get('ui5-input[id*="delete-confirm-input"]').find(' input[id*="inner"]').type('wrong-name', { force: true });
+    cy.get('ui5-input[id*="delete-confirm-input"]').typeIntoEnabledUi5Input('wrong-name');
 
     cy.get('ui5-button').contains('Delete').should('have.attr', 'disabled');
   });
@@ -73,9 +73,9 @@ describe('DeleteConfirmationDialog', () => {
   it('should call onDeletionConfirmed and setIsOpen when Delete is confirmed', () => {
     mountDialog();
 
-    cy.get('ui5-input[id*="delete-confirm-input"]').find(' input[id*="inner"]').type('test-resource');
+    cy.get('ui5-input[id*="delete-confirm-input"]').typeIntoEnabledUi5Input('test-resource');
 
-    cy.get('ui5-button').contains('Delete').click();
+    cy.get('ui5-button').contains('Delete').clickEnabled();
 
     cy.get('@setIsOpen').should('have.been.calledWith', false);
 
@@ -87,7 +87,7 @@ describe('DeleteConfirmationDialog', () => {
     mountDialog();
 
     // Type something
-    cy.get('ui5-input[id*="delete-confirm-input"]').find(' input[id*="inner"]').type('test-resource', { force: true });
+    cy.get('ui5-input[id*="delete-confirm-input"]').typeIntoEnabledUi5Input('test-resource');
 
     // Close dialog
     cy.get('ui5-button').contains('Cancel').click();

--- a/src/components/Projects/ProjectsList.cy.tsx
+++ b/src/components/Projects/ProjectsList.cy.tsx
@@ -44,6 +44,12 @@ const mount = (onProjectSelect?: (name: string) => void) =>
   );
 
 describe('ProjectsList search', () => {
+  beforeEach(() => {
+    // Ensure a stale `rememberedProject` from a previous test can't cause
+    // the ProjectsList to auto-redirect out of the search screen.
+    clearRememberedProject();
+  });
+
   it('shows all projects when search is empty', () => {
     mount();
     cy.contains('alpha-project').should('exist');

--- a/src/components/Projects/ProjectsListItemMenu.cy.tsx
+++ b/src/components/Projects/ProjectsListItemMenu.cy.tsx
@@ -56,10 +56,10 @@ describe('ProjectsListItemMenu', () => {
     );
 
     cy.get('ui5-button[icon="overflow"]').click();
-    cy.contains('Delete project').click({ force: true });
-    cy.get('ui5-dialog[open]').find('ui5-input').typeIntoUi5Input('test-project');
+    cy.contains('Delete project').clickEnabled();
+    cy.openedDialog().find('ui5-input').typeIntoEnabledUi5Input('test-project');
     cy.then(() => cy.wrap(deleteProjectCalled).should('equal', false));
-    cy.get('ui5-dialog[open]').find('ui5-button').contains('Delete').click();
+    cy.openedDialog().find('ui5-button').contains('Delete').clickEnabled();
     cy.then(() => cy.wrap(deleteProjectCalled).should('equal', true));
   });
 
@@ -67,9 +67,9 @@ describe('ProjectsListItemMenu', () => {
     mountMenu();
 
     cy.get('ui5-button[icon="overflow"]').click();
-    cy.contains('Edit project').click({ force: true });
+    cy.contains('Edit project').clickEnabled();
 
-    cy.get('ui5-dialog[open]').should('exist');
+    cy.openedDialog().should('exist');
     cy.get('#name').should('have.attr', 'disabled');
     cy.get('#name').invoke('prop', 'value').should('eq', 'test-project');
   });
@@ -92,12 +92,12 @@ describe('ProjectsListItemMenu', () => {
     );
 
     cy.get('ui5-button[icon="overflow"]').click();
-    cy.contains('Edit project').click({ force: true });
+    cy.contains('Edit project').clickEnabled();
 
     // Wait for the dialog form to be fully rendered (not in loading state)
     cy.get('#displayName').should('not.have.attr', 'disabled');
     cy.get('#displayName').find('input[id*="inner"]').clear().type('Updated Display Name');
-    cy.get('ui5-button').contains('Save').click();
+    cy.get('ui5-button').contains('Save').clickEnabled();
 
     cy.then(() => {
       cy.wrap(updatePayload).should('not.be.null');
@@ -129,13 +129,13 @@ describe('ProjectsListItemMenu', () => {
     );
 
     cy.get('ui5-button[icon="overflow"]').click();
-    cy.contains('Edit project').click({ force: true });
+    cy.contains('Edit project').clickEnabled();
 
-    cy.get('[data-testid="add-member-button"]').first().click({ force: true });
-    cy.get('[data-testid="member-email-input"]').typeIntoUi5Input('new-user@example.com');
-    cy.get('[data-testid="add-member-button"]').last().click({ force: true });
+    cy.get('[data-testid="add-member-button"]').first().clickEnabled();
+    cy.get('[data-testid="member-email-input"]').typeIntoEnabledUi5Input('new-user@example.com');
+    cy.get('[data-testid="add-member-button"]').last().clickEnabled();
 
-    cy.get('ui5-button').contains('Save').click();
+    cy.get('ui5-button').contains('Save').clickEnabled();
 
     cy.then(() => {
       cy.wrap(updatePayload).should('not.be.null');

--- a/src/components/Shared/CopyButton.cy.tsx
+++ b/src/components/Shared/CopyButton.cy.tsx
@@ -14,32 +14,36 @@ describe('CopyButton collapsible', () => {
     );
   };
 
+  // Re-query the button each time — Cypress `cy.get()` returns a chainable
+  // that resolves to whatever the DOM had when it ran. Reusing a chain
+  // reference across actions/renders was a source of stale-element flakes
+  // combined with the `cy.wait(350)` animation delays we've now removed.
+  const button = () => cy.get('ui5-button[icon="copy"]');
+
   it('renders with copy icon only when not hovered', () => {
     mountWithProviders(<CopyButton collapsible text={testText} />);
 
-    cy.get('ui5-button[icon="copy"]').should('exist');
+    button().should('exist');
   });
 
   it('expands to show text on hover', () => {
     mountWithProviders(<CopyButton collapsible text={testText} />);
 
-    const button = cy.get('ui5-button[icon="copy"]');
-    button.trigger('mouseenter', { force: true });
-
-    cy.wait(350);
-    button.should('contain.text', testText);
+    // `.trigger('mouseenter', { force: true })` is intentional: UI5 web
+    // components don't reliably surface synthetic mouseenter across their
+    // shadow-DOM boundary otherwise. It's a UI5 quirk, not a masked bug.
+    button().trigger('mouseenter', { force: true });
+    // `should` retries until the animation completes — no cy.wait needed.
+    button().should('contain.text', testText);
   });
 
   it('collapses when mouse leaves', () => {
     mountWithProviders(<CopyButton collapsible text={testText} />);
 
-    const button = cy.get('ui5-button[icon="copy"]');
-    button.trigger('mouseenter', { force: true });
-    cy.wait(350);
-    button.trigger('mouseleave', { force: true });
-    cy.wait(350);
-
-    button.should('exist');
+    button().trigger('mouseenter', { force: true });
+    button().should('contain.text', testText);
+    button().trigger('mouseleave', { force: true });
+    button().should('not.contain.text', testText);
   });
 
   it('shows success state when clicked', () => {
@@ -54,31 +58,26 @@ describe('CopyButton collapsible', () => {
 
     mountWithProviders(<CopyButton collapsible text={testText} />);
 
-    const button = cy.get('ui5-button[icon="copy"]');
-    button.trigger('mouseenter', { force: true });
-    cy.wait(350);
-    button.click();
-    cy.wait(500);
+    button().trigger('mouseenter', { force: true });
+    button().should('contain.text', testText);
+    button().click();
 
-    button.should('have.attr', 'design', 'Positive');
-    button.should('contain.text', 'Copied to clipboard');
+    button().should('have.attr', 'design', 'Positive');
+    button().should('contain.text', 'Copied to clipboard');
   });
 
   it('displays text as tooltip', () => {
     mountWithProviders(<CopyButton collapsible text={testText} />);
 
-    cy.get('ui5-button[icon="copy"]').should('have.attr', 'tooltip', testText);
+    button().should('have.attr', 'tooltip', testText);
   });
 
   it('handles long strings', () => {
     const longText = 'project-very-long-project-name--ws-very-long-workspace-name';
     mountWithProviders(<CopyButton collapsible text={longText} />);
 
-    const button = cy.get('ui5-button[icon="copy"]');
-    button.trigger('mouseenter', { force: true });
-    cy.wait(350);
-
-    button.should('contain.text', longText);
+    button().trigger('mouseenter', { force: true });
+    button().should('contain.text', longText);
   });
 
   it('renders non-collapsible variant without container div', () => {


### PR DESCRIPTION
## Problem

We've been hitting the same class of Cypress flake repeatedly:

```
CypressError: cy.type() failed because it targeted a disabled element.
```

A repo-wide sweep turned up ~30 offending sites concentrated in two anti-patterns:

1. **`{ force: true }` on `.click()` / `.type()`** — Cypress's implicit retry only runs before `.should()` assertions, *not* before actions. When a menu item, dialog input, or overflow button hasn't finished mounting/enabling, plain `.click()` fails intermittently. `force` makes it "pass" but the underlying race is still there — sometimes the click actually lands on the wrong element or triggers before form state is reconciled.
2. **`cy.wait(350)` / `cy.wait(500)` for animations and dialog opens** — hard-coded delays are brittle (they fail when a machine is slow, e.g. CI) and hide real timing bugs.

Combined with **UI5 dialogs whose `onOpen` fires a `react-hook-form.reset()` a tick after mount** (see [ManagedResources.cy.tsx:153](https://github.com/openmcp-project/ui-frontend/blob/main/src/components/ControlPlane/ManagedResources.cy.tsx#L153) — the comment explicitly acknowledges this), the inner `<input>` can transition from enabled → disabled → enabled during the first 100–500ms of a dialog. Tests that fire `cy.type()` at the wrong moment in that dance fail hard.

## Solution — three new custom commands

Added to [cypress/support/commands.ts](../blob/test/stabilize-cypress-flake/cypress/support/commands.ts):

| Command | Replaces | Behavior |
|---|---|---|
| `.clickEnabled()` | `.click({ force: true })` | Asserts `visible` + `not.have.attr('disabled')` (both auto-retry), then clicks. |
| `.typeIntoEnabledUi5Input(text)` | `.find(' input[id*="inner"]').type(..., { force: true })` | Same gate on the outer `<ui5-input>`, then uses UI5's shadow-DOM-aware `typeIntoUi5Input`. |
| `cy.openedDialog(sel?)` | `cy.get('ui5-dialog[open]')` before dialog contents are touched | Selector defaults to `ui5-dialog[open]`; waits for `.should('be.visible')`. |

All three build on `.should()`, so the assertion retries until the element is actually ready. If it never becomes ready, the test fails **at the readiness assertion** with a clear message instead of "click succeeded but the app did nothing" — that's the diagnostic win.

## Changes

- **Commit 1** — Add the three helpers + JSDoc + TypeScript declarations. No behavior changes.
- **Commit 2** — Move `clearRememberedProject()` cleanup into `beforeEach` in `ShellBar.cy.tsx` and `ProjectsList.cy.tsx` (search describe). Previously scattered inline, so a failing test would leak state.
- **Commit 3** — Sweep 6 test files:
  - ~20 `{ force: true }` calls → `.clickEnabled()`
  - 3 shadow-DOM force-types → `.typeIntoEnabledUi5Input()`
  - 6 fixed `cy.wait(350|500)` (CopyButton animations) → observable-state assertions like `.should('contain.text', ...)`
  - 1 `cy.wait(500)` for dialog reset (ManagedResources) → `cy.openedDialog(); cy.contains('Advanced').should('be.visible')`
  - Fixed a stale-chain bug in `CopyButton.cy.tsx`: `const button = cy.get(...)` reused across renders → now a `button()` helper that re-queries.

Two `.trigger('mouseenter'|'mouseleave', { force: true })` calls in CopyButton were kept — UI5 web components don't reliably surface synthetic mouse events across the shadow-DOM boundary otherwise. A comment explains why.

## Files touched

| File | Change |
|---|---|
| `cypress/support/commands.ts` | +59 (three helpers) |
| `cypress/support/commands.d.ts` | +30 (types) |
| `src/components/ControlPlane/ManagedResources.cy.tsx` | 11 force → clickEnabled, 1 wait removed |
| `src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCard.cy.tsx` | 1 force → clickEnabled, dialog helper |
| `src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.cy.tsx` | 1 force → clickEnabled, dialog helper |
| `src/components/Core/ShellBar.cy.tsx` | 2 force → clickEnabled, beforeEach cleanup |
| `src/components/Dialogs/DeleteConfirmationDialog.cy.tsx` | 3 force-typed inputs → typeIntoEnabledUi5Input |
| `src/components/Projects/ProjectsList.cy.tsx` | beforeEach cleanup |
| `src/components/Projects/ProjectsListItemMenu.cy.tsx` | 6 force → clickEnabled |
| `src/components/Shared/CopyButton.cy.tsx` | 6 cy.wait removed, stale-chain fix |

## What this does NOT fix (yet)

Two production-side sources of flake remain, better tackled separately:

- **`fetchPolicy: 'network-only'`** in [useGetProject.ts](src/spaces/onboarding/hooks/useGetProject.ts) / [useGetWorkspace.ts](src/spaces/onboarding/hooks/useGetWorkspace.ts). In tests with a `MockedProvider` that has one matching mock, a re-render triggers a second request with no mock → indefinite loading → fields disabled forever. Fix requires either duplicate mocks in tests or a test-only override of the fetch policy.
- **Dialogs' `useEffect(() => reset(...))` pattern** in edit forms — root cause of "field briefly disabled after mount". The correct fix is `defaultValues` derived synchronously via `useMemo` + a `key` prop for remount, but that's a component refactor.

## Verification

- `npm run type-check` ✅
- `npm run lint` ✅
- Cypress runs deferred to CI (they need `--component` + Chrome; you've historically run these on your side).

## Suggested review order

1. Read the three helper definitions in `cypress/support/commands.ts` (small file, self-contained, JSDoc explains the rationale inline).
2. Skim commit 3 for one file — the pattern is identical across all six.