### PR TITLE
feat(gitops): replace sourceRefName free-text with GitRepository dropdown

### DIFF
--- a/src/components/Dialogs/CreateKustomizationDialog.cy.tsx
+++ b/src/components/Dialogs/CreateKustomizationDialog.cy.tsx
@@ -1,5 +1,39 @@
+import '@ui5/webcomponents-cypress-commands';
 import { CreateKustomizationDialog } from './CreateKustomizationDialog';
 import { CreateKustomizationParams } from '../../hooks/useCreateKustomization';
+import { useApiResource } from '../../lib/api/useApiResource';
+import { GitReposResponse } from '../../lib/api/types/flux/listGitRepo';
+
+const fakeRepos = ['my-repo', 'another-repo', 'test-repo'];
+
+const makeGitRepoItems = (names: string[]) =>
+  names.map((name) => ({
+    metadata: { name, creationTimestamp: '' },
+    spec: { package: '' },
+    kind: 'GitRepository',
+    status: { artifact: { revision: '' } },
+  }));
+
+const fakeUseListGitRepositories = (() => ({
+  data: { items: makeGitRepoItems(fakeRepos) } as GitReposResponse,
+  isLoading: false,
+  error: undefined,
+  isValidating: false,
+})) as unknown as typeof useApiResource;
+
+const fakeUseListGitRepositoriesEmpty = (() => ({
+  data: { items: [] as unknown as GitReposResponse['items'] } as GitReposResponse,
+  isLoading: false,
+  error: undefined,
+  isValidating: false,
+})) as unknown as typeof useApiResource;
+
+const fakeUseListGitRepositoriesLoading = (() => ({
+  data: undefined,
+  isLoading: true,
+  error: undefined,
+  isValidating: false,
+})) as unknown as typeof useApiResource;
 
 describe('CreateKustomizationDialog', () => {
   let capturedData: CreateKustomizationParams | null = null;
@@ -11,16 +45,33 @@ describe('CreateKustomizationDialog', () => {
     isLoading: false,
   });
 
+  const mount = (overrides: object = {}) =>
+    cy.mount(
+      <CreateKustomizationDialog
+        isOpen={true}
+        useCreateKustomization={fakeUseCreateKustomization}
+        useListGitRepositories={fakeUseListGitRepositories}
+        onClose={cy.stub()}
+        {...overrides}
+      />,
+    );
+
   beforeEach(() => {
     capturedData = null;
   });
 
+  it('renders git repositories as Select options', () => {
+    mount();
+
+    cy.get('[data-testid="sourceRefName-select"]').should('exist');
+    fakeRepos.forEach((name) => {
+      cy.get('[data-testid="sourceRefName-select"]').contains(name);
+    });
+  });
+
   it('creates a kustomization with valid data', () => {
     const onClose = cy.stub();
-
-    cy.mount(
-      <CreateKustomizationDialog isOpen={true} useCreateKustomization={fakeUseCreateKustomization} onClose={onClose} />,
-    );
+    mount({ onClose });
 
     const expectedPayload = {
       namespace: 'default',
@@ -33,28 +84,21 @@ describe('CreateKustomizationDialog', () => {
       substitutions: [],
     };
 
-    // Fill in the form
     cy.get('[name="name"]').typeIntoUi5Input('test-kustomization');
     cy.get('[name="interval"]').find('input').clear().type('5m0s');
-    cy.get('[name="sourceRefName"]').typeIntoUi5Input('test-repo');
+    cy.get('[ui5-select][data-cy="sourceRefName-select"]').openDropDownByClick();
+    cy.get('[ui5-select][data-cy="sourceRefName-select"]').clickDropdownMenuItemByText('test-repo');
     cy.get('[name="path"]').find('input').clear().type('./deploy');
 
-    // Submit the form
     cy.get('ui5-button').contains('Create').click();
 
-    // Verify the hook was called with correct data
     cy.then(() => cy.wrap(capturedData).deepEqualJson(expectedPayload));
-
-    // Dialog should close on success
     cy.wrap(onClose).should('have.been.called');
   });
 
   it('includes substitutions when provided', () => {
     const onClose = cy.stub();
-
-    cy.mount(
-      <CreateKustomizationDialog isOpen={true} useCreateKustomization={fakeUseCreateKustomization} onClose={onClose} />,
-    );
+    mount({ onClose });
 
     const expectedPayload = {
       namespace: 'default',
@@ -67,72 +111,63 @@ describe('CreateKustomizationDialog', () => {
       substitutions: [{ key: 'key1', value: 'value1' }],
     };
 
-    // Fill in the form
     cy.get('[name="name"]').typeIntoUi5Input('test-kustomization');
-    cy.get('[name="sourceRefName"]').typeIntoUi5Input('test-repo');
+    cy.get('[ui5-select][data-cy="sourceRefName-select"]').openDropDownByClick();
+    cy.get('[ui5-select][data-cy="sourceRefName-select"]').clickDropdownMenuItemByText('test-repo');
 
-    // Add substitution
     cy.get('ui5-button').contains('Add Substitution').click();
     cy.get('[name="substitutions.0.key"]').typeIntoUi5Input('key1');
     cy.get('[name="substitutions.0.value"]').typeIntoUi5Input('value1');
 
-    // Submit the form
     cy.get('ui5-button').contains('Create').click();
 
-    // Verify the hook was called with correct data
     cy.then(() => cy.wrap(capturedData).deepEqualJson(expectedPayload));
-
-    // Dialog should close on success
     cy.wrap(onClose).should('have.been.called');
   });
 
-  it('validates required fields', () => {
+  it('validates required fields including sourceRefName', () => {
     const onClose = cy.stub();
+    mount({ onClose });
 
-    cy.mount(
-      <CreateKustomizationDialog isOpen={true} useCreateKustomization={fakeUseCreateKustomization} onClose={onClose} />,
-    );
-
-    // Try to submit without filling required fields
     cy.get('ui5-button').contains('Create').click();
 
-    // Should show validation errors
     cy.get('[name="name"]').should('have.attr', 'value-state', 'Negative');
     cy.contains('This field is required').should('exist');
-    cy.get('[name="sourceRefName"]').should('have.attr', 'value-state', 'Negative');
+    cy.get('[data-testid="sourceRefName-select"]').should('have.attr', 'value-state', 'Negative');
 
-    // Dialog should not close
     cy.wrap(onClose).should('not.have.been.called');
   });
 
   it('closes dialog when cancel is clicked', () => {
     const onClose = cy.stub();
+    mount({ onClose });
 
-    cy.mount(
-      <CreateKustomizationDialog isOpen={true} useCreateKustomization={fakeUseCreateKustomization} onClose={onClose} />,
-    );
-
-    // Fill in some data
     cy.get('[name="name"]').typeIntoUi5Input('test-kustomization');
-
-    // Click cancel
     cy.get('ui5-button').contains('Cancel').click();
 
-    // Dialog should close without calling onSuccess
     cy.wrap(onClose).should('have.been.called');
   });
 
   it('uses default values for interval and prune', () => {
-    const onClose = cy.stub();
+    mount();
 
-    cy.mount(
-      <CreateKustomizationDialog isOpen={true} useCreateKustomization={fakeUseCreateKustomization} onClose={onClose} />,
-    );
-
-    // Check default values
     cy.get('[name="interval"]').find('input').should('have.value', '1m0s');
     cy.get('[name="path"]').find('input').should('have.value', './');
     cy.get('[name="prune"]').should('have.attr', 'checked');
+  });
+
+  it('shows loading state while repositories are being fetched', () => {
+    mount({ useListGitRepositories: fakeUseListGitRepositoriesLoading });
+
+    cy.get('[data-testid="sourceRefName-select"]').should('have.attr', 'disabled');
+    cy.get('[data-testid="sourceRefName-select"]').contains('Loading repositories');
+  });
+
+  it('shows only the placeholder when no repositories exist', () => {
+    mount({ useListGitRepositories: fakeUseListGitRepositoriesEmpty });
+
+    cy.get('[data-testid="sourceRefName-select"]').should('exist');
+    cy.get('[data-testid="sourceRefName-select"] ui5-option[data-value]').should('have.length', 1);
   });
 
   it('should not close dialog when creation fails', () => {
@@ -144,26 +179,22 @@ describe('CreateKustomizationDialog', () => {
     });
 
     const onClose = cy.stub();
-
     cy.mount(
       <CreateKustomizationDialog
         isOpen={true}
         useCreateKustomization={failingUseCreateKustomization}
+        useListGitRepositories={fakeUseListGitRepositories}
         onClose={onClose}
       />,
     );
 
-    // Fill in the form
     cy.get('[name="name"]').typeIntoUi5Input('test-kustomization');
-    cy.get('[name="sourceRefName"]').typeIntoUi5Input('test-repo');
+    cy.get('[ui5-select][data-cy="sourceRefName-select"]').openDropDownByClick();
+    cy.get('[ui5-select][data-cy="sourceRefName-select"]').clickDropdownMenuItemByText('test-repo');
 
-    // Submit the form
     cy.get('ui5-button').contains('Create').click();
 
-    // Dialog should NOT close on failure
     cy.wrap(onClose).should('not.have.been.called');
-
-    // Dialog should still be visible
     cy.contains('Create Kustomization').should('be.visible');
   });
 });

--- a/src/components/Dialogs/CreateKustomizationDialog.tsx
+++ b/src/components/Dialogs/CreateKustomizationDialog.tsx
@@ -1,5 +1,5 @@
-import { Dialog, Bar, Label, Input, Button, Form, FormGroup, CheckBox } from '@ui5/webcomponents-react';
-import { useForm, Controller, useFieldArray } from 'react-hook-form';
+import { Dialog, Bar, Label, Input, Button, Form, FormGroup, CheckBox, Select, Option } from '@ui5/webcomponents-react';
+import { useForm, Controller, useFieldArray, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useId } from 'react';
 import { z } from 'zod';
@@ -8,6 +8,8 @@ import {
   useCreateKustomization as _useCreateKustomization,
   CreateKustomizationParams,
 } from '../../hooks/useCreateKustomization';
+import { useApiResource as _useApiResource } from '../../lib/api/useApiResource';
+import { FluxRequest } from '../../lib/api/types/flux/listGitRepo';
 import styles from './CreateKustomizationDialog.module.css';
 import '@ui5/webcomponents-icons/dist/delete';
 import '@ui5/webcomponents-icons/dist/add';
@@ -16,15 +18,25 @@ interface CreateKustomizationDialogProps {
   isOpen: boolean;
   onClose: () => void;
   useCreateKustomization?: typeof _useCreateKustomization;
+  useListGitRepositories?: typeof _useApiResource;
 }
 
 export function CreateKustomizationDialog({
   isOpen,
   onClose,
   useCreateKustomization = _useCreateKustomization,
+  useListGitRepositories = _useApiResource,
 }: CreateKustomizationDialogProps) {
   const { t } = useTranslation();
   const { createKustomization, isLoading } = useCreateKustomization();
+
+  const { data: gitRepoData, isLoading: isLoadingRepos } = useListGitRepositories(
+    FluxRequest,
+    undefined,
+    undefined,
+    !isOpen,
+  );
+  const gitRepoNames = (gitRepoData?.items ?? []).map((item) => item.metadata.name);
 
   const namespaceId = useId();
   const nameId = useId();
@@ -58,6 +70,7 @@ export function CreateKustomizationDialog({
     control,
     handleSubmit,
     reset,
+    setValue,
     formState: { errors },
   } = useForm<FormSchema>({
     defaultValues: {
@@ -72,6 +85,8 @@ export function CreateKustomizationDialog({
     },
     resolver: zodResolver(validationSchema),
   });
+
+  const sourceRefName = useWatch({ control, name: 'sourceRefName' }) ?? '';
 
   const { fields, append, remove } = useFieldArray({
     control,
@@ -212,20 +227,31 @@ export function CreateKustomizationDialog({
                 <Label required for={sourceRefNameId}>
                   {t('CreateKustomizationDialog.gitRepositoryTitle')}
                 </Label>
-                <Controller
-                  name="sourceRefName"
-                  control={control}
-                  render={({ field }) => (
-                    <Input
-                      {...field}
-                      id={sourceRefNameId}
-                      placeholder={t('CreateKustomizationDialog.sourceRefNameTitle')}
-                      valueState={errors.sourceRefName ? 'Negative' : 'None'}
-                      valueStateMessage={<span>{errors.sourceRefName?.message}</span>}
-                      className={styles.input}
-                    />
-                  )}
-                />
+                <Select
+                  id={sourceRefNameId}
+                  data-testid="sourceRefName-select"
+                  data-cy="sourceRefName-select"
+                  className={styles.input}
+                  disabled={isLoadingRepos}
+                  value={sourceRefName}
+                  valueState={errors.sourceRefName ? 'Negative' : 'None'}
+                  valueStateMessage={<span>{errors.sourceRefName?.message}</span>}
+                  onChange={(e) => {
+                    const selected = (e.detail.selectedOption as HTMLElement).dataset.value ?? '';
+                    setValue('sourceRefName', selected, { shouldValidate: true });
+                  }}
+                >
+                  <Option data-value="" selected={!sourceRefName}>
+                    {isLoadingRepos
+                      ? t('CreateKustomizationDialog.loadingRepos')
+                      : t('CreateKustomizationDialog.selectRepo')}
+                  </Option>
+                  {gitRepoNames.map((name) => (
+                    <Option key={name} data-value={name} selected={sourceRefName === name}>
+                      {name}
+                    </Option>
+                  ))}
+                </Select>
               </div>
 
               <div className={styles.formField}>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -631,6 +631,8 @@
     "sourceRefTitle": "Source Reference",
     "sourceRefNameTitle": "Name",
     "gitRepositoryTitle": "Git Repository",
+    "selectRepo": "Select a Git Repository",
+    "loadingRepos": "Loading repositories…",
     "pathTitle": "Path",
     "pruneTitle": "Prune",
     "targetNamespaceTitle": "Target Namespace",


### PR DESCRIPTION
<img width="545" height="655" alt="image" src="https://github.com/user-attachments/assets/e3793651-b39a-4e9e-b318-a7a2bfbc6ae0" />


## Summary

- The **Git Repository** field in the Create Kustomization dialog was a free-text `Input`. Users had to know the exact name of an existing `GitRepository` resource.
- Replaced with a **`Select` dropdown** populated from the live list of `GitRepository` resources (same `FluxRequest` / `useApiResource` already used by the GitRepositories list view).
- The `useListGitRepositories` hook is injectable for testability (DI pattern matching the rest of the codebase).
- Shows a **"Loading…"** placeholder and disables the Select while fetching.
- Fetch is disabled until the dialog opens to avoid a stale background request.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint --max-warnings 0` — clean
- [x] All 9 Cypress component tests pass (`CreateKustomizationDialog.cy.tsx`):
  - renders repos as Select options
  - creates kustomization with selected repo
  - includes substitutions with selected repo
  - validates required fields (Select shows Negative state)
  - cancel, defaults, loading state, empty repo list, failure no-close