### PR TITLE
fix(shellbar): remove separator line next to account avatar

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -127,3 +127,7 @@ ui5-toast {
   margin: 1rem auto;
   max-width: 80%;
 }
+
+ui5-shellbar {
+  --_ui5-shellbar_separator-color: transparent;
+}


### PR DESCRIPTION

<img width="1234" height="69" alt="image" src="https://github.com/user-attachments/assets/3296ac3f-f543-4cba-820c-5e96781004ab" />


## Summary

- Removes the slim vertical line rendered by the UI5 ShellBar between the content area and the profile avatar
- Achieved by overriding the `--_ui5-shellbar_separator-color` CSS custom property to `transparent` on the `ui5-shellbar` host element in `src/index.css`

## Test plan

- [ ] Open the app and verify the separator line next to the account avatar in the top shell bar is gone
- [ ] Confirm no other ShellBar styling is affected (logo, title, content area, buttons)
- [ ] Check both light and dark themes if applicable