### PR TITLE
perf(swr): reduce polling pressure on MCP detail pages

### DIFF
--- a/src/components/SWRConfigWithTokenRefresh.tsx
+++ b/src/components/SWRConfigWithTokenRefresh.tsx
@@ -3,17 +3,6 @@ import { SWRConfig } from 'swr';
 import { useIsRefreshInProgress as useIsOnboardingRefreshInProgress } from '../spaces/onboarding/auth/tokenRefresh';
 import { useIsRefreshInProgress as useIsMcpRefreshInProgress } from '../spaces/mcp/auth/tokenRefresh';
 
-/**
- * SWR configuration wrapper that pauses data fetching during token refresh.
- *
- * Tuning notes:
- * - refreshInterval: 15s (down from 10s) — halves background traffic; 15s staleness
- *   is acceptable for an ops-style UI where status changes are infrequent.
- * - revalidateOnFocus: false — eliminates the burst of re-fetches on every tab
- *   switch, which was the noisiest source of concurrent backend requests.
- * - dedupingInterval: 5000 — collapses same-key calls within a 5s window instead
- *   of the default 2s, reducing duplicate requests when multiple components mount.
- */
 export function SWRConfigWithTokenRefresh({ children }: { children: ReactNode }) {
   const onboardingRefreshing = useIsOnboardingRefreshInProgress();
   const mcpRefreshing = useIsMcpRefreshInProgress();

--- a/src/components/SWRConfigWithTokenRefresh.tsx
+++ b/src/components/SWRConfigWithTokenRefresh.tsx
@@ -5,6 +5,14 @@ import { useIsRefreshInProgress as useIsMcpRefreshInProgress } from '../spaces/m
 
 /**
  * SWR configuration wrapper that pauses data fetching during token refresh.
+ *
+ * Tuning notes:
+ * - refreshInterval: 15s (down from 10s) — halves background traffic; 15s staleness
+ *   is acceptable for an ops-style UI where status changes are infrequent.
+ * - revalidateOnFocus: false — eliminates the burst of re-fetches on every tab
+ *   switch, which was the noisiest source of concurrent backend requests.
+ * - dedupingInterval: 5000 — collapses same-key calls within a 5s window instead
+ *   of the default 2s, reducing duplicate requests when multiple components mount.
  */
 export function SWRConfigWithTokenRefresh({ children }: { children: ReactNode }) {
   const onboardingRefreshing = useIsOnboardingRefreshInProgress();
@@ -14,7 +22,9 @@ export function SWRConfigWithTokenRefresh({ children }: { children: ReactNode })
   return (
     <SWRConfig
       value={{
-        refreshInterval: 10000,
+        refreshInterval: 15000,
+        revalidateOnFocus: false,
+        dedupingInterval: 5000,
         // component re-renders on refresh state changes, so the closure is not stale
         isPaused: () => isRefreshing,
       }}


### PR DESCRIPTION
## Summary

- **refreshInterval: 10s → 15s** — cuts background request rate by 33%
- **revalidateOnFocus: false** — eliminates the burst of concurrent re-fetches on every tab switch, which was the noisiest source of parallel requests
- **dedupingInterval: 5s** — collapses same-key SWR calls within a wider window when multiple components mount simultaneously

## Context

All three settings live in the single global `SWRConfigWithTokenRefresh` wrapper so the change applies consistently across the app. The project page card list is GraphQL/Apollo (not SWR), so this only affects MCP detail page queries (Crossplane, Flux, Landscaper, KPIs).

## Test plan
- [ ] Open an MCP detail page and verify data still refreshes
- [ ] Switch browser tabs and confirm no flood of requests fires on return
- [ ] Verify token refresh still pauses polling correctly