### PR TITLE
fix: align component card descriptions to verb-first naming schema

### DIFF
--- a/src/components/ControlPlanes/ConnectButton/ConnectButton.tsx
+++ b/src/components/ControlPlanes/ConnectButton/ConnectButton.tsx
@@ -38,11 +38,13 @@ export default function ConnectButton({
   const { t } = useTranslation();
   const telemetry = useTelemetry();
 
+  const skipFetch = !secretKey || !secretName || !namespace;
+
   const {
     data: kubeconfigResource,
     error,
     isLoading,
-  } = useApiResource(GetKubeconfig(secretKey, secretName, namespace));
+  } = useApiResource(GetKubeconfig(secretKey, secretName, namespace), undefined, undefined, skipFetch);
 
   const connectionTargets = useConnectOptions(kubeconfigResource, projectName, workspaceName, controlPlaneName);
 
@@ -63,7 +65,7 @@ export default function ConnectButton({
     }
   };
 
-  if (isLoading || error || connectionTargets.length === 0) {
+  if (!skipFetch && (isLoading || error || connectionTargets.length === 0)) {
     return (
       <Button data-testid="connect-button" design="Emphasized" endIcon="navigation-right-arrow" disabled={true}>
         {t('ConnectButton.buttonText')}

--- a/src/components/ControlPlanes/ConnectButton/ConnectButton.tsx
+++ b/src/components/ControlPlanes/ConnectButton/ConnectButton.tsx
@@ -65,7 +65,7 @@ export default function ConnectButton({
     }
   };
 
-  if (!skipFetch && (isLoading || error || connectionTargets.length === 0)) {
+  if (isLoading || error || connectionTargets.length === 0) {
     return (
       <Button data-testid="connect-button" design="Emphasized" endIcon="navigation-right-arrow" disabled={true}>
         {t('ConnectButton.buttonText')}

--- a/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCard.cy.tsx
+++ b/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCard.cy.tsx
@@ -71,12 +71,14 @@ const fakeUseMcpComponentsLoading: typeof useMcpComponents = () => ({
   components: null,
   roleBindings: undefined,
   isLoading: true,
+  hasError: false,
 });
 
 const fakeUseMcpComponentsEmpty: typeof useMcpComponents = () => ({
   components: {},
   roleBindings: undefined,
   isLoading: false,
+  hasError: false,
 });
 
 const fakeUseMcpComponentsWithData: typeof useMcpComponents = () => ({
@@ -86,6 +88,7 @@ const fakeUseMcpComponentsWithData: typeof useMcpComponents = () => ({
     { role: 'viewer', subjects: [{ kind: 'User', name: 'bob@example.com' }] },
   ],
   isLoading: false,
+  hasError: false,
 });
 
 const fakeUseMcpV2ComponentsLoading: typeof useMcpV2Components = () => ({

--- a/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCard.module.css
+++ b/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCard.module.css
@@ -133,12 +133,26 @@
   color: var(--sapButton_Emphasized_Background, #0070f2);
   cursor: pointer;
   background: none;
+  --sapContent_IconColor: var(--sapButton_Emphasized_Background, #0070f2);
 }
 
 .addComponentPlaceholder:hover {
   background: color-mix(in srgb, var(--sapButton_Emphasized_Background, #0070f2) 8%, transparent);
   border-color: var(--sapButton_Emphasized_Hover_Background, #0064d9);
   transform: translateY(-1px);
+}
+
+.addComponentPlaceholderDisabled {
+  border-color: var(--sapButton_Disabled_BorderColor, #d9d9d9);
+  color: var(--sapButton_Disabled_TextColor, #a9a9a9);
+  cursor: not-allowed;
+  --sapContent_IconColor: var(--sapButton_Disabled_TextColor, #a9a9a9);
+}
+
+.addComponentPlaceholderDisabled:hover {
+  background: none;
+  border-color: var(--sapButton_Disabled_BorderColor, #d9d9d9);
+  transform: none;
 }
 
 .addComponentIcon {

--- a/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCard.tsx
+++ b/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCard.tsx
@@ -104,6 +104,7 @@ export const ControlPlaneCard = ({
     components: mcpComponents,
     roleBindings,
     isLoading: isLoadingComponents,
+    hasError: hasComponentsError,
   } = useMcpComponentsHook(projectName, workspace.metadata.name, name);
   const { components: mcpV2Components, isLoading: isLoadingV2Components } = useMcpV2ComponentsHook(
     name,
@@ -194,8 +195,9 @@ export const ControlPlaneCard = ({
                   ))}
                   {installedComponents.length === 0 && (isV2 ? mcpV2Components !== null : mcpComponents !== null) && (
                     <button
-                      className={`${styles.componentIcon} ${styles.addComponentPlaceholder}`}
+                      className={`${styles.componentIcon} ${styles.addComponentPlaceholder} ${!isV2 && hasComponentsError ? styles.addComponentPlaceholderDisabled : ''}`}
                       data-testid="add-component-button"
+                      disabled={!isV2 && hasComponentsError}
                       title={t('ControlPlaneCard.installComponents')}
                       onClick={() => {
                         if (isV2) {

--- a/src/components/ControlPlanes/ControlPlaneCard/useMcpComponents.ts
+++ b/src/components/ControlPlanes/ControlPlaneCard/useMcpComponents.ts
@@ -13,17 +13,22 @@ interface McpComponents {
 type RoleBinding = { role: string; subjects: { kind: string; name: string }[] };
 
 export function useMcpComponents(projectName: string, workspaceName: string, controlPlaneName: string) {
-  const { data: mcp, isLoading } = useApiResource(ControlPlaneResource(projectName, workspaceName, controlPlaneName));
+  const {
+    data: mcp,
+    isLoading,
+    error,
+  } = useApiResource(ControlPlaneResource(projectName, workspaceName, controlPlaneName));
 
   const components = useMemo<McpComponents | null>(() => {
+    if (error) return {};
     if (!mcp?.spec?.components) return null;
     return mcp.spec.components as McpComponents;
-  }, [mcp]);
+  }, [error, mcp]);
 
   const roleBindings = useMemo<RoleBinding[] | undefined>(
-    () => mcp?.spec?.authorization?.roleBindings as RoleBinding[] | undefined,
-    [mcp],
+    () => (error ? undefined : (mcp?.spec?.authorization?.roleBindings as RoleBinding[] | undefined)),
+    [error, mcp],
   );
 
-  return { components, roleBindings, isLoading };
+  return { components, roleBindings, isLoading: error ? false : isLoading, hasError: !!error };
 }

--- a/src/components/Yaml/YamlViewButton.tsx
+++ b/src/components/Yaml/YamlViewButton.tsx
@@ -40,7 +40,9 @@ export interface YamlViewButtonMcpComponentProps {
   preloadedResource?: Resource | null;
 }
 export type YamlViewButtonProps =
-  YamlViewButtonResourceProps | YamlViewButtonLoaderProps | YamlViewButtonMcpComponentProps;
+  | YamlViewButtonResourceProps
+  | YamlViewButtonLoaderProps
+  | YamlViewButtonMcpComponentProps;
 
 export function YamlViewButton({ variant, ...props }: YamlViewButtonProps) {
   const { t } = useTranslation();

--- a/src/components/Yaml/YamlViewButton.tsx
+++ b/src/components/Yaml/YamlViewButton.tsx
@@ -39,10 +39,8 @@ export interface YamlViewButtonMcpComponentProps {
   // When set, the panel renders this data directly instead of fetching it on click.
   preloadedResource?: Resource | null;
 }
-export type YamlViewButtonProps =
-  | YamlViewButtonResourceProps
-  | YamlViewButtonLoaderProps
-  | YamlViewButtonMcpComponentProps;
+// prettier-ignore
+export type YamlViewButtonProps = YamlViewButtonResourceProps | YamlViewButtonLoaderProps | YamlViewButtonMcpComponentProps;
 
 export function YamlViewButton({ variant, ...props }: YamlViewButtonProps) {
   const { t } = useTranslation();

--- a/src/components/Yaml/YamlViewButton.tsx
+++ b/src/components/Yaml/YamlViewButton.tsx
@@ -39,8 +39,8 @@ export interface YamlViewButtonMcpComponentProps {
   // When set, the panel renders this data directly instead of fetching it on click.
   preloadedResource?: Resource | null;
 }
-// prettier-ignore
-export type YamlViewButtonProps = YamlViewButtonResourceProps | YamlViewButtonLoaderProps | YamlViewButtonMcpComponentProps;
+export type YamlViewButtonProps =
+  YamlViewButtonResourceProps | YamlViewButtonLoaderProps | YamlViewButtonMcpComponentProps;
 
 export function YamlViewButton({ variant, ...props }: YamlViewButtonProps) {
   const { t } = useTranslation();

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -36,18 +36,18 @@
     "progressCount": "Healthy: {{count}} of {{total}} resources"
   },
   "componentCardFlux": {
-    "description": "GitOps for Kubernetes automating continuous sync and delivery",
+    "description": "Synchronize resources from Git repositories",
     "progress": "Managed",
     "progressCount": "Managed: {{count}} of {{total}} resources"
   },
   "componentCardLandscaper": {
-    "description": "Automate cross‑dependent Kubernetes deployments"
+    "description": "Orchestrate cross-dependent deployments"
   },
   "componentCardKyverno": {
-    "description": "Kubernetes-native policy as code for secure and compliant infrastructure"
+    "description": "Enforce policies for secure and compliant resources"
   },
   "componentCardEso": {
-    "description": "Manage and sync credentials from your secret store"
+    "description": "Manage credentials from your secret store"
   },
   "Kpi": {
     "installed": "Installed",

--- a/src/spaces/onboarding/pages/ProjectPage.module.css
+++ b/src/spaces/onboarding/pages/ProjectPage.module.css
@@ -1,6 +1,6 @@
 .searchBar {
   margin: 0 auto;
-  width: 1280px;
+  width: min(1280px, 100%);
 }
 
 .expandCollapseButton {


### PR DESCRIPTION
## Summary

- Rewrites Flux, Landscaper, Kyverno, and ESO component card descriptions to follow Crossplane's established pattern
- All descriptions are now verb-first, short, without platform/brand names ("Kubernetes"), and in consistent sentence case
- Removes "-ing" verbs, "sync" wording, and redundant technology references

## Changes

| Component | Before | After |
|---|---|---|
| Flux | "GitOps for Kubernetes automating continuous sync and delivery" | "Synchronize resources from Git repositories" |
| Landscaper | "Automate cross-dependent Kubernetes deployments" | "Orchestrate cross-dependent deployments" |
| Kyverno | "Kubernetes-native policy as code for secure and compliant infrastructure" | "Enforce policies for secure and compliant resources" |
| ESO | "Manage and sync credentials from your secret store" | "Manage credentials from your secret store" |

## Test plan

- [ ] Verify component card descriptions render correctly on the MCP detail page