### PR TITLE
fix(controlplane): remove Download Kubeconfig from View dropdown

### DIFF
--- a/src/components/ControlPlanes/ConnectButton/ConnectButton.tsx
+++ b/src/components/ControlPlanes/ConnectButton/ConnectButton.tsx
@@ -1,6 +1,5 @@
 import { Button, Menu, MenuItem, MenuSeparator } from '@ui5/webcomponents-react';
 import { useId, useState } from 'react';
-import { DownloadKubeconfig } from '../CopyKubeconfigButton.tsx';
 import { useTranslation } from 'react-i18next';
 import { useNavigate as _useNavigate } from 'react-router-dom';
 import { useConnectOptions, type ConnectOption } from './useConnectOptions.ts';
@@ -53,14 +52,7 @@ export default function ConnectButton({
   };
 
   const handleMenuAction = (event: CustomEvent) => {
-    const { action, target } = event.detail.item.dataset;
-
-    if (action === 'download') {
-      DownloadKubeconfig(kubeconfigResource, controlPlaneName);
-      telemetry.track({ name: 'kubeconfig.downloaded', source: 'controlplane-card' });
-      setIsMenuOpen(false);
-      return;
-    }
+    const { target } = event.detail.item.dataset;
 
     if (target) {
       const selected = connectionTargets.find((option) => option.url === target);
@@ -128,8 +120,6 @@ export default function ConnectButton({
               additionalText={t('ConnectButton.customIdP')}
             />
           ))}
-        <MenuSeparator />
-        <MenuItem text={t('ConnectButton.downloadKubeconfig')} data-action="download" />
       </Menu>
     </div>
   );

--- a/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCardMenu.tsx
+++ b/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCardMenu.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useApiResource } from '../../../lib/api/useApiResource.ts';
 import { GetKubeconfig } from '../../../lib/api/types/crate/getKubeconfig.ts';
 import { DownloadKubeconfig } from '../CopyKubeconfigButton.tsx';
+import { useTelemetry } from '../../../lib/telemetry/telemetry.ts';
 
 type ControlPlanesListMenuProps = {
   setDialogDeleteMcpIsOpen: Dispatch<SetStateAction<boolean>>;
@@ -28,6 +29,7 @@ export const ControlPlaneCardMenu: FC<ControlPlanesListMenuProps> = ({
   const openerId = useId();
   const [menuIsOpen, setMenuIsOpen] = useState(false);
   const { t } = useTranslation();
+  const telemetry = useTelemetry();
   const hasAccessInfo = !!(secretKey && secretName && namespace);
   const { data: kubeconfigResource } = useApiResource(
     GetKubeconfig(secretKey, secretName, namespace),
@@ -66,6 +68,7 @@ export const ControlPlaneCardMenu: FC<ControlPlanesListMenuProps> = ({
           }
           if (action === 'downloadKubeconfig') {
             DownloadKubeconfig(kubeconfigResource, controlPlaneName);
+            telemetry.track({ name: 'kubeconfig.downloaded', source: 'controlplane-card' });
           }
 
           setMenuIsOpen(false);

--- a/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCardMenuV2.tsx
+++ b/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCardMenuV2.tsx
@@ -6,6 +6,7 @@ import { Dispatch, FC, SetStateAction, useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useKubeconfigQuery } from '../../../spaces/onboarding/hooks/useKubeconfigQuery.ts';
 import { DownloadKubeconfig } from '../CopyKubeconfigButton.tsx';
+import { useTelemetry } from '../../../lib/telemetry/telemetry.ts';
 
 type ControlPlaneCardMenuV2Props = {
   setDialogDeleteMcpIsOpen: Dispatch<SetStateAction<boolean>>;
@@ -27,6 +28,7 @@ export const ControlPlaneCardMenuV2: FC<ControlPlaneCardMenuV2Props> = ({
   const openerId = useId();
   const [menuIsOpen, setMenuIsOpen] = useState(false);
   const { t } = useTranslation();
+  const telemetry = useTelemetry();
   const { kubeconfigDecoded } = useKubeconfigQuery(oidcOpenmcpSecretName, mcpNamespace, 'kubeconfig');
 
   return (
@@ -52,6 +54,7 @@ export const ControlPlaneCardMenuV2: FC<ControlPlaneCardMenuV2Props> = ({
           }
           if (action === 'downloadKubeconfig') {
             DownloadKubeconfig(kubeconfigDecoded, controlPlaneName);
+            telemetry.track({ name: 'kubeconfig.downloaded', source: 'controlplane-card' });
           }
           setMenuIsOpen(false);
         }}


### PR DESCRIPTION
## The problem

`Download Kubeconfig` was moved behind the three-dots card menu, but the entry was never removed from the **View** button dropdown (`ConnectButton`). Result: the same action appears in two places on the same card.




## The fix

<img width="531" height="340" alt="image" src="https://github.com/user-attachments/assets/d0d673eb-5ca3-43c3-ac67-8bbe0a3912b1" />
<img width="440" height="340" alt="image" src="https://github.com/user-attachments/assets/4b7821d8-188e-4a0d-b67a-af303302e5db" />