### PR TITLE
fix(shellbar): restore open-source switch after @ui5/webcomponents 2.24

### DIFF
--- a/src/components/Core/ShellBar.module.css
+++ b/src/components/Core/ShellBar.module.css
@@ -52,13 +52,11 @@
   width: 100%;
 }
 
-/* Wrapper placed in ShellBar's default slot — fills available space */
+/* Wrapper placed in ShellBar's content slot — pushed right by the preceding ShellBarSpacer */
 .shellBarContent {
   display: flex;
   align-items: center;
   gap: 1rem;
-  width: 100%;
-  justify-content: flex-end;
 }
 
 .membersSlot {

--- a/src/components/Core/ShellBar.tsx
+++ b/src/components/Core/ShellBar.tsx
@@ -20,6 +20,7 @@ import {
   PopoverDomRef,
   ShellBar,
   ShellBarDomRef,
+  ShellBarSpacer,
   Switch,
   TextAreaDomRef,
   Ui5CustomEvent,
@@ -100,39 +101,44 @@ export function ShellBarComponent({
             </div>
           </div>
         }
+        content={[
+          <ShellBarSpacer key="spacer" />,
+          <div key="content" className={styles.shellBarContent}>
+            {roleBindings && (
+              <div className={styles.membersSlot}>
+                <span className={styles.membersLabel}>{t('ShellBar.membersLabel')}</span>
+                <MembersAvatarView
+                  members={convertRoleBindingsToMembers(roleBindings)}
+                  project={project}
+                  workspace={workspace}
+                  hideNamespaceColumn
+                  source="controlplane-detail"
+                />
+              </div>
+            )}
+            <KubeconfigShellBarButton />
+            {mode === 'open-source' && <OverflowMenuButton />}
+            {mcpName && (
+              <div className={styles.switchWrapper}>
+                <span className={styles.switchLabel}>{t('ShellBar.modeOpenSource')}</span>
+                <Switch
+                  checked={mode === 'open-source'}
+                  disabled={!headlampAvailable}
+                  onChange={(e) => {
+                    const next = e.target.checked ? 'open-source' : 'beginner';
+                    setMode(next);
+                    telemetry.track({
+                      name: 'view-mode.toggled',
+                      mode: next === 'open-source' ? 'headlamp' : 'legacy',
+                    });
+                  }}
+                />
+              </div>
+            )}
+          </div>,
+        ]}
         onProfileClick={onProfileClick}
-      >
-        <div className={styles.shellBarContent}>
-          {roleBindings && (
-            <div className={styles.membersSlot}>
-              <span className={styles.membersLabel}>{t('ShellBar.membersLabel')}</span>
-              <MembersAvatarView
-                members={convertRoleBindingsToMembers(roleBindings)}
-                project={project}
-                workspace={workspace}
-                hideNamespaceColumn
-                source="controlplane-detail"
-              />
-            </div>
-          )}
-          <KubeconfigShellBarButton />
-          {mode === 'open-source' && <OverflowMenuButton />}
-          {mcpName && (
-            <div className={styles.switchWrapper}>
-              <span className={styles.switchLabel}>{t('ShellBar.modeOpenSource')}</span>
-              <Switch
-                checked={mode === 'open-source'}
-                disabled={!headlampAvailable}
-                onChange={(e) => {
-                  const next = e.target.checked ? 'open-source' : 'beginner';
-                  setMode(next);
-                  telemetry.track({ name: 'view-mode.toggled', mode: next === 'open-source' ? 'headlamp' : 'legacy' });
-                }}
-              />
-            </div>
-          )}
-        </div>
-      </ShellBar>
+      />
 
       <ProfilePopover
         open={profilePopoverOpen}


### PR DESCRIPTION
## Problem

After the `@ui5/webcomponents` 2.22 → 2.24 bump (#604, already merged), the **Open Source View** switch — along with the members view, kubeconfig button, and overflow menu — disappeared from the ShellBar.

## Root cause

In `@ui5/webcomponents-fiori` 2.24, `ShellBar`'s **default slot** changed to `items: DefaultSlot<ShellBarItem>` — it now only accepts `<ui5-shellbar-item>` elements. The arbitrary content wrapper was passed as default children, so under 2.24 it silently stopped rendering.

## Fix

- Move the content wrapper into the dedicated `content` slot (added in fiori 2.7).
- Right-align it with a leading `<ShellBarSpacer>`. UI5 splits content-slot children into start/end groups at the spacer element (`splitContent` in `ShellBar.js`) — everything after the spacer is rendered right-aligned.
- Drop the now-obsolete `width: 100%` / `justify-content: flex-end` from `.shellBarContent`.

## Notes

- The `content` slot is still flagged **experimental** by UI5 — worth re-checking on future bumps.
- Verified manually: switch is back and right-aligned as before.