### PR TITLE
fix: remove X-Frame-Options header to allow portal embedding

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -123,6 +123,9 @@ fastify.register(helmet, {
   // Headlamp's inline bootstrap scripts are blocked by script-src 'self', and the header
   // must simply be absent for those responses — Helmet does not support per-request directives.
   contentSecurityPolicy: false,
+  // frame-ancestors in the manual CSP below handles framing policy; this would add a
+  // conflicting X-Frame-Options: SAMEORIGIN header that overrides it and breaks portal embedding.
+  xFrameOptions: false,
   // Needed for https enforcement
   hsts: {
     maxAge: 31536000,


### PR DESCRIPTION
## Summary
- Disables `xFrameOptions` in `@fastify/helmet` to remove the `X-Frame-Options: SAMEORIGIN` response header

## Why
Helmet adds `X-Frame-Options: SAMEORIGIN` by default, which conflicts with the manual `frame-ancestors` CSP directive in `server.ts`. Browsers honour `X-Frame-Options` over `frame-ancestors` when both are present, causing the app to be blocked from loading in the Hyperspace portal iframe.

The `frame-ancestors` directive already handles framing security — `X-Frame-Options` is redundant and actively harmful here.

## Test
Verified locally: embedded `localhost:5173` in an iframe — loads correctly after this change with no `X-Frame-Options` header in the response.