### PR TITLE
chore(deps): remove unused direct @fastify/static dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@fastify/secure-session": "8.3.0",
         "@fastify/sensible": "6.0.4",
         "@fastify/session": "11.1.1",
-        "@fastify/static": "9.3.0",
         "@fastify/vite": "9.1.1",
         "@hookform/resolvers": "5.4.0",
         "@monaco-editor/react": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@fastify/secure-session": "8.3.0",
     "@fastify/sensible": "6.0.4",
     "@fastify/session": "11.1.1",
-    "@fastify/static": "9.3.0",
     "@fastify/vite": "9.1.1",
     "@hookform/resolvers": "5.4.0",
     "@monaco-editor/react": "4.7.0",


### PR DESCRIPTION
#684 wants to update @fastify/static but it was never imported in our code, it is only a transitive peer of @fastify/vite. It was mistakenly added as a direct dependency in the BFF prototype (#108).
