### PR TITLE
feat(workspace): single-open accordion, access control, fetch queue

### DIFF
--- a/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.cy.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.cy.tsx
@@ -37,7 +37,7 @@ const workspaces = [makeWorkspace('alpha'), makeWorkspace('beta'), makeWorkspace
 
 function mountAllWorkspaces(
   ws: Workspace[],
-  expandedWorkspaces: Set<string> = new Set(),
+  expandedWorkspace: string | null = null,
   onToggleWorkspace: (name: string) => void = cy.stub(),
 ) {
   cy.mount(
@@ -49,7 +49,7 @@ function mountAllWorkspaces(
               <ControlPlaneListAllWorkspaces
                 projectName="test"
                 workspaces={ws}
-                expandedWorkspaces={expandedWorkspaces}
+                expandedWorkspace={expandedWorkspace}
                 useMcpsQuery={fakeUseMcpsQuery}
                 useDeleteWorkspace={fakeUseDeleteWorkspace}
                 onToggleWorkspace={onToggleWorkspace}
@@ -67,7 +67,6 @@ function panel(name: string) {
 }
 
 function togglePanel(name: string) {
-  // Click the toggle button inside the custom workspace section
   panel(name).find('button').first().click();
 }
 
@@ -76,27 +75,27 @@ function isExpanded(name: string) {
 }
 
 describe('ControlPlaneListAllWorkspaces — expansion via props', () => {
-  it('all workspaces start collapsed when expandedWorkspaces is empty', () => {
-    mountAllWorkspaces(workspaces, new Set());
+  it('all workspaces start collapsed when expandedWorkspace is null', () => {
+    mountAllWorkspaces(workspaces, null);
 
     isExpanded('alpha').should('eq', 'false');
     isExpanded('beta').should('eq', 'false');
     isExpanded('gamma').should('eq', 'false');
   });
 
-  it('expands workspaces that are in expandedWorkspaces', () => {
-    mountAllWorkspaces(workspaces, new Set(['alpha', 'gamma']));
+  it('expands only the specified workspace', () => {
+    mountAllWorkspaces(workspaces, 'alpha');
 
     isExpanded('alpha').should('eq', 'true');
     isExpanded('beta').should('eq', 'false');
-    isExpanded('gamma').should('eq', 'true');
+    isExpanded('gamma').should('eq', 'false');
   });
 
-  it('expands all when all names are in expandedWorkspaces', () => {
-    mountAllWorkspaces(workspaces, new Set(['alpha', 'beta', 'gamma']));
+  it('expands a different workspace when specified', () => {
+    mountAllWorkspaces(workspaces, 'gamma');
 
-    isExpanded('alpha').should('eq', 'true');
-    isExpanded('beta').should('eq', 'true');
+    isExpanded('alpha').should('eq', 'false');
+    isExpanded('beta').should('eq', 'false');
     isExpanded('gamma').should('eq', 'true');
   });
 });
@@ -104,7 +103,7 @@ describe('ControlPlaneListAllWorkspaces — expansion via props', () => {
 describe('ControlPlaneListAllWorkspaces — toggle callback', () => {
   it('calls onToggleWorkspace with workspace name when panel is toggled', () => {
     const onToggle = cy.stub().as('onToggle');
-    mountAllWorkspaces(workspaces, new Set(), onToggle);
+    mountAllWorkspaces(workspaces, null, onToggle);
 
     togglePanel('beta');
 
@@ -113,7 +112,7 @@ describe('ControlPlaneListAllWorkspaces — toggle callback', () => {
 
   it('calls onToggleWorkspace for each toggle independently', () => {
     const onToggle = cy.stub().as('onToggle');
-    mountAllWorkspaces(workspaces, new Set(['alpha', 'beta']), onToggle);
+    mountAllWorkspaces(workspaces, 'alpha', onToggle);
 
     togglePanel('alpha');
     togglePanel('gamma');
@@ -126,7 +125,7 @@ describe('ControlPlaneListAllWorkspaces — toggle callback', () => {
 
 describe('ControlPlaneListAllWorkspaces — empty state', () => {
   it('renders empty state when there are no workspaces', () => {
-    mountAllWorkspaces([], new Set());
+    mountAllWorkspaces([], null);
 
     cy.get('[data-testid^="workspace-panel-"]').should('not.exist');
     cy.get('ui5-illustrated-message').should('exist');

--- a/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.tsx
@@ -3,7 +3,7 @@ import '@ui5/webcomponents-fiori/dist/illustrations/NoData.js';
 import '@ui5/webcomponents-fiori/dist/illustrations/EmptyList.js';
 import '@ui5/webcomponents-fiori/dist/illustrations/NoSearchResults.js';
 import ButtonDesign from '@ui5/webcomponents/dist/types/ButtonDesign.js';
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDeleteWorkspace as _useDeleteWorkspace } from '../../../spaces/onboarding/hooks/useDeleteWorkspace.ts';
 import { useMcpsQuery as _useMcpsQuery } from '../../../spaces/onboarding/hooks/useMcpsQuery.ts';
@@ -15,7 +15,7 @@ interface Props {
   projectName: string;
   workspaces: Workspace[];
   search?: string;
-  expandedWorkspaces: Set<string>;
+  expandedWorkspace: string | null;
   onToggleWorkspace: (workspaceName: string) => void;
   useMcpsQuery?: typeof _useMcpsQuery;
   useDeleteWorkspace?: typeof _useDeleteWorkspace;
@@ -25,7 +25,7 @@ export default function ControlPlaneListAllWorkspaces({
   projectName,
   workspaces,
   search = '',
-  expandedWorkspaces,
+  expandedWorkspace,
   onToggleWorkspace,
   useMcpsQuery = _useMcpsQuery,
   useDeleteWorkspace = _useDeleteWorkspace,
@@ -53,6 +53,27 @@ export default function ControlPlaneListAllWorkspaces({
     });
   }
 
+  // Queue: fetch one collapsed workspace at a time, in order.
+  // grantedIndex tracks which collapsed workspace has the fetch slot.
+  // When it completes (onFetchComplete) we advance to the next.
+  const [grantedIndex, setGrantedIndex] = useState(0);
+  const [forbiddenWorkspaces, setForbiddenWorkspaces] = useState<Set<string>>(new Set());
+
+  const handleFetchComplete = useCallback(() => {
+    setGrantedIndex((prev) => prev + 1);
+  }, []);
+
+  const handleForbiddenDetected = useCallback((workspaceName: string) => {
+    setForbiddenWorkspaces((prev) => {
+      if (prev.has(workspaceName)) return prev;
+      const next = new Set(prev);
+      next.add(workspaceName);
+      return next;
+    });
+    // Also advance the queue — a forbidden workspace counts as complete.
+    setGrantedIndex((prev) => prev + 1);
+  }, []);
+
   if (workspaces.length === 0) {
     return (
       <FlexBox direction="Column" alignItems="Center">
@@ -72,6 +93,14 @@ export default function ControlPlaneListAllWorkspaces({
     );
   }
 
+  let collapsedSeen = 0;
+
+  // Forbidden workspaces sink to the bottom once detected; order is otherwise stable.
+  const sortedWorkspaces = [
+    ...workspaces.filter((ws) => !forbiddenWorkspaces.has(ws.metadata.name)),
+    ...workspaces.filter((ws) => forbiddenWorkspaces.has(ws.metadata.name)),
+  ];
+
   return (
     <>
       {showNoResults && (
@@ -83,19 +112,30 @@ export default function ControlPlaneListAllWorkspaces({
           />
         </FlexBox>
       )}
-      {workspaces.map((workspace) => (
-        <ControlPlaneListWorkspaceGridTile
-          key={`${projectName}-${workspace.metadata.name}`}
-          projectName={projectName}
-          workspace={workspace}
-          search={search}
-          isExpanded={expandedWorkspaces.has(workspace.metadata.name)}
-          useMcpsQuery={useMcpsQuery}
-          useDeleteWorkspace={useDeleteWorkspace}
-          onToggleExpanded={() => onToggleWorkspace(workspace.metadata.name)}
-          onVisibilityChange={(isVisible) => handleVisibilityChange(workspace.metadata.name, isVisible)}
-        />
-      ))}
+      {sortedWorkspaces.map((workspace) => {
+        const isExpanded = workspace.metadata.name === expandedWorkspace;
+        let isFetchGranted = false;
+        if (!isExpanded) {
+          isFetchGranted = collapsedSeen === grantedIndex;
+          collapsedSeen++;
+        }
+        return (
+          <ControlPlaneListWorkspaceGridTile
+            key={`${projectName}-${workspace.metadata.name}`}
+            projectName={projectName}
+            workspace={workspace}
+            search={search}
+            isExpanded={isExpanded}
+            isFetchGranted={isFetchGranted}
+            useMcpsQuery={useMcpsQuery}
+            useDeleteWorkspace={useDeleteWorkspace}
+            onFetchComplete={isFetchGranted ? handleFetchComplete : undefined}
+            onForbiddenDetected={() => handleForbiddenDetected(workspace.metadata.name)}
+            onToggleExpanded={() => onToggleWorkspace(workspace.metadata.name)}
+            onVisibilityChange={(isVisible) => handleVisibilityChange(workspace.metadata.name, isVisible)}
+          />
+        );
+      })}
     </>
   );
 }

--- a/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.cy.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.cy.tsx
@@ -180,4 +180,106 @@ describe('ControlPlaneListWorkspaceGridTile', () => {
       cy.get('@onToggle').should('have.been.calledOnce');
     });
   });
+
+  describe('fetch gating — GetMCPsList only fires when granted', () => {
+    it('does NOT call useMcpsQuery with a namespace when collapsed and no fetch slot granted', () => {
+      const querySpy = cy.stub().as('querySpy').returns({
+        data: [],
+        error: undefined,
+        isPending: false,
+        hasReceivedData: false,
+      });
+
+      cy.mount(
+        <MockedProvider mocks={[]}>
+          <MemoryRouter>
+            <FrontendConfigContext.Provider value={frontendConfig}>
+              <SplitterProvider>
+                <FeatureToggleProvider>
+                  <ControlPlaneListWorkspaceGridTile
+                    workspace={workspace}
+                    projectName="some-project"
+                    isExpanded={false}
+                    isFetchGranted={false}
+                    useMcpsQuery={querySpy}
+                    useDeleteWorkspace={fakeUseDeleteWorkspace}
+                    onToggleExpanded={cy.stub()}
+                  />
+                </FeatureToggleProvider>
+              </SplitterProvider>
+            </FrontendConfigContext.Provider>
+          </MemoryRouter>
+        </MockedProvider>,
+      );
+
+      // querySpy is called but with undefined — meaning no actual query fires
+      cy.get('@querySpy').should('have.been.calledWith', undefined);
+    });
+
+    it('calls useMcpsQuery with the workspace namespace when isFetchGranted is true', () => {
+      const querySpy = cy.stub().as('querySpy').returns({
+        data: [],
+        error: undefined,
+        isPending: false,
+        hasReceivedData: false,
+      });
+
+      cy.mount(
+        <MockedProvider mocks={[]}>
+          <MemoryRouter>
+            <FrontendConfigContext.Provider value={frontendConfig}>
+              <SplitterProvider>
+                <FeatureToggleProvider>
+                  <ControlPlaneListWorkspaceGridTile
+                    workspace={workspace}
+                    projectName="some-project"
+                    isExpanded={false}
+                    isFetchGranted={true}
+                    useMcpsQuery={querySpy}
+                    useDeleteWorkspace={fakeUseDeleteWorkspace}
+                    onToggleExpanded={cy.stub()}
+                  />
+                </FeatureToggleProvider>
+              </SplitterProvider>
+            </FrontendConfigContext.Provider>
+          </MemoryRouter>
+        </MockedProvider>,
+      );
+
+      cy.get('@querySpy').should('have.been.calledWith', 'project-some-project--ws-workspaceName');
+    });
+
+    it('calls useMcpsQuery with the workspace namespace when expanded', () => {
+      const querySpy = cy.stub().as('querySpy').returns({
+        data: [],
+        error: undefined,
+        isPending: false,
+        hasReceivedData: false,
+      });
+
+      cy.mount(
+        <MockedProvider mocks={[]}>
+          <MemoryRouter>
+            <FrontendConfigContext.Provider value={frontendConfig}>
+              <SplitterProvider>
+                <FeatureToggleProvider>
+                  <ControlPlaneListWorkspaceGridTile
+                    workspace={workspace}
+                    projectName="some-project"
+                    isExpanded={true}
+                    isFetchGranted={false}
+                    useMcpsQuery={querySpy}
+                    useDeleteWorkspace={fakeUseDeleteWorkspace}
+                    onToggleExpanded={cy.stub()}
+                  />
+                </FeatureToggleProvider>
+              </SplitterProvider>
+            </FrontendConfigContext.Provider>
+          </MemoryRouter>
+        </MockedProvider>,
+      );
+
+      cy.get('@querySpy').should('have.been.calledWith', 'project-some-project--ws-workspaceName');
+    });
+  });
 });

--- a/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
@@ -2,10 +2,12 @@ import '@ui5/webcomponents-fiori/dist/illustrations/EmptyList.js';
 import '@ui5/webcomponents-fiori/dist/illustrations/NoData.js';
 import IllustrationMessageType from '@ui5/webcomponents-fiori/dist/types/IllustrationMessageType.js';
 import '@ui5/webcomponents-icons/dist/delete';
+import '@ui5/webcomponents-icons/dist/locked.js';
 import '@ui5/webcomponents-icons/dist/product';
 import '@ui5/webcomponents-icons/dist/slim-arrow-right';
-import { Button, BusyIndicator, FlexBox, Icon, ObjectPageSection, Title } from '@ui5/webcomponents-react';
-import { useEffect, useMemo, useState } from 'react';
+import { Button, BusyIndicator, FlexBox, Icon, ObjectPageSection, Popover, Title } from '@ui5/webcomponents-react';
+import PopoverPlacement from '@ui5/webcomponents/dist/types/PopoverPlacement.js';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFeatureToggle } from '../../../context/FeatureToggleContext.tsx';
 import { isForbiddenError } from '../../../lib/api/error.ts';
@@ -13,6 +15,7 @@ import { DISPLAY_NAME_ANNOTATION } from '../../../lib/api/types/shared/keyNames.
 import { useLink } from '../../../lib/shared/useLink.ts';
 import { useDeleteWorkspace as _useDeleteWorkspace } from '../../../spaces/onboarding/hooks/useDeleteWorkspace.ts';
 import { useMcpsQuery as _useMcpsQuery } from '../../../spaces/onboarding/hooks/useMcpsQuery.ts';
+import { useWorkspaceV2ComponentsQuery } from '../../../spaces/onboarding/hooks/useWorkspaceV2ComponentsQuery.ts';
 import { Workspace } from '../../../spaces/onboarding/types/Workspace.ts';
 import { DeleteConfirmationDialog } from '../../Dialogs/DeleteConfirmationDialog.tsx';
 import { EditWorkspaceDialogContainer } from '../../Dialogs/EditWorkspaceDialogContainer.tsx';
@@ -27,6 +30,8 @@ import { ControlPlaneCard } from '../ControlPlaneCard/ControlPlaneCard.tsx';
 import { ControlPlanesListMenu } from '../ControlPlanesListMenu.tsx';
 import { MembersAvatarView } from './MembersAvatarView.tsx';
 import styles from './WorkspacesList.module.css';
+import { useAuthOnboarding } from '../../../spaces/onboarding/auth/AuthContextOnboarding.tsx';
+import { MemberKind } from '../../../lib/api/types/shared/members.ts';
 import { useTelemetry } from '../../../lib/telemetry/telemetry.ts';
 
 interface Props {
@@ -34,6 +39,9 @@ interface Props {
   workspace: Workspace;
   search?: string;
   isExpanded?: boolean;
+  isFetchGranted?: boolean;
+  onFetchComplete?: () => void;
+  onForbiddenDetected?: () => void;
   onToggleExpanded?: () => void;
   onVisibilityChange?: (isVisible: boolean) => void;
   useMcpsQuery?: typeof _useMcpsQuery;
@@ -45,6 +53,9 @@ export function ControlPlaneListWorkspaceGridTile({
   workspace,
   search = '',
   isExpanded,
+  isFetchGranted = false,
+  onFetchComplete,
+  onForbiddenDetected,
   onToggleExpanded,
   onVisibilityChange,
   useMcpsQuery = _useMcpsQuery,
@@ -60,6 +71,21 @@ export function ControlPlaneListWorkspaceGridTile({
 
   const { t } = useTranslation();
   const { enableMcpV2 } = useFeatureToggle();
+  const { user, isPending: authPending } = useAuthOnboarding();
+
+  // Workspace access check: user must appear in workspace.spec.members.
+  // Case-insensitive on both kind and email — defensive against API casing variations.
+  // null = auth not yet resolved (treated as optimistic allow).
+  const isMember: boolean | null =
+    authPending || !user
+      ? null
+      : (workspace.spec.members ?? []).some(
+          (m) =>
+            m.kind.toLowerCase() === MemberKind.User.toLowerCase() && m.name.toLowerCase() === user.email.toLowerCase(),
+        );
+
+  // Only skip fetching when we're certain the user is not a member.
+  const shouldFetch = isMember !== false && (!!isExpanded || isFetchGranted);
 
   const [dialogDeleteWsIsOpen, setDialogDeleteWsIsOpen] = useState(false);
   const [dialogEditWsIsOpen, setDialogEditWsIsOpen] = useState(false);
@@ -68,7 +94,34 @@ export function ControlPlaneListWorkspaceGridTile({
     data: managedControlPlanes,
     error: cpsError,
     isPending,
-  } = useMcpsQuery(`project-${projectName}--ws-${workspaceName}`);
+    hasReceivedData,
+  } = useMcpsQuery(shouldFetch ? `project-${projectName}--ws-${workspaceName}` : undefined);
+
+  // Signal the queue when this tile's fetch settles (data OR error) so the next one can start.
+  // Non-members never fetch, so signal immediately once isMember is resolved as false.
+  const hasFiredComplete = useRef(false);
+  useEffect(() => {
+    const settled = hasReceivedData || !!cpsError || isMember === false;
+    if (!settled || hasFiredComplete.current) return;
+    hasFiredComplete.current = true;
+    onFetchComplete?.();
+  }, [hasReceivedData, cpsError, isMember, onFetchComplete]);
+
+  // Only fetch components for the expanded workspace — collapsed tiles don't show them.
+  const { componentsMap, isLoading: isLoadingV2Components } = useWorkspaceV2ComponentsQuery(
+    isExpanded ? workspace.status?.namespace : undefined,
+  );
+
+  const isForbidden = isMember === false || (!!cpsError && isForbiddenError(cpsError));
+  const [forbiddenPopoverOpen, setForbiddenPopoverOpen] = useState(false);
+  const forbiddenButtonId = `forbidden-btn-${workspaceName}`;
+
+  const hasFiredForbidden = useRef(false);
+  useEffect(() => {
+    if (!isForbidden || hasFiredForbidden.current) return;
+    hasFiredForbidden.current = true;
+    onForbiddenDetected?.();
+  }, [isForbidden, onForbiddenDetected]);
 
   const query = search.trim().toLowerCase();
   const workspaceMatches =
@@ -82,10 +135,11 @@ export function ControlPlaneListWorkspaceGridTile({
         )
       : managedControlPlanes;
 
-  const hasMcpMatch = !isPending && query && !workspaceMatches && (visibleMcps ?? []).length > 0;
+  const hasMcpMatch = hasReceivedData && !isPending && query && !workspaceMatches && (visibleMcps ?? []).length > 0;
   // Hide tile when searching and nothing matches (workspace name/displayName or any CP name)
-  const hidden = !isPending && query && !workspaceMatches && !hasMcpMatch;
-  const shouldCollapsePanel = query ? !(workspaceMatches || hasMcpMatch) : !isExpanded;
+  const hidden = hasReceivedData && !isPending && query && !workspaceMatches && !hasMcpMatch;
+  // Force-collapse when forbidden — the locked header replaces the expand toggle
+  const shouldCollapsePanel = isForbidden || (query ? !(workspaceMatches || hasMcpMatch) : !isExpanded);
 
   useEffect(() => {
     onVisibilityChange?.(!hidden);
@@ -94,28 +148,15 @@ export function ControlPlaneListWorkspaceGridTile({
   const { deleteWorkspace } = useDeleteWorkspace(projectNamespace, workspaceName);
   const telemetry = useTelemetry();
   const { mcpCreationGuide } = useLink();
-  const errorView = createErrorView(cpsError);
 
   function isWorkspaceReady(currentWorkspace: Workspace): boolean {
     return currentWorkspace.status != null && currentWorkspace.status.namespace != null;
   }
 
-  function createErrorView(error: Error | undefined) {
-    if (error) {
-      if (isForbiddenError(error)) {
-        return (
-          <IllustratedError
-            title={t('ControlPlaneListWorkspaceGridTile.permissionErrorMessage')}
-            details={t('ControlPlaneListWorkspaceGridTile.permissionErrorMessageSubtitle')}
-            compact={true}
-          />
-        );
-      } else {
-        return <IllustratedError title={t('ControlPlaneListWorkspaceGridTile.loadingErrorMessage')} />;
-      }
-    }
-    return null;
-  }
+  const errorView = (() => {
+    if (!cpsError || isForbidden) return null;
+    return <IllustratedError title={t('ControlPlaneListWorkspaceGridTile.loadingErrorMessage')} />;
+  })();
 
   const uniqueMembers = useMemo(() => {
     const seenKeys = new Set<string>();
@@ -147,23 +188,62 @@ export function ControlPlaneListWorkspaceGridTile({
       >
         <section className={styles.workspaceSection} data-testid={`workspace-panel-${workspaceName}`}>
           <div className={styles.workspaceHeader}>
-            <button
-              type="button"
-              className={styles.workspaceToggle}
-              aria-expanded={!shouldCollapsePanel}
-              onClick={onToggleExpanded}
-            >
-              <Icon
-                name="slim-arrow-right"
-                className={`${styles.chevron} ${shouldCollapsePanel ? '' : styles.chevronOpen}`}
-              />
-              <Icon name="product" className={styles.workspaceIcon} />
-              <span className={`${styles.workspaceEyebrow} mono-font`}>{t('Entities.Workspace')} ·</span>
-              <Title level="H3" className={styles.workspaceTitle}>
-                {showDisplayName ? workspaceDisplayName : workspaceName}{' '}
-                {!isWorkspaceReady(workspace) ? '(Loading)' : ''}
-              </Title>
-            </button>
+            {isForbidden ? (
+              <>
+                <button
+                  id={forbiddenButtonId}
+                  type="button"
+                  className={styles.workspaceToggle}
+                  aria-expanded={false}
+                  onClick={() => setForbiddenPopoverOpen((o) => !o)}
+                >
+                  <Icon name="locked" className={styles.workspaceIcon} />
+                  <span className={`${styles.workspaceEyebrow} mono-font`}>{t('Entities.Workspace')} ·</span>
+                  <Title level="H3" className={styles.workspaceTitle}>
+                    {showDisplayName ? workspaceDisplayName : workspaceName}
+                  </Title>
+                </button>
+                <Popover
+                  open={forbiddenPopoverOpen}
+                  opener={forbiddenButtonId}
+                  placement={PopoverPlacement.Bottom}
+                  onClose={() => setForbiddenPopoverOpen(false)}
+                >
+                  <div style={{ padding: '0.5rem 1rem' }}>
+                    <p>{t('ControlPlaneListWorkspaceGridTile.permissionErrorMessage')}</p>
+                    <p style={{ color: 'var(--sapContent_LabelColor)', fontSize: '0.875rem' }}>
+                      {t('ControlPlaneListWorkspaceGridTile.permissionErrorMessageSubtitle')}
+                    </p>
+                  </div>
+                </Popover>
+              </>
+            ) : isMember === null ? (
+              <div className={styles.workspaceToggle}>
+                <BusyIndicator active delay={0} size="S" />
+                <span className={`${styles.workspaceEyebrow} mono-font`}>{t('Entities.Workspace')} ·</span>
+                <Title level="H3" className={styles.workspaceTitle}>
+                  {showDisplayName ? workspaceDisplayName : workspaceName}
+                </Title>
+              </div>
+            ) : (
+              <button
+                type="button"
+                className={styles.workspaceToggle}
+                aria-expanded={!shouldCollapsePanel}
+                onClick={onToggleExpanded}
+              >
+                <Icon
+                  name="slim-arrow-right"
+                  className={`${styles.chevron} ${shouldCollapsePanel ? '' : styles.chevronOpen}`}
+                />
+                <Icon name="product" className={styles.workspaceIcon} />
+                <span className={`${styles.workspaceEyebrow} mono-font`}>{t('Entities.Workspace')} ·</span>
+                <Title level="H3" className={styles.workspaceTitle}>
+                  {showDisplayName ? workspaceDisplayName : workspaceName}{' '}
+                  {!isWorkspaceReady(workspace) ? '(Loading)' : ''}
+                </Title>
+              </button>
+            )}
             <CopyButton collapsible text={workspace.status?.namespace || '-'} source="workspace-namespace" />
             <div className={styles.headerSpacer} />
             <MembersAvatarView
@@ -182,8 +262,8 @@ export function ControlPlaneListWorkspaceGridTile({
               <ControlPlanesListMenu
                 setDialogDeleteWsIsOpen={setDialogDeleteWsIsOpen}
                 setDialogEditWsIsOpen={setDialogEditWsIsOpen}
-                setIsCreateManagedControlPlaneWizardOpen={setIsCreateManagedControlPlaneWizardOpen}
                 setInitialTemplateName={setInitialTemplateName}
+                setIsCreateManagedControlPlaneWizardOpen={setIsCreateManagedControlPlaneWizardOpen}
                 setIsCreateManagedControlPlaneWizardOpenV2={setIsCreateManagedControlPlaneWizardOpenV2}
               />
             </FlexBox>
@@ -193,7 +273,7 @@ export function ControlPlaneListWorkspaceGridTile({
             <div className={styles.workspaceBody}>
               {errorView ? (
                 errorView
-              ) : isPending ? (
+              ) : !hasReceivedData || (isPending && managedControlPlanes?.length === 0) ? (
                 <BusyIndicator active delay={0} size="M" />
               ) : managedControlPlanes?.length === 0 ? (
                 <IllustratedBanner
@@ -209,8 +289,8 @@ export function ControlPlaneListWorkspaceGridTile({
                     <>
                       <Button
                         className={styles.createButton}
-                        icon={'add'}
                         design={'Emphasized'}
+                        icon={'add'}
                         onClick={() => {
                           setIsCreateManagedControlPlaneWizardOpen(true);
                         }}
@@ -241,6 +321,8 @@ export function ControlPlaneListWorkspaceGridTile({
                         controlPlane={mcp}
                         projectName={projectName}
                         workspace={workspace}
+                        v2ComponentsMap={componentsMap}
+                        isLoadingV2Components={isLoadingV2Components}
                       />
                     ))}
                   </div>

--- a/src/lib/api/types/shared/members.ts
+++ b/src/lib/api/types/shared/members.ts
@@ -43,7 +43,7 @@ export const MemberSchema = z.object({
   kind: z.string(),
   name: z.string(),
   roles: z.array(z.string()),
-  namespace: z.string().optional(),
+  namespace: z.string().nullish().transform((v) => v ?? undefined).optional(),
 });
 
 export function areMembersEqual(a: Member, b?: Member): boolean {

--- a/src/lib/api/types/shared/members.ts
+++ b/src/lib/api/types/shared/members.ts
@@ -43,7 +43,11 @@ export const MemberSchema = z.object({
   kind: z.string(),
   name: z.string(),
   roles: z.array(z.string()),
-  namespace: z.string().nullish().transform((v) => v ?? undefined).optional(),
+  namespace: z
+    .string()
+    .nullish()
+    .transform((v) => v ?? undefined)
+    .optional(),
 });
 
 export function areMembersEqual(a: Member, b?: Member): boolean {

--- a/src/spaces/onboarding/pages/ProjectPage.module.css
+++ b/src/spaces/onboarding/pages/ProjectPage.module.css
@@ -2,7 +2,3 @@
   margin: 0 auto;
   width: min(1280px, 100%);
 }
-
-.expandCollapseButton {
-  flex-shrink: 0;
-}

--- a/src/spaces/onboarding/pages/ProjectPage.tsx
+++ b/src/spaces/onboarding/pages/ProjectPage.tsx
@@ -1,5 +1,3 @@
-import '@ui5/webcomponents-icons/dist/collapse-all.js';
-import '@ui5/webcomponents-icons/dist/expand-all.js';
 import '@ui5/webcomponents-icons/dist/pushpin-off';
 import '@ui5/webcomponents-icons/dist/pushpin-on';
 import { Button, FlexBox, ObjectPage, ObjectPageSection, ObjectPageTitle, Title } from '@ui5/webcomponents-react';
@@ -20,7 +18,7 @@ import { useRememberedProject } from '../../../hooks/useRememberedProject.ts';
 import { isNotFoundError } from '../../../lib/api/error.ts';
 import { useTelemetry } from '../../../lib/telemetry/telemetry.ts';
 import { Routes } from '../../../Routes.ts';
-import { getExpandedWorkspaces, setExpandedWorkspaces } from '../../../utils/expandedWorkspace.ts';
+import { getExpandedWorkspace, setExpandedWorkspace } from '../../../utils/expandedWorkspace.ts';
 import { projectnameToNamespace } from '../../../utils/index.ts';
 import { useWorkspacesQuery } from '../hooks/useWorkspacesQuery.ts';
 import styles from './ProjectPage.module.css';
@@ -35,8 +33,8 @@ export default function ProjectPage() {
   const isProjectRemembered = rememberedProject === projectName;
   const telemetry = useTelemetry();
 
-  const [expandedWorkspaces, setExpandedWorkspacesState] = useState<Set<string>>(() =>
-    getExpandedWorkspaces(projectName ?? ''),
+  const [expandedWorkspace, setExpandedWorkspaceState] = useState<string | null>(() =>
+    getExpandedWorkspace(projectName ?? ''),
   );
 
   const isInitialRender = useRef(true);
@@ -45,19 +43,11 @@ export default function ProjectPage() {
       isInitialRender.current = false;
       return;
     }
-    setExpandedWorkspaces(projectName ?? '', expandedWorkspaces);
-  }, [projectName, expandedWorkspaces]);
+    setExpandedWorkspace(projectName ?? '', expandedWorkspace);
+  }, [projectName, expandedWorkspace]);
 
   function handleToggleWorkspace(workspaceName: string) {
-    setExpandedWorkspacesState((prev) => {
-      const next = new Set(prev);
-      if (next.has(workspaceName)) {
-        next.delete(workspaceName);
-      } else {
-        next.add(workspaceName);
-      }
-      return next;
-    });
+    setExpandedWorkspaceState((prev) => (prev === workspaceName ? null : workspaceName));
   }
 
   // Fire `workspace-list.searched` only once per "search session" — from the
@@ -131,16 +121,6 @@ export default function ProjectPage() {
     );
   }
 
-  const allExpanded = workspaces.length > 0 && workspaces.every((ws) => expandedWorkspaces.has(ws.metadata.name));
-
-  function handleExpandAll() {
-    setExpandedWorkspacesState(new Set(workspaces!.map((ws) => ws.metadata.name)));
-  }
-
-  function handleCollapseAll() {
-    setExpandedWorkspacesState(new Set());
-  }
-
   return (
     <>
       <ObjectPage
@@ -199,36 +179,13 @@ export default function ProjectPage() {
                 onChange={handleSearchChange}
                 onKeyDown={handleSearchKeyDown}
               />
-              {allExpanded ? (
-                <Button
-                  className={styles.expandCollapseButton}
-                  design="Transparent"
-                  disabled={!!search}
-                  icon="collapse-all"
-                  tooltip={t('ControlPlaneListAllWorkspaces.collapseAll')}
-                  onClick={handleCollapseAll}
-                >
-                  {t('ControlPlaneListAllWorkspaces.collapseAll')}
-                </Button>
-              ) : (
-                <Button
-                  className={styles.expandCollapseButton}
-                  design="Transparent"
-                  disabled={!!search}
-                  icon="expand-all"
-                  tooltip={t('ControlPlaneListAllWorkspaces.expandAll')}
-                  onClick={handleExpandAll}
-                >
-                  {t('ControlPlaneListAllWorkspaces.expandAll')}
-                </Button>
-              )}
             </FlexBox>
           )}
           <ControlPlaneListAllWorkspaces
             projectName={projectName}
             workspaces={workspaces}
             search={search}
-            expandedWorkspaces={expandedWorkspaces}
+            expandedWorkspace={expandedWorkspace}
             onToggleWorkspace={handleToggleWorkspace}
           />
         </ObjectPageSection>

--- a/src/utils/expandedWorkspace.spec.ts
+++ b/src/utils/expandedWorkspace.spec.ts
@@ -1,49 +1,44 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { getExpandedWorkspaces, setExpandedWorkspaces } from './expandedWorkspace';
+import { getExpandedWorkspace, setExpandedWorkspace } from './expandedWorkspace';
 
 describe('expandedWorkspace', () => {
   beforeEach(() => {
     localStorage.clear();
   });
 
-  it('returns empty Set when nothing is stored', () => {
-    expect(getExpandedWorkspaces('my-project').size).toBe(0);
+  it('returns null when nothing is stored', () => {
+    expect(getExpandedWorkspace('my-project')).toBeNull();
   });
 
-  it('stores and retrieves multiple workspace names per project', () => {
-    setExpandedWorkspaces('my-project', new Set(['ws-dev', 'ws-prod']));
-    const result = getExpandedWorkspaces('my-project');
-    expect(result.has('ws-dev')).toBe(true);
-    expect(result.has('ws-prod')).toBe(true);
-    expect(result.size).toBe(2);
-  });
-
-  it('stores independently per project', () => {
-    setExpandedWorkspaces('project-a', new Set(['ws-dev']));
-    setExpandedWorkspaces('project-b', new Set(['ws-prod']));
-    expect(getExpandedWorkspaces('project-a').has('ws-dev')).toBe(true);
-    expect(getExpandedWorkspaces('project-b').has('ws-prod')).toBe(true);
+  it('stores and retrieves a workspace name', () => {
+    setExpandedWorkspace('my-project', 'ws-dev');
+    expect(getExpandedWorkspace('my-project')).toBe('ws-dev');
   });
 
   it('overwrites previous value for the same project', () => {
-    setExpandedWorkspaces('my-project', new Set(['ws-dev']));
-    setExpandedWorkspaces('my-project', new Set(['ws-prod']));
-    const result = getExpandedWorkspaces('my-project');
-    expect(result.has('ws-dev')).toBe(false);
-    expect(result.has('ws-prod')).toBe(true);
+    setExpandedWorkspace('my-project', 'ws-dev');
+    setExpandedWorkspace('my-project', 'ws-prod');
+    expect(getExpandedWorkspace('my-project')).toBe('ws-prod');
   });
 
-  it('removes the key when an empty Set is stored', () => {
-    setExpandedWorkspaces('my-project', new Set(['ws-dev']));
-    setExpandedWorkspaces('my-project', new Set());
-    expect(localStorage.getItem('expandedWorkspaces:my-project')).toBeNull();
-    expect(getExpandedWorkspaces('my-project').size).toBe(0);
+  it('removes the key when null is stored', () => {
+    setExpandedWorkspace('my-project', 'ws-dev');
+    setExpandedWorkspace('my-project', null);
+    expect(localStorage.getItem('expandedWorkspace:my-project')).toBeNull();
+    expect(getExpandedWorkspace('my-project')).toBeNull();
+  });
+
+  it('stores independently per project', () => {
+    setExpandedWorkspace('project-a', 'ws-dev');
+    setExpandedWorkspace('project-b', 'ws-prod');
+    expect(getExpandedWorkspace('project-a')).toBe('ws-dev');
+    expect(getExpandedWorkspace('project-b')).toBe('ws-prod');
   });
 
   it('clearing one project does not affect another', () => {
-    setExpandedWorkspaces('project-a', new Set(['ws-dev']));
-    setExpandedWorkspaces('project-b', new Set(['ws-prod']));
-    setExpandedWorkspaces('project-a', new Set());
-    expect(getExpandedWorkspaces('project-b').has('ws-prod')).toBe(true);
+    setExpandedWorkspace('project-a', 'ws-dev');
+    setExpandedWorkspace('project-b', 'ws-prod');
+    setExpandedWorkspace('project-a', null);
+    expect(getExpandedWorkspace('project-b')).toBe('ws-prod');
   });
 });

--- a/src/utils/expandedWorkspace.ts
+++ b/src/utils/expandedWorkspace.ts
@@ -1,25 +1,25 @@
-const STORAGE_KEY_PREFIX = 'expandedWorkspaces:';
+const STORAGE_KEY_PREFIX = 'expandedWorkspace:';
 
 function storageKey(projectName: string): string {
   return `${STORAGE_KEY_PREFIX}${projectName}`;
 }
 
-export function getExpandedWorkspaces(projectName: string): Set<string> {
+export function getExpandedWorkspace(projectName: string): string | null {
   try {
-    const raw = localStorage.getItem(storageKey(projectName));
-    if (!raw) return new Set();
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return new Set();
-    return new Set(parsed as string[]);
+    return localStorage.getItem(storageKey(projectName));
   } catch {
-    return new Set();
+    return null;
   }
 }
 
-export function setExpandedWorkspaces(projectName: string, expanded: Set<string>): void {
-  if (expanded.size === 0) {
-    localStorage.removeItem(storageKey(projectName));
-  } else {
-    localStorage.setItem(storageKey(projectName), JSON.stringify([...expanded]));
+export function setExpandedWorkspace(projectName: string, workspaceName: string | null): void {
+  try {
+    if (workspaceName === null) {
+      localStorage.removeItem(storageKey(projectName));
+    } else {
+      localStorage.setItem(storageKey(projectName), workspaceName);
+    }
+  } catch {
+    // ignore
   }
 }


### PR DESCRIPTION
## Summary

**Single-open accordion**
One workspace expands at a time. Clicking the open one collapses it (all-collapsed allowed). Last-open workspace is persisted per project in `localStorage`.

**Access control**
Workspace membership is checked statically from `spec.members` (already available in the `GetWorkspaces` response — no extra request). Non-members see a locked icon with a popover instead of an expand toggle, and are sorted to the bottom of the list.

**Background fetch queue**
Expanded workspace fires `GetMCPsList` + `GetWorkspaceV2Components` immediately. Collapsed workspaces queue one-at-a-time — each starts only after the previous settles — keeping search working without competing with the active workspace for HTTP connections.

**Bug fix**
`MemberSchema` used `z.string().optional()` for `namespace`; GraphQL returns `null` which Zod rejects, silently emptying `spec.members` for all workspaces (causing everyone to appear unauthorized). Fixed with `.nullish()`.

## Dependencies

> **Blocked on:** #718 (`perf/workspace-card-perf`) → #717 (`perf/graphql-subscriptions`)

## Test plan

- [ ] Only one workspace can be expanded at a time
- [ ] Collapsing the last open workspace leaves all collapsed
- [ ] Last-open workspace is restored on page reload
- [ ] Workspace where user is not in `spec.members` shows locked icon, no expand
- [ ] Locked workspaces appear at the bottom
- [ ] Search returns results across all workspaces (collapsed ones fetch in background)
- [ ] Non-member workspaces do not fire `GetMCPsList`