### PR TITLE
perf: disable SWR revalidation triggers and cache static assets

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -179,6 +179,11 @@ await fastify.register(FastifyVite, {
   root: __dirname,
   dev: isLocalDev,
   spa: true,
+  // Vite content-hashes all assets in /assets/ — safe to cache indefinitely
+  fastifyStaticOptions: isLocalDev ? undefined : {
+    maxAge: '1y',
+    immutable: true,
+  },
 });
 
 fastify.get('/sentry', function (req, reply) {

--- a/src/components/SWRConfigWithTokenRefresh.tsx
+++ b/src/components/SWRConfigWithTokenRefresh.tsx
@@ -15,7 +15,8 @@ export function SWRConfigWithTokenRefresh({ children }: { children: ReactNode })
     <SWRConfig
       value={{
         refreshInterval: 10000,
-        // component re-renders on refresh state changes, so the closure is not stale
+        revalidateOnFocus: false,
+        revalidateOnReconnect: false,
         isPaused: () => isRefreshing,
       }}
     >


### PR DESCRIPTION
## Summary

- **BFF**: Cache hashed static assets (`/assets/*`) for 1 year with `immutable` flag — safe because Vite content-hashes all filenames at build time.
- **SWR**: Disable `revalidateOnFocus` and `revalidateOnReconnect` — these were triggering unnecessary refetches of all REST endpoints whenever the tab regained focus or the network reconnected.

## Dependencies

None — standalone, no dependency on other PRs in this series.

## Test plan

- [ ] Navigating away and back to the tab does not trigger REST refetches
- [ ] Static assets return with `Cache-Control: max-age=31536000, immutable` in production build