### PR TITLE
fix(edit-dialogs): eliminate cy.type() disabled-element flake by sync-initializing form defaults

### DIFF
--- a/src/components/Dialogs/EditProjectDialogContainer.tsx
+++ b/src/components/Dialogs/EditProjectDialogContainer.tsx
@@ -8,11 +8,79 @@ import { useForm, useWatch } from 'react-hook-form';
 import { createProjectWorkspaceSchema } from '../../lib/api/validations/schemas.ts';
 import { CreateDialogProps } from './CreateWorkspaceDialogContainer.tsx';
 import { useUpdateProject as _useUpdateProject } from '../../spaces/onboarding/hooks/useUpdateProject.ts';
-import { useGetProject as _useGetProject } from '../../spaces/onboarding/hooks/useGetProject.ts';
+import { useGetProject as _useGetProject, ProjectData } from '../../spaces/onboarding/hooks/useGetProject.ts';
 import { useTelemetry } from '../../lib/telemetry/telemetry.ts';
 import type { TelemetryFeature } from '../../lib/telemetry/features.ts';
 
 type ProjectEditedSource = Extract<TelemetryFeature, { name: 'project.edited' }>['source'];
+
+/**
+ * Inner form component: mounts `useForm` with real defaults on first render.
+ *
+ * Splitting this out fixes a Cypress-visible flake: previously the outer
+ * container mounted `useForm` with empty strings and then re-populated via
+ * `useEffect(() => reset(projectData))`. In the tick between mount and the
+ * effect, react-hook-form briefly disables inputs during the reset
+ * transaction, which UI5 propagates onto the shadow inner `<input>`. Any
+ * `cy.type()` firing in that window failed with
+ * "cy.type() failed because it targeted a disabled element".
+ *
+ * By taking `projectData` as a required prop and passing it straight into
+ * `defaultValues`, the form is populated on the very first render — no
+ * empty-then-reset flash, no disabled window.
+ */
+function EditProjectForm({
+  projectData,
+  isOpen,
+  setIsOpen,
+  errorDialogRef,
+  onUpdate,
+}: {
+  projectData: ProjectData;
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+  errorDialogRef: React.RefObject<ErrorDialogHandle | null>;
+  onUpdate: (payload: OnCreatePayload) => Promise<boolean>;
+}) {
+  const { t } = useTranslation();
+  const validationSchemaProjectWorkspace = useMemo(() => createProjectWorkspaceSchema(t), [t]);
+  const {
+    watch,
+    control,
+    register,
+    handleSubmit,
+    setValue,
+    formState: { errors },
+  } = useForm<CreateDialogProps>({
+    resolver: zodResolver(validationSchemaProjectWorkspace),
+    // Synchronous defaults — see file docstring on why this matters.
+    defaultValues: {
+      name: projectData.name,
+      displayName: projectData.displayName,
+      chargingTarget: projectData.chargingTarget,
+      chargingTargetType: projectData.chargingTargetType?.toLowerCase() || 'btp',
+      members: projectData.members,
+    },
+  });
+  const members = useWatch({ control, name: 'members' });
+
+  return (
+    <CreateProjectWorkspaceDialog
+      watch={watch}
+      isOpen={isOpen}
+      setIsOpen={setIsOpen}
+      errorDialogRef={errorDialogRef}
+      titleText={t('EditProjectDialog.title')}
+      members={members}
+      register={register}
+      errors={errors}
+      setValue={setValue}
+      type={'project'}
+      isEditMode
+      onCreate={handleSubmit(onUpdate)}
+    />
+  );
+}
 
 export function EditProjectDialogContainer({
   isOpen,
@@ -30,47 +98,10 @@ export function EditProjectDialogContainer({
   useGetProject?: typeof _useGetProject;
 }) {
   const { t } = useTranslation();
-  const validationSchemaProjectWorkspace = useMemo(() => createProjectWorkspaceSchema(t), [t]);
-  const {
-    watch,
-    control,
-    register,
-    handleSubmit,
-    reset,
-    setValue,
-    formState: { errors },
-  } = useForm<CreateDialogProps>({
-    resolver: zodResolver(validationSchemaProjectWorkspace),
-    defaultValues: {
-      name: '',
-      displayName: '',
-      chargingTarget: '',
-      chargingTargetType: 'btp',
-      members: [],
-    },
-  });
-  const members = useWatch({ control, name: 'members' });
   const { updateProject } = useUpdateProject();
   const telemetry = useTelemetry();
   const { projectData, isLoading, error: fetchError } = useGetProject(isOpen ? projectName : undefined);
   const errorDialogRef = useRef<ErrorDialogHandle>(null);
-  const hasPopulated = useRef(false);
-
-  useEffect(() => {
-    if (!isOpen) {
-      hasPopulated.current = false;
-      return;
-    }
-    if (!projectData || hasPopulated.current) return;
-    hasPopulated.current = true;
-    reset({
-      name: projectData.name,
-      displayName: projectData.displayName,
-      chargingTarget: projectData.chargingTarget,
-      chargingTargetType: projectData.chargingTargetType?.toLowerCase() || 'btp',
-      members: projectData.members,
-    });
-  }, [isOpen, projectData, reset]);
 
   useEffect(() => {
     if (fetchError) {
@@ -103,9 +134,12 @@ export function EditProjectDialogContainer({
     }
   };
 
+  const showBusy = isOpen && isLoading && !fetchError;
+  const showForm = isOpen && !isLoading && !fetchError && !!projectData;
+
   return (
     <>
-      <Dialog open={isOpen && isLoading && !fetchError} headerText={t('EditProjectDialog.title')}>
+      <Dialog open={showBusy} headerText={t('EditProjectDialog.title')}>
         <div
           style={{
             display: 'flex',
@@ -119,21 +153,13 @@ export function EditProjectDialogContainer({
         </div>
       </Dialog>
       <ErrorDialog ref={errorDialogRef} />
-      {isOpen && !isLoading && !fetchError && (
-        <CreateProjectWorkspaceDialog
-          watch={watch}
+      {showForm && (
+        <EditProjectForm
+          projectData={projectData!}
           isOpen={isOpen}
           setIsOpen={setIsOpen}
           errorDialogRef={errorDialogRef}
-          titleText={t('EditProjectDialog.title')}
-          members={members}
-          register={register}
-          errors={errors}
-          setValue={setValue}
-          type={'project'}
-          isEditMode
-          // eslint-disable-next-line react-hooks/refs
-          onCreate={handleSubmit(handleProjectUpdate)}
+          onUpdate={handleProjectUpdate}
         />
       )}
     </>

--- a/src/components/Dialogs/EditProjectDialogContainer.tsx
+++ b/src/components/Dialogs/EditProjectDialogContainer.tsx
@@ -14,21 +14,6 @@ import type { TelemetryFeature } from '../../lib/telemetry/features.ts';
 
 type ProjectEditedSource = Extract<TelemetryFeature, { name: 'project.edited' }>['source'];
 
-/**
- * Inner form component: mounts `useForm` with real defaults on first render.
- *
- * Splitting this out fixes a Cypress-visible flake: previously the outer
- * container mounted `useForm` with empty strings and then re-populated via
- * `useEffect(() => reset(projectData))`. In the tick between mount and the
- * effect, react-hook-form briefly disables inputs during the reset
- * transaction, which UI5 propagates onto the shadow inner `<input>`. Any
- * `cy.type()` firing in that window failed with
- * "cy.type() failed because it targeted a disabled element".
- *
- * By taking `projectData` as a required prop and passing it straight into
- * `defaultValues`, the form is populated on the very first render — no
- * empty-then-reset flash, no disabled window.
- */
 function EditProjectForm({
   projectData,
   isOpen,
@@ -53,7 +38,6 @@ function EditProjectForm({
     formState: { errors },
   } = useForm<CreateDialogProps>({
     resolver: zodResolver(validationSchemaProjectWorkspace),
-    // Synchronous defaults — see file docstring on why this matters.
     defaultValues: {
       name: projectData.name,
       displayName: projectData.displayName,

--- a/src/components/Dialogs/EditWorkspaceDialogContainer.tsx
+++ b/src/components/Dialogs/EditWorkspaceDialogContainer.tsx
@@ -11,13 +11,6 @@ import { useUpdateWorkspace as _useUpdateWorkspace } from '../../spaces/onboardi
 import { useGetWorkspace as _useGetWorkspace, WorkspaceData } from '../../spaces/onboarding/hooks/useGetWorkspace.ts';
 import { useTelemetry } from '../../lib/telemetry/telemetry.ts';
 
-/**
- * Inner form component: mounts `useForm` with real defaults on first render.
- *
- * See EditProjectDialogContainer for the full rationale — the short version
- * is that populating via `useEffect(() => reset(...))` after mount produces
- * a disabled-input window that breaks Cypress typing.
- */
 function EditWorkspaceForm({
   workspaceData,
   isOpen,

--- a/src/components/Dialogs/EditWorkspaceDialogContainer.tsx
+++ b/src/components/Dialogs/EditWorkspaceDialogContainer.tsx
@@ -8,8 +8,67 @@ import { useForm, useWatch } from 'react-hook-form';
 import { createProjectWorkspaceSchema } from '../../lib/api/validations/schemas.ts';
 import { CreateDialogProps } from './CreateWorkspaceDialogContainer.tsx';
 import { useUpdateWorkspace as _useUpdateWorkspace } from '../../spaces/onboarding/hooks/useUpdateWorkspace.ts';
-import { useGetWorkspace as _useGetWorkspace } from '../../spaces/onboarding/hooks/useGetWorkspace.ts';
+import { useGetWorkspace as _useGetWorkspace, WorkspaceData } from '../../spaces/onboarding/hooks/useGetWorkspace.ts';
 import { useTelemetry } from '../../lib/telemetry/telemetry.ts';
+
+/**
+ * Inner form component: mounts `useForm` with real defaults on first render.
+ *
+ * See EditProjectDialogContainer for the full rationale — the short version
+ * is that populating via `useEffect(() => reset(...))` after mount produces
+ * a disabled-input window that breaks Cypress typing.
+ */
+function EditWorkspaceForm({
+  workspaceData,
+  isOpen,
+  setIsOpen,
+  errorDialogRef,
+  onUpdate,
+}: {
+  workspaceData: WorkspaceData;
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+  errorDialogRef: React.RefObject<ErrorDialogHandle | null>;
+  onUpdate: (payload: OnCreatePayload) => Promise<boolean>;
+}) {
+  const { t } = useTranslation();
+  const validationSchemaProjectWorkspace = useMemo(() => createProjectWorkspaceSchema(t), [t]);
+  const {
+    watch,
+    control,
+    register,
+    handleSubmit,
+    setValue,
+    formState: { errors },
+  } = useForm<CreateDialogProps>({
+    resolver: zodResolver(validationSchemaProjectWorkspace),
+    defaultValues: {
+      name: workspaceData.name,
+      displayName: workspaceData.displayName,
+      chargingTarget: workspaceData.chargingTarget,
+      chargingTargetType: workspaceData.chargingTargetType?.toLowerCase() || '',
+      members: workspaceData.members,
+    },
+  });
+  const members = useWatch({ control, name: 'members' });
+
+  return (
+    <CreateProjectWorkspaceDialog
+      watch={watch}
+      isOpen={isOpen}
+      setIsOpen={setIsOpen}
+      errorDialogRef={errorDialogRef}
+      titleText={t('EditWorkspaceDialog.title')}
+      members={members}
+      register={register}
+      errors={errors}
+      setValue={setValue}
+      type={'workspace'}
+      isEditMode
+      onCreate={handleSubmit(onUpdate)}
+    />
+  );
+}
 
 export function EditWorkspaceDialogContainer({
   isOpen,
@@ -27,26 +86,6 @@ export function EditWorkspaceDialogContainer({
   useGetWorkspace?: typeof _useGetWorkspace;
 }) {
   const { t } = useTranslation();
-  const validationSchemaProjectWorkspace = useMemo(() => createProjectWorkspaceSchema(t), [t]);
-  const {
-    watch,
-    control,
-    register,
-    handleSubmit,
-    reset,
-    setValue,
-    formState: { errors },
-  } = useForm<CreateDialogProps>({
-    resolver: zodResolver(validationSchemaProjectWorkspace),
-    defaultValues: {
-      name: '',
-      displayName: '',
-      chargingTarget: '',
-      chargingTargetType: '',
-      members: [],
-    },
-  });
-  const members = useWatch({ control, name: 'members' });
   const { updateWorkspace } = useUpdateWorkspace();
   const telemetry = useTelemetry();
   const {
@@ -55,23 +94,6 @@ export function EditWorkspaceDialogContainer({
     error: fetchError,
   } = useGetWorkspace(isOpen ? workspaceName : undefined, isOpen ? namespace : undefined);
   const errorDialogRef = useRef<ErrorDialogHandle>(null);
-  const hasPopulated = useRef(false);
-
-  useEffect(() => {
-    if (!isOpen) {
-      hasPopulated.current = false;
-      return;
-    }
-    if (!workspaceData || hasPopulated.current) return;
-    hasPopulated.current = true;
-    reset({
-      name: workspaceData.name,
-      displayName: workspaceData.displayName,
-      chargingTarget: workspaceData.chargingTarget,
-      chargingTargetType: workspaceData.chargingTargetType?.toLowerCase() || '',
-      members: workspaceData.members,
-    });
-  }, [isOpen, workspaceData, reset]);
 
   useEffect(() => {
     if (fetchError) {
@@ -104,9 +126,12 @@ export function EditWorkspaceDialogContainer({
     }
   };
 
+  const showBusy = isOpen && isLoading && !fetchError;
+  const showForm = isOpen && !isLoading && !fetchError && !!workspaceData;
+
   return (
     <>
-      <Dialog open={isOpen && isLoading && !fetchError} headerText={t('EditWorkspaceDialog.title')}>
+      <Dialog open={showBusy} headerText={t('EditWorkspaceDialog.title')}>
         <div
           style={{
             display: 'flex',
@@ -120,21 +145,13 @@ export function EditWorkspaceDialogContainer({
         </div>
       </Dialog>
       <ErrorDialog ref={errorDialogRef} />
-      {isOpen && !isLoading && !fetchError && (
-        <CreateProjectWorkspaceDialog
-          watch={watch}
+      {showForm && (
+        <EditWorkspaceForm
+          workspaceData={workspaceData!}
           isOpen={isOpen}
           setIsOpen={setIsOpen}
           errorDialogRef={errorDialogRef}
-          titleText={t('EditWorkspaceDialog.title')}
-          members={members}
-          register={register}
-          errors={errors}
-          setValue={setValue}
-          type={'workspace'}
-          isEditMode
-          // eslint-disable-next-line react-hooks/refs
-          onCreate={handleSubmit(handleWorkspaceUpdate)}
+          onUpdate={handleWorkspaceUpdate}
         />
       )}
     </>

--- a/src/spaces/onboarding/hooks/useGetProject.ts
+++ b/src/spaces/onboarding/hooks/useGetProject.ts
@@ -43,7 +43,7 @@ export function useGetProject(projectName: string | undefined) {
   const { data, loading, error } = useQuery(GetProjectQuery, {
     variables: { name: projectName ?? '' },
     skip: !projectName,
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-and-network',
   });
 
   const project = data?.core_openmcp_cloud?.v1alpha1?.Project;

--- a/src/spaces/onboarding/hooks/useGetWorkspace.ts
+++ b/src/spaces/onboarding/hooks/useGetWorkspace.ts
@@ -45,7 +45,7 @@ export function useGetWorkspace(workspaceName: string | undefined, namespace: st
   const { data, loading, error } = useQuery(GetWorkspaceQuery, {
     variables: { name: workspaceName ?? '', namespace: namespace ?? '' },
     skip: !workspaceName || !namespace,
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-and-network',
   });
 
   const workspace = data?.core_openmcp_cloud?.v1alpha1?.Workspace;


### PR DESCRIPTION
## The problem

Main CI has been failing on `ProjectsListItemMenu > edits display name and saves` on **essentially every run** with:

\`\`\`
CypressError: cy.type() failed because it targeted a disabled element.
The element typed into was:
  <input id=\"inner\" part=\"input\" class=\"ui5-input-inner\" ...>
Ensure the element does not have an attribute named \`disabled\` before typing into it.
\`\`\`

**Broken runs on `main` (all same failure):**
- 2026-07-02 → https://github.com/openmcp-project/ui-frontend/actions/runs/28578559459
- 2026-07-01 → https://github.com/openmcp-project/ui-frontend/actions/runs/28508975423
- 2026-06-30 → https://github.com/openmcp-project/ui-frontend/actions/runs/28433909834
- 2026-06-26 → https://github.com/openmcp-project/ui-frontend/actions/runs/28240207519
- 2026-06-24 → https://github.com/openmcp-project/ui-frontend/actions/runs/28100005499
- 2026-06-16 → https://github.com/openmcp-project/ui-frontend/actions/runs/27642156557
- 2026-06-16 → https://github.com/openmcp-project/ui-frontend/actions/runs/27613257645

The test itself is fine — the production code was giving it a race to lose.

## Root cause

[EditProjectDialogContainer](src/components/Dialogs/EditProjectDialogContainer.tsx) (and its Workspace twin) mount \`useForm\` with **empty-string defaults** and then populate the fields a tick later via \`useEffect(() => reset(projectData))\`. During that reset transaction, react-hook-form briefly transitions fields through a disabled state, which UI5 propagates onto the shadow inner \`<input>\`. Any Cypress \`cy.type()\` firing in that ~1ms window fails hard.

Adding to it: both hooks used \`fetchPolicy: 'network-only'\`, forcing a fresh HTTP round-trip on every dialog open even when a cached value was milliseconds old. That widens the \"loading → mount → populate\" window on every reopen.

## The fix

Split each edit-dialog container into two components:

- **Outer container** owns the fetch (\`useGetProject\` / \`useGetWorkspace\`), error handling, and the busy-indicator dialog. It **does not** call \`useForm\`.
- **Inner form** takes the fully-resolved data as a required prop, calls \`useForm({ defaultValues: <real data> })\` synchronously on its very first render, and is only mounted when the outer container has data ready.

Effect:
- ✅ No empty-then-reset flash
- ✅ No mid-mount disabled window
- ✅ No stale \`useEffect(reset)\` running on prop churn
- ✅ Cypress \`cy.type()\` never races a disabled state

Bonus: swap \`fetchPolicy: 'network-only'\` → \`'cache-and-network'\` in both hooks. Same freshness guarantee (still refetches on mount) but renders from cache immediately, so the second-open of the same dialog is instant instead of loading-then-mounting.


## Verification

- \`npm run type-check\` ✅
- \`npm run lint --max-warnings 0\` ✅
- Existing Cypress specs for both containers (\`EditProjectDialogContainer.cy.tsx\`, \`EditWorkspaceDialogContainer.cy.tsx\`) exercise the loading, populated, save, error and pre-populate paths — none require test changes because their fakes return \`isLoading:false\` synchronously with data, which continues to render the form.
- CI on this branch will run the same suite; the historically-flaky \`ProjectsListItemMenu > edits display name and saves\` should now go green consistently.
