### PR TITLE
feat: add open-source (Headlamp) view to V2 control plane detail page

### DIFF
--- a/src/spaces/controlPlaneV2/pages/ControlPlanePageV2.tsx
+++ b/src/spaces/controlPlaneV2/pages/ControlPlanePageV2.tsx
@@ -3,13 +3,14 @@ import '@ui5/webcomponents-fiori/dist/illustrations/SimpleError';
 import {
   BusyIndicator,
   FlexBox,
+  MessageStrip,
   ObjectPage,
   ObjectPageHeader,
   ObjectPageSection,
   ObjectPageSubSection,
   ObjectPageTitle,
 } from '@ui5/webcomponents-react';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { generatePath, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import CopyKubeconfigButton from '../../../components/ControlPlanes/CopyKubeconfigButton.tsx';
 import styles from './ControlPlanePageV2.module.css';
 // throws error sometimes if not imported
@@ -22,7 +23,7 @@ import { NotFoundBanner } from '../../../components/Ui/NotFoundBanner/NotFoundBa
 import { YamlViewButton } from '../../../components/Yaml/YamlViewButton.tsx';
 import { isNotFoundError } from '../../../lib/api/error.ts';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { McpStatusSection } from '../../../components/ControlPlane/McpStatusSection.tsx';
 
 import { McpMembersAvatarView } from '../../../components/ControlPlanes/McpMembersAvatarView/McpMembersAvatarView.tsx';
@@ -31,7 +32,7 @@ import { ControlPlanePageMenu } from '../../../components/ControlPlanes/ControlP
 import { WizardStepType } from '../../../components/Wizards/CreateControlPlaneV2/CreateControlPlaneV2WizardContainer.tsx';
 import { EditControlPlaneV2WizardDataLoader } from '../../../components/Wizards/CreateControlPlaneV2/EditControlPlaneV2WizardDataLoader.tsx';
 import { DISPLAY_NAME_ANNOTATION } from '../../../lib/api/types/shared/keyNames.ts';
-import { McpContextProvider, WithinManagedControlPlane } from '../../../lib/shared/McpContext.tsx';
+import { McpContextProvider, WithinManagedControlPlane, useMcp } from '../../../lib/shared/McpContext.tsx';
 import { useControlPlaneV2Query } from '../../onboarding/hooks/controlPlaneV2/useControlPlaneV2Query.ts';
 
 import { GitRepositories } from '../../../components/ControlPlane/GitRepositories.tsx';
@@ -51,6 +52,161 @@ import { useEsoQuery } from '../components/Kpi/useEsoQuery.ts';
 import { useFluxQuery } from '../components/Kpi/useFluxQuery.ts';
 import { useLandscaperQuery } from '../components/Kpi/useLandscaperQuery.ts';
 import { McpHeader } from '../../mcp/components/McpHeader/McpHeader.tsx';
+import IllustrationMessageType from '@ui5/webcomponents-fiori/dist/types/IllustrationMessageType.js';
+import { IllustratedBanner } from '../../../components/Ui/IllustratedBanner/IllustratedBanner.tsx';
+import { useFrontendConfig } from '../../../context/FrontendConfigContext.tsx';
+import { useViewMode } from '../../../context/ViewModeContext.tsx';
+import { useShellBarMcpActions } from '../../../context/ShellBarMcpActionsContext.tsx';
+import { registerKubeconfigWithBff } from '../../mcp/pages/headlampKubeconfig.ts';
+import { Routes } from '../../../Routes.ts';
+
+function OpenSourceHeadlamp({
+  projectName,
+  workspaceName,
+  controlPlaneName,
+}: {
+  projectName: string;
+  workspaceName: string;
+  controlPlaneName: string;
+}) {
+  const mcp = useMcp();
+  const { setMcpActions, clearMcpActions } = useShellBarMcpActions();
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+  const { documentationBaseUrl } = useFrontendConfig();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const clusterAlias = `${mcp.project}--${mcp.workspace}--${mcp.name}`;
+  const baseSrcPrefix = `/api/headlamp/c/${encodeURIComponent(clusterAlias)}`;
+
+  const rawInitialPath = searchParams.get('headlampPath') ?? '';
+  const sanitisedInitialPath = rawInitialPath.startsWith(baseSrcPrefix)
+    ? rawInitialPath.slice(baseSrcPrefix.length) || '/'
+    : rawInitialPath;
+
+  const backPath = generatePath(Routes.Project, { projectName });
+  const [iframeSrc, setIframeSrc] = useState<string | null>(null);
+  const [error, setError] = useState(false);
+  const [headlampPath, setHeadlampPath] = useState<string>(sanitisedInitialPath);
+  const isUnsupportedPath = headlampPath.includes('/settings') || headlampPath.includes('/plugins');
+
+  useEffect(() => {
+    setMcpActions({
+      kubeconfig: mcp.kubeconfig,
+      mcpName: mcp.name,
+      roleBindings: mcp.roleBindings,
+      project: projectName,
+      workspace: workspaceName,
+      navigateBack: () => navigate(backPath),
+    });
+    return () => {
+      clearMcpActions();
+    };
+  }, [
+    mcp.kubeconfig,
+    mcp.name,
+    mcp.roleBindings,
+    projectName,
+    workspaceName,
+    backPath,
+    navigate,
+    setMcpActions,
+    clearMcpActions,
+  ]);
+
+  useEffect(() => {
+    if (!mcp.kubeconfig) return;
+    const controller = new AbortController();
+    const baseSrc = `/api/headlamp/c/${encodeURIComponent(clusterAlias)}`;
+    registerKubeconfigWithBff(mcp.kubeconfig, clusterAlias, controller.signal)
+      .then(() => {
+        if (!controller.signal.aborted)
+          setIframeSrc(sanitisedInitialPath ? `${baseSrc}${sanitisedInitialPath}` : baseSrc);
+      })
+      .catch((err) => {
+        if (!controller.signal.aborted) setError(true);
+        else if (err instanceof Error && err.name !== 'AbortError') setError(true);
+      });
+    return () => {
+      controller.abort();
+      setIframeSrc(null);
+      setError(false);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mcp.kubeconfig, clusterAlias]);
+
+  useEffect(() => {
+    if (!iframeSrc) return;
+    const intervalId = setInterval(() => {
+      try {
+        const fullPathname = iframeRef.current?.contentWindow?.location?.pathname ?? '';
+        if (!fullPathname) return;
+        const internalPath = fullPathname.startsWith(baseSrcPrefix)
+          ? fullPathname.slice(baseSrcPrefix.length) || '/'
+          : fullPathname;
+        if (internalPath !== headlampPath) {
+          setHeadlampPath(internalPath);
+          setSearchParams(
+            (prev) => {
+              const next = new URLSearchParams(prev);
+              next.set('headlampPath', internalPath);
+              return next;
+            },
+            { replace: true },
+          );
+        }
+      } catch {
+        // cross-origin access blocked — ignore
+      }
+    }, 1000);
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [iframeSrc, headlampPath, baseSrcPrefix, setSearchParams]);
+
+  if (error) {
+    return (
+      <IllustratedBanner
+        illustrationName={IllustrationMessageType.SimpleError}
+        title={t('McpPage.headlampUnavailableTitle')}
+        subtitle={t('McpPage.headlampUnavailableSubtitle')}
+        help={{ link: `${documentationBaseUrl}/docs/help`, buttonText: t('McpPage.headlampGetSupport') }}
+      />
+    );
+  }
+
+  if (!iframeSrc) return null;
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: 'calc(100vh - 3rem)' }}>
+      {isUnsupportedPath && (
+        <div style={{ position: 'absolute', top: 0, left: 0, right: 0, zIndex: 10, padding: '0.5rem' }}>
+          <MessageStrip design="Information" hideCloseButton>
+            {t('McpPage.headlampUnsupportedPlugin')}
+          </MessageStrip>
+        </div>
+      )}
+      <iframe
+        ref={iframeRef}
+        key={iframeSrc}
+        src={iframeSrc}
+        style={{ width: '100%', height: '100%', border: 'none', display: 'block' }}
+        title={`${t('McpPage.headlampTitle')} — ${projectName}/${workspaceName}/${controlPlaneName}`}
+      />
+    </div>
+  );
+}
+
+function LegacyModeShellBarSync({ controlPlaneName }: { controlPlaneName: string }) {
+  const { setMcpActions, clearMcpActions } = useShellBarMcpActions();
+  useEffect(() => {
+    setMcpActions({ mcpName: controlPlaneName });
+    return () => {
+      clearMcpActions();
+    };
+  }, [controlPlaneName, setMcpActions, clearMcpActions]);
+  return null;
+}
 
 const MCP_PAGE_SECTIONS = ['overview', 'crossplane', 'flux', 'landscaper'] as const;
 export type McpPageSectionId = (typeof MCP_PAGE_SECTIONS)[number];
@@ -60,6 +216,7 @@ export default function ControlPlanePageV2() {
   const namespace = projectName && workspaceName ? `project-${projectName}--ws-${workspaceName}` : undefined;
   const [searchParams, setSearchParams] = useSearchParams();
   const { t } = useTranslation();
+  const { mode } = useViewMode();
   const [isEditManagedControlPlaneWizardOpen, setIsEditManagedControlPlaneWizardOpen] = useState(false);
   const [editManagedControlPlaneWizardSection, setEditManagedControlPlaneWizardSection] = useState<
     undefined | WizardStepType
@@ -146,6 +303,32 @@ export default function ControlPlanePageV2() {
   const isComponentInstalledFlux = !!fluxData?.isInstalled;
   const isComponentInstalledLandscaper = !!landscaperData?.isInstalled;
 
+  if (mode === 'open-source') {
+    return (
+      <McpContextProvider
+        context={{
+          project: projectName,
+          workspace: workspaceName,
+          name: controlPlaneName,
+        }}
+        isV2
+      >
+        <AuthProviderMcp>
+          <WithinManagedControlPlane>
+            <ManagedControlPlaneAuthorization>
+              <OpenSourceHeadlamp
+                key={`${projectName}/${workspaceName}/${controlPlaneName}`}
+                projectName={projectName}
+                workspaceName={workspaceName}
+                controlPlaneName={controlPlaneName}
+              />
+            </ManagedControlPlaneAuthorization>
+          </WithinManagedControlPlane>
+        </AuthProviderMcp>
+      </McpContextProvider>
+    );
+  }
+
   return (
     <McpContextProvider
       context={{
@@ -158,6 +341,7 @@ export default function ControlPlanePageV2() {
       <AuthProviderMcp>
         <WithinManagedControlPlane>
           <ManagedControlPlaneAuthorization>
+            <LegacyModeShellBarSync controlPlaneName={controlPlaneName} />
             <ObjectPage
               mode="IconTabBar"
               titleArea={


### PR DESCRIPTION
## Summary

- Ports the Headlamp iframe (open-source view) from `ManagedControlPlanePage` (V1) to `ControlPlanePageV2` so V2 users can also toggle into Headlamp mode
- `LegacyModeShellBarSync` registers `mcpName` in `ShellBarMcpActionsContext` so the mode toggle switch appears in the ShellBar for V2 detail pages
- `OpenSourceHeadlamp` renders the full-screen Headlamp iframe with back-nav, kubeconfig download/copy, and roleBindings wired into the ShellBar — behaviour is identical to V1
- Uses `McpContextProvider isV2` in both branches so the correct kubeconfig secret path is used for V2 control planes

## Test plan

- [ ] Navigate to a V2 control plane detail page — mode toggle switch should appear in ShellBar (requires `enableHeadlamp` feature flag)
- [ ] Toggle to open-source mode — Headlamp iframe should load full-screen
- [ ] ShellBar should show back button, kubeconfig button, and members avatars in open-source mode
- [ ] Toggle back to beginner mode — ObjectPage should render normally
- [ ] `headlampPath` URL search param should sync with iframe navigation
- [ ] V1 (`ManagedControlPlanePage`) behaviour unchanged