### PR TITLE
fix(auth): silently re-auth on 401, fall back to sign-in

### DIFF
--- a/src/common/auth/createTokenRefreshCoordinator.spec.ts
+++ b/src/common/auth/createTokenRefreshCoordinator.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createTokenRefreshCoordinator } from './createTokenRefreshCoordinator';
+
+describe('createTokenRefreshCoordinator', () => {
+  it('returns true (no-op) when no refresh fn is registered', async () => {
+    const { refreshToken } = createTokenRefreshCoordinator('test-none');
+    expect(await refreshToken()).toBe(true);
+  });
+
+  it('passes the force flag through to the registered refresh fn', async () => {
+    const { registerRefreshFn, refreshToken } = createTokenRefreshCoordinator('test-force');
+    const fn = vi.fn(async (force?: boolean) => force === true);
+    registerRefreshFn(fn);
+
+    expect(await refreshToken()).toBe(false); // default force=false
+    expect(await refreshToken(true)).toBe(true); // forced
+
+    expect(fn).toHaveBeenNthCalledWith(1, false);
+    expect(fn).toHaveBeenNthCalledWith(2, true);
+  });
+
+  it('single-flights concurrent refreshes into one call', async () => {
+    const { registerRefreshFn, refreshToken } = createTokenRefreshCoordinator('test-single');
+    let resolveFn: (v: boolean) => void = () => {};
+    const fn = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveFn = resolve;
+        }),
+    );
+    registerRefreshFn(fn);
+
+    const a = refreshToken(true);
+    const b = refreshToken(true);
+    resolveFn(true);
+
+    expect(await a).toBe(true);
+    expect(await b).toBe(true);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/common/auth/createTokenRefreshCoordinator.ts
+++ b/src/common/auth/createTokenRefreshCoordinator.ts
@@ -14,15 +14,15 @@
 import { useSyncExternalStore } from 'react';
 
 interface TokenRefreshCoordinator {
-  registerRefreshFn: (fn: () => Promise<boolean>) => void;
-  refreshToken: () => Promise<boolean>;
+  registerRefreshFn: (fn: (force?: boolean) => Promise<boolean>) => void;
+  refreshToken: (force?: boolean) => Promise<boolean>;
   useIsRefreshInProgress: () => boolean;
 }
 
 export function createTokenRefreshCoordinator(lockName: string): TokenRefreshCoordinator {
   let isRefreshInProgress = false;
   let pendingRefresh: Promise<boolean> | null = null;
-  let registeredRefreshFn: (() => Promise<boolean>) | null = null;
+  let registeredRefreshFn: ((force?: boolean) => Promise<boolean>) | null = null;
 
   const listeners = new Set<() => void>();
 
@@ -35,40 +35,40 @@ export function createTokenRefreshCoordinator(lockName: string): TokenRefreshCoo
     return () => listeners.delete(listener);
   }
 
-  async function performRefresh(): Promise<boolean> {
+  async function performRefresh(force: boolean): Promise<boolean> {
     if (!registeredRefreshFn) return false;
 
     isRefreshInProgress = true;
     notifyListeners();
 
     try {
-      return await registeredRefreshFn();
+      return await registeredRefreshFn(force);
     } finally {
       isRefreshInProgress = false;
       notifyListeners();
     }
   }
 
-  async function acquireLockAndRefresh(): Promise<boolean> {
+  async function acquireLockAndRefresh(force: boolean): Promise<boolean> {
     if (!registeredRefreshFn) return false;
 
     // Fallback for browsers without Web Locks API
     if (!navigator.locks) {
-      return performRefresh();
+      return performRefresh(force);
     }
 
-    return await navigator.locks.request(lockName, performRefresh);
+    return await navigator.locks.request(lockName, () => performRefresh(force));
   }
 
-  function registerRefreshFn(fn: () => Promise<boolean>): void {
+  function registerRefreshFn(fn: (force?: boolean) => Promise<boolean>): void {
     registeredRefreshFn = fn;
   }
 
-  async function refreshToken(): Promise<boolean> {
+  async function refreshToken(force = false): Promise<boolean> {
     if (!registeredRefreshFn) return true;
 
     if (!pendingRefresh) {
-      pendingRefresh = acquireLockAndRefresh().finally(() => {
+      pendingRefresh = acquireLockAndRefresh(force).finally(() => {
         pendingRefresh = null;
       });
     }

--- a/src/lib/api/error.spec.ts
+++ b/src/lib/api/error.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isNotFoundError, isForbiddenError, APIError } from './error';
+import { isNotFoundError, isForbiddenError, isUnauthorizedError, APIError } from './error';
 import { ErrorLike } from '@apollo/client';
 
 describe('error', () => {
@@ -62,6 +62,28 @@ describe('error', () => {
       expect(isForbiddenError(new APIError('', 500))).toBe(false);
       expect(isForbiddenError(undefined)).toBe(false);
       expect(isForbiddenError(null)).toBe(false);
+    });
+  });
+
+  describe('isUnauthorizedError', () => {
+    it('should return true for APIError with status 401', () => {
+      expect(isUnauthorizedError(new APIError('Session expired', 401))).toBe(true);
+    });
+
+    it('should return true for ErrorLike networkError with statusCode 401', () => {
+      expect(isUnauthorizedError({ networkError: { statusCode: 401 } } as unknown as ErrorLike)).toBe(true);
+    });
+
+    it('should return true when the message carries "status code 401" (Apollo-style)', () => {
+      const error = new Error('Response not successful: Received status code 401');
+      expect(isUnauthorizedError(error as unknown as ErrorLike)).toBe(true);
+    });
+
+    it('should return false for other statuses / nullish', () => {
+      expect(isUnauthorizedError(new APIError('', 403))).toBe(false);
+      expect(isUnauthorizedError(new APIError('', 500))).toBe(false);
+      expect(isUnauthorizedError(undefined)).toBe(false);
+      expect(isUnauthorizedError(null)).toBe(false);
     });
   });
 });

--- a/src/lib/api/error.ts
+++ b/src/lib/api/error.ts
@@ -33,6 +33,17 @@ export function isForbiddenError(error?: ErrorLike | APIError | null): boolean {
   return error?.message?.includes('is forbidden') ?? false;
 }
 
+/**
+ * True for an HTTP 401 — an Apollo network error, our REST `APIError`, or an
+ * Apollo error whose message carries the status code (e.g. "Received status
+ * code 401"). Used as a backstop so a stray 401 redirects to sign-in instead
+ * of rendering a dead-end error screen.
+ */
+export function isUnauthorizedError(error?: ErrorLike | APIError | null): boolean {
+  if (hasHttpStatus(error, 401)) return true;
+  return /(status code|statuscode)\s*401\b/i.test(error?.message ?? '');
+}
+
 function hasHttpStatus(error: ErrorLike | APIError | null | undefined, ...codes: number[]): boolean {
   if (error instanceof APIError) {
     return codes.includes(error.status);

--- a/src/lib/api/fetch.ts
+++ b/src/lib/api/fetch.ts
@@ -97,10 +97,37 @@ export const fetchApiServer = async (
     throw error;
   }
 
-  if (!res.ok) {
+  // The client thought the token was valid but the server rejected it (clock
+  // skew, backgrounded tab, revoked session). Force a refresh and retry once
+  // before giving up and redirecting to sign-in.
+  if (res.status === 401) {
+    const refreshed = isMcpRequest ? await refreshMcpToken(true) : await refreshOnboardingToken(true);
+    if (refreshed) {
+      try {
+        res = await fetch(`/api/onboarding${path}`, {
+          headers,
+          method: httpMethod,
+          body,
+        });
+      } catch (error) {
+        telemetry().report(error, {
+          context: {
+            method: httpMethod,
+            path: `/api/onboarding${path}`,
+          },
+        });
+        throw error;
+      }
+    }
+
     if (res.status === 401) {
       redirectToLogin(isMcpRequest ? 'mcp' : 'onboarding');
+      const error = new APIError('Session expired', 401);
+      throw error;
     }
+  }
+
+  if (!res.ok) {
     const error = new APIError('An error occurred while fetching the data.', res.status);
     error.info = await parseJsonOrText(res);
 

--- a/src/spaces/mcp/auth/AuthContextMcp.tsx
+++ b/src/spaces/mcp/auth/AuthContextMcp.tsx
@@ -99,43 +99,46 @@ export function AuthProviderMcp({ children }: { children: ReactNode }) {
     void refreshAuthStatus(false);
   }, [refreshAuthStatus]);
 
-  const ensureFreshToken = useCallback(async () => {
-    if (!tokenExpiry || tokenExpiry - Date.now() >= REFRESH_BUFFER_MS) {
-      return true; // Token still valid
-    }
-
-    const queryParams = new URLSearchParams();
-    if (projectName && workspaceName && controlPlaneName && idpName) {
-      // Custom identity provider
-      queryParams.set('namespace', namespace);
-      queryParams.set('mcp', controlPlaneName);
-      queryParams.set('idp', idpName);
-    }
-    const queryString = queryParams.toString() ? `?${queryParams.toString()}` : '';
-
-    try {
-      const response = await fetch(`/api/auth/mcp/refresh${queryString}`, { method: 'POST' });
-      if (response.ok) {
-        await refreshAuthStatus(true);
-        return true;
+  const ensureFreshToken = useCallback(
+    async (force = false) => {
+      if (!force && (!tokenExpiry || tokenExpiry - Date.now() >= REFRESH_BUFFER_MS)) {
+        return true; // Token still valid
       }
 
-      if (response.status === 401) {
-        setIsAuthenticated(false);
-        setTokenExpiry(null);
+      const queryParams = new URLSearchParams();
+      if (projectName && workspaceName && controlPlaneName && idpName) {
+        // Custom identity provider
+        queryParams.set('namespace', namespace);
+        queryParams.set('mcp', controlPlaneName);
+        queryParams.set('idp', idpName);
       }
+      const queryString = queryParams.toString() ? `?${queryParams.toString()}` : '';
 
-      return false;
-    } catch (error) {
-      Sentry.addBreadcrumb({
-        category: 'auth',
-        message: 'Background token refresh failed',
-        level: 'warning',
-        ...(error instanceof Error && { data: { error: error.message } }),
-      });
-      return false;
-    }
-  }, [tokenExpiry, refreshAuthStatus, projectName, workspaceName, controlPlaneName, idpName, namespace]);
+      try {
+        const response = await fetch(`/api/auth/mcp/refresh${queryString}`, { method: 'POST' });
+        if (response.ok) {
+          await refreshAuthStatus(true);
+          return true;
+        }
+
+        if (response.status === 401) {
+          setIsAuthenticated(false);
+          setTokenExpiry(null);
+        }
+
+        return false;
+      } catch (error) {
+        Sentry.addBreadcrumb({
+          category: 'auth',
+          message: 'Background token refresh failed',
+          level: 'warning',
+          ...(error instanceof Error && { data: { error: error.message } }),
+        });
+        return false;
+      }
+    },
+    [tokenExpiry, refreshAuthStatus, projectName, workspaceName, controlPlaneName, idpName, namespace],
+  );
 
   // Register with tokenRefresh module to ensure only one refresh runs at a time across the app
   useEffect(() => {

--- a/src/spaces/onboarding/auth/AuthContextOnboarding.tsx
+++ b/src/spaces/onboarding/auth/AuthContextOnboarding.tsx
@@ -89,35 +89,38 @@ export function AuthProviderOnboarding({ children }: { children: ReactNode }) {
     telemetry.identify(user?.sub ? { id: user.sub, email: user.email } : null);
   }, [user, telemetry]);
 
-  const ensureFreshToken = useCallback(async () => {
-    if (!tokenExpiry || tokenExpiry - Date.now() >= REFRESH_BUFFER_MS) {
-      return true; // Token still valid
-    }
-
-    try {
-      const response = await fetch('/api/auth/onboarding/refresh', { method: 'POST' });
-      if (response.ok) {
-        await refreshAuthStatus(true);
-        return true;
+  const ensureFreshToken = useCallback(
+    async (force = false) => {
+      if (!force && (!tokenExpiry || tokenExpiry - Date.now() >= REFRESH_BUFFER_MS)) {
+        return true; // Token still valid
       }
 
-      if (response.status === 401) {
-        setIsAuthenticated(false);
-        setUser(null);
-        setTokenExpiry(null);
-      }
+      try {
+        const response = await fetch('/api/auth/onboarding/refresh', { method: 'POST' });
+        if (response.ok) {
+          await refreshAuthStatus(true);
+          return true;
+        }
 
-      return false;
-    } catch (error) {
-      Sentry.addBreadcrumb({
-        category: 'auth',
-        message: 'Background token refresh failed',
-        level: 'warning',
-        ...(error instanceof Error && { data: { error: error.message } }),
-      });
-      return false;
-    }
-  }, [tokenExpiry, refreshAuthStatus]);
+        if (response.status === 401) {
+          setIsAuthenticated(false);
+          setUser(null);
+          setTokenExpiry(null);
+        }
+
+        return false;
+      } catch (error) {
+        Sentry.addBreadcrumb({
+          category: 'auth',
+          message: 'Background token refresh failed',
+          level: 'warning',
+          ...(error instanceof Error && { data: { error: error.message } }),
+        });
+        return false;
+      }
+    },
+    [tokenExpiry, refreshAuthStatus],
+  );
 
   // Register with tokenRefresh module to ensure only one refresh runs at a time across the app
   useEffect(() => {

--- a/src/spaces/onboarding/pages/ProjectPage.tsx
+++ b/src/spaces/onboarding/pages/ProjectPage.tsx
@@ -17,7 +17,8 @@ import { ResourceSearchBar } from '../../../components/Shared/ResourceSearchBar.
 import { Center } from '../../../components/Ui/Center/Center.tsx';
 import { NotFoundBanner } from '../../../components/Ui/NotFoundBanner/NotFoundBanner.tsx';
 import { useRememberedProject } from '../../../hooks/useRememberedProject.ts';
-import { isNotFoundError } from '../../../lib/api/error.ts';
+import { isNotFoundError, isUnauthorizedError } from '../../../lib/api/error.ts';
+import { redirectToLogin } from '../../../common/auth/redirectToLogin.ts';
 import { useTelemetry } from '../../../lib/telemetry/telemetry.ts';
 import { Routes } from '../../../Routes.ts';
 import { getExpandedWorkspaces, setExpandedWorkspaces } from '../../../utils/expandedWorkspace.ts';
@@ -117,6 +118,12 @@ export default function ProjectPage() {
   }
 
   if (error || !workspaces || !projectName) {
+    // Backstop: a 401 that slipped past the Apollo error link / REST retry
+    // should send the user to re-auth, not a dead-end error screen.
+    if (isUnauthorizedError(error)) {
+      redirectToLogin('onboarding');
+      return <Loading />;
+    }
     return (
       <Center>
         <IllustratedError

--- a/src/spaces/onboarding/services/ApolloClientProvider.tsx
+++ b/src/spaces/onboarding/services/ApolloClientProvider.tsx
@@ -1,6 +1,8 @@
 import { ApolloClient, ApolloLink, InMemoryCache, Observable, split } from '@apollo/client';
+import { ServerError } from '@apollo/client/errors';
 import { ApolloProvider } from '@apollo/client/react';
 import { HttpLink } from '@apollo/client/link/http';
+import { ErrorLink } from '@apollo/client/link/error';
 import { getMainDefinition } from '@apollo/client/utilities';
 import { ClientOptions, createClient } from 'graphql-sse';
 import { print, ExecutionResult, FormattedExecutionResult } from 'graphql';
@@ -108,8 +110,60 @@ const tokenRefreshLink = new ApolloLink((operation, forward) => {
   });
 });
 
+/**
+ * Reacts to a 401 that comes *back* from the server (token looked valid to the
+ * client but was rejected — clock skew, backgrounded tab, revoked session).
+ * Forces a token refresh and retries the operation once; if the forced refresh
+ * fails, redirects to sign-in. Guarded via operation context so a persistently
+ * 401ing server can't loop.
+ */
+const RETRIED_CONTEXT_KEY = 'auth401Retried';
+
+const errorLink = new ErrorLink(({ error, operation, forward }) => {
+  if (!ServerError.is(error) || error.statusCode !== 401) {
+    return;
+  }
+
+  if (operation.getContext()[RETRIED_CONTEXT_KEY]) {
+    // Already retried once and still 401 → the forced refresh didn't help.
+    redirectToLogin('onboarding');
+    return;
+  }
+
+  return new Observable<ExecutionResult | FormattedExecutionResult>((observer) => {
+    let subscription: { unsubscribe(): void } | null = null;
+    let isUnsubscribed = false;
+
+    refreshToken(true)
+      .then((valid) => {
+        if (isUnsubscribed) return;
+
+        if (!valid) {
+          redirectToLogin('onboarding');
+          observer.error(error);
+          return;
+        }
+
+        operation.setContext({ [RETRIED_CONTEXT_KEY]: true });
+        subscription = forward(operation).subscribe({
+          next: (value) => !isUnsubscribed && observer.next(value),
+          error: (err) => !isUnsubscribed && observer.error(err),
+          complete: () => !isUnsubscribed && observer.complete(),
+        });
+      })
+      .catch((err) => {
+        if (!isUnsubscribed) observer.error(err);
+      });
+
+    return () => {
+      isUnsubscribed = true;
+      subscription?.unsubscribe();
+    };
+  });
+});
+
 const client = new ApolloClient({
-  link: ApolloLink.from([tokenRefreshLink, splitLink]),
+  link: ApolloLink.from([errorLink, tokenRefreshLink, splitLink]),
   cache: new InMemoryCache({
     typePolicies: {
       Query: {


### PR DESCRIPTION
Recurring 'Something went wrong — status code 401' came from purely time-based token refresh; nothing reacted to an actual 401. Now: force-refresh + retry once (Apollo ErrorLink + REST fetch), redirect to sign-in on failure (returns to same page via redirectToLogin). Adds isUnauthorizedError backstop + coordinator force-flag. Tests green (type-check, lint, unit).