### PR TITLE
Update ProjectsList.tsx - remove responsivePopIn

### DIFF
--- a/src/components/Projects/ProjectsList.tsx
+++ b/src/components/Projects/ProjectsList.tsx
@@ -189,7 +189,6 @@ export default function ProjectsList({
         accessor: 'creationTimestamp',
         width: 120,
         disableFilters: true,
-        responsivePopIn: true,
         responsiveMinWidth: 1200,
         sortType: (rowA: { original: ProjectListRow }, rowB: { original: ProjectListRow }) => {
           const a = timestampsRef.current.get(rowA.original.projectName) ?? '';


### PR DESCRIPTION
<img width="943" height="440" alt="image" src="https://github.com/user-attachments/assets/fded8dcb-cbf0-406b-81a8-56f9f70cf035" />

remove this behavior of moving createdAt column into name if width is too small. 
we simply do not show column anymore