### PR TITLE
fix: align component card descriptions to verb-first naming schema

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -36,18 +36,18 @@
     "progressCount": "Healthy: {{count}} of {{total}} resources"
   },
   "componentCardFlux": {
-    "description": "GitOps for Kubernetes automating continuous sync and delivery",
+    "description": "Synchronize resources from Git repositories",
     "progress": "Managed",
     "progressCount": "Managed: {{count}} of {{total}} resources"
   },
   "componentCardLandscaper": {
-    "description": "Automate cross‑dependent Kubernetes deployments"
+    "description": "Orchestrate cross-dependent deployments"
   },
   "componentCardKyverno": {
-    "description": "Kubernetes-native policy as code for secure and compliant infrastructure"
+    "description": "Enforce policies for secure and compliant resources"
   },
   "componentCardEso": {
-    "description": "Manage and sync credentials from your secret store"
+    "description": "Manage credentials from your secret store"
   },
   "Kpi": {
     "installed": "Installed",

--- a/src/spaces/mcp/components/ComponentsDashboard/ComponentsDashboard.cy.tsx
+++ b/src/spaces/mcp/components/ComponentsDashboard/ComponentsDashboard.cy.tsx
@@ -28,22 +28,22 @@ describe('ComponentsDashboard', () => {
     cy.get('.ui5-card-header')
       .eq(1)
       .should('contain.text', 'Flux')
-      .and('contain.text', 'GitOps for Kubernetes automating continuous sync and delivery');
+      .and('contain.text', 'Synchronize resources from Git repositories');
 
     cy.get('.ui5-card-header')
       .eq(2)
       .should('contain.text', 'Landscaper')
-      .and('contain.text', 'Automate cross‑dependent Kubernetes deployments');
+      .and('contain.text', 'Orchestrate cross-dependent deployments');
 
     cy.get('.ui5-card-header')
       .eq(3)
       .should('contain.text', 'Kyverno')
-      .and('contain.text', 'Kubernetes-native policy as code for secure and compliant infrastructure');
+      .and('contain.text', 'Enforce policies for secure and compliant resources');
 
     cy.get('.ui5-card-header')
       .eq(4)
       .should('contain.text', 'External Secrets Operator')
-      .and('contain.text', 'Manage and sync credentials from your secret store');
+      .and('contain.text', 'Manage credentials from your secret store');
   });
 
   it('calls onInstallButtonClick when Install is clicked on each card', () => {


### PR DESCRIPTION
## Summary

- Rewrites Flux, Landscaper, Kyverno, and ESO component card descriptions to follow Crossplane's established pattern
- All descriptions are now verb-first, short, without platform/brand names ("Kubernetes"), and in consistent sentence case

## Changes

| Component | Before | After |
|---|---|---|
| Flux | "GitOps for Kubernetes automating continuous sync and delivery" | "Synchronize resources from Git repositories" |
| Landscaper | "Automate cross-dependent Kubernetes deployments" | "Orchestrate cross-dependent deployments" |
| Kyverno | "Kubernetes-native policy as code for secure and compliant infrastructure" | "Enforce policies for secure and compliant resources" |
| ESO | "Manage and sync credentials from your secret store" | "Manage credentials from your secret store" |

## Test plan

- [ ] Verify component card descriptions render correctly on the MCP detail page