### PR TITLE
fix(csp): split FRAME_ANCESTORS on comma for valid frame-ancestors

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -141,7 +141,13 @@ fastify.addHook('onSend', async (req, reply, payload) => {
   if (pathname === '/api/headlamp' || pathname.startsWith('/api/headlamp/')) {
     return payload;
   }
-  const frameAncestors = (fastify as any).config?.FRAME_ANCESTORS ?? '';
+  // FRAME_ANCESTORS is a comma-separated env list; CSP separates sources by whitespace,
+  // so a raw comma turns every entry after the first into one invalid token the browser drops.
+  const frameAncestors = ((fastify as any).config?.FRAME_ANCESTORS ?? '')
+    .split(',')
+    .map((origin: string) => origin.trim())
+    .filter(Boolean)
+    .join(' ');
   const csp = [
     "default-src 'self'",
     "style-src 'self' 'unsafe-inline'",
@@ -151,7 +157,7 @@ fastify.addHook('onSend', async (req, reply, payload) => {
       ? `script-src 'self' 'unsafe-inline' 'unsafe-eval' ${sentryHost} ${dynatraceOrigin}`
       : `script-src 'self' ${sentryHost} ${dynatraceOrigin}`,
     "frame-src 'self'",
-    `frame-ancestors 'self' ${frameAncestors}`,
+    `frame-ancestors 'self'${frameAncestors ? ` ${frameAncestors}` : ''}`,
     "base-uri 'self'",
     "font-src 'self' https: data:",
     "form-action 'self'",


### PR DESCRIPTION
`FRAME_ANCESTORS` is comma-separated, but CSP separates sources by
whitespace. Interpolated raw, all origins after the first became one
invalid token the browser drops, blocking iframe embedding.

Fix: normalize to whitespace-separated origins (like `ALLOWED_CORS_ORIGINS`
already does). No env change needed.