### PR TITLE
fix: hide search bar when there are no projects/workspaces

### DIFF
--- a/src/components/Projects/ProjectsList.tsx
+++ b/src/components/Projects/ProjectsList.tsx
@@ -10,9 +10,9 @@ import '@ui5/webcomponents-icons/dist/copy';
 import { t } from 'i18next';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRememberedProject } from '../../hooks/useRememberedProject.ts';
+import { useTelemetry } from '../../lib/telemetry/telemetry.ts';
 import { useProjectMembers as _useProjectMembers } from '../../spaces/onboarding/hooks/useProjectMembers';
 import { useProjectsQuery as _useProjectsQuery } from '../../spaces/onboarding/hooks/useProjectsQuery';
-import { useTelemetry } from '../../lib/telemetry/telemetry.ts';
 import { projectnameToNamespace } from '../../utils';
 import { formatDateAsTimeAgo } from '../../utils/i18n/timeAgo';
 import { CopyButton } from '../Shared/CopyButton.tsx';
@@ -268,7 +268,9 @@ export default function ProjectsList({
 
   return (
     <FadeIn>
-      <ResourceSearchBar focusOnMount value={search} onChange={handleSearchChange} onKeyDown={handleSearchKeyDown} />
+      {data.length > 0 && (
+        <ResourceSearchBar focusOnMount value={search} onChange={handleSearchChange} onKeyDown={handleSearchKeyDown} />
+      )}
       <div ref={tableContainerRef}>
         <AnalyticalTable
           style={{

--- a/src/spaces/onboarding/pages/ProjectPage.tsx
+++ b/src/spaces/onboarding/pages/ProjectPage.tsx
@@ -12,7 +12,6 @@ import { CopyButton } from '../../../components/Shared/CopyButton.tsx';
 import IllustratedError from '../../../components/Shared/IllustratedError.tsx';
 import Loading from '../../../components/Shared/Loading.tsx';
 import { ResourceSearchBar } from '../../../components/Shared/ResourceSearchBar.tsx';
-import styles from './ProjectPage.module.css';
 import { Center } from '../../../components/Ui/Center/Center.tsx';
 import { NotFoundBanner } from '../../../components/Ui/NotFoundBanner/NotFoundBanner.tsx';
 import { useRememberedProject } from '../../../hooks/useRememberedProject.ts';
@@ -21,6 +20,7 @@ import { useTelemetry } from '../../../lib/telemetry/telemetry.ts';
 import { Routes } from '../../../Routes.ts';
 import { projectnameToNamespace } from '../../../utils/index.ts';
 import { useWorkspacesQuery } from '../hooks/useWorkspacesQuery.ts';
+import styles from './ProjectPage.module.css';
 
 export default function ProjectPage() {
   const { projectName } = useParams();
@@ -152,13 +152,15 @@ export default function ProjectPage() {
         }
         //TODO: project chooser should be part of the breadcrumb section if possible?
       >
-        <ResourceSearchBar
-          className={styles.searchBar}
-          focusOnMount
-          value={search}
-          onChange={handleSearchChange}
-          onKeyDown={handleSearchKeyDown}
-        />
+        {workspaces.length > 0 && (
+          <ResourceSearchBar
+            className={styles.searchBar}
+            focusOnMount
+            value={search}
+            onChange={handleSearchChange}
+            onKeyDown={handleSearchKeyDown}
+          />
+        )}
         <ControlPlaneListAllWorkspaces projectName={projectName} workspaces={workspaces} search={search} />
       </ObjectPage>
     </>


### PR DESCRIPTION
**What this PR does / why we need it**:
Hide search bar when there are no projects/workspaces because it is not needed