### PR TITLE
fix(test): assert avatar-group not.exist when members are empty

### DIFF
--- a/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCard.cy.tsx
+++ b/src/components/ControlPlanes/ControlPlaneCard/ControlPlaneCard.cy.tsx
@@ -553,7 +553,7 @@ describe('ControlPlaneCard', () => {
           </MemoryRouter>
         </MockedProvider>,
       );
-      cy.get('ui5-avatar-group').find('ui5-avatar').should('have.length', 0);
+      cy.get('ui5-avatar-group').should('not.exist');
     });
 
     it('renders avatars for v2 members from spec.iam.oidc roleBindings', () => {
@@ -600,7 +600,7 @@ describe('ControlPlaneCard', () => {
           </MemoryRouter>
         </MockedProvider>,
       );
-      cy.get('ui5-avatar-group').find('ui5-avatar').should('have.length', 0);
+      cy.get('ui5-avatar-group').should('not.exist');
     });
   });
 


### PR DESCRIPTION
## Summary

`MembersAvatarView` returns `null` when `members.length === 0`, so `ui5-avatar-group` is never rendered. Two tests were asserting `cy.get('ui5-avatar-group').find('ui5-avatar').should('have.length', 0)` which times out waiting for an element that can never appear.

Fixed both:
- `renders no avatars when there are no members` (v1 card)
- `renders no avatars for v2 when spec.iam is absent` (v2 card)

This unblocks PR #661 (`feat/avatar-color-consistency`) which was failing CI with the same error.

## Test plan
- [ ] `ControlPlaneCard.cy.tsx` passes locally