### PR TITLE
feat: deeplink support for open-source view mode

### DIFF
--- a/src/context/ViewModeContext.spec.tsx
+++ b/src/context/ViewModeContext.spec.tsx
@@ -26,17 +26,17 @@ describe('ViewModeContext', () => {
     vi.restoreAllMocks();
   });
 
-  it('defaults to beginner mode when nothing is stored', () => {
+  it('defaults to open-source mode when nothing is stored and headlamp is enabled', () => {
     mockConfig(true);
     const { result } = renderHook(() => useViewMode(), { wrapper });
-    expect(result.current.mode).toBe('beginner');
+    expect(result.current.mode).toBe('open-source');
   });
 
-  it('falls back to beginner mode for any unknown stored value', () => {
+  it('falls back to open-source mode for any unknown stored value when headlamp is enabled', () => {
     mockConfig(true);
     localStorage.setItem('mcp-ui-view-mode', 'some-unknown-value');
     const { result } = renderHook(() => useViewMode(), { wrapper });
-    expect(result.current.mode).toBe('beginner');
+    expect(result.current.mode).toBe('open-source');
   });
 
   it('restores open-source mode from localStorage when headlamp is enabled', () => {

--- a/src/context/ViewModeContext.tsx
+++ b/src/context/ViewModeContext.tsx
@@ -19,7 +19,10 @@ export function ViewModeProvider({ children }: { children: ReactNode }) {
 
   const [mode, setModeState] = useState<ViewMode>(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
-    return stored === 'open-source' && headlampAvailable ? 'open-source' : 'beginner';
+    if (!headlampAvailable) return 'beginner';
+    // Default to open-source when headlamp is available and no explicit choice was stored
+    if (stored === 'beginner') return 'beginner';
+    return 'open-source';
   });
 
   const setMode = (newMode: ViewMode) => {

--- a/src/spaces/controlPlaneV2/pages/ControlPlanePageV2.tsx
+++ b/src/spaces/controlPlaneV2/pages/ControlPlanePageV2.tsx
@@ -371,7 +371,7 @@ export default function ControlPlanePageV2() {
   const namespace = projectName && workspaceName ? `project-${projectName}--ws-${workspaceName}` : undefined;
   const [searchParams, setSearchParams] = useSearchParams();
   const { t } = useTranslation();
-  const { mode } = useViewMode();
+  const { mode, setMode } = useViewMode();
   const [isEditManagedControlPlaneWizardOpen, setIsEditManagedControlPlaneWizardOpen] = useState(false);
   const [editManagedControlPlaneWizardSection, setEditManagedControlPlaneWizardSection] = useState<
     undefined | WizardStepType
@@ -383,6 +383,29 @@ export default function ControlPlanePageV2() {
     }
     return 'overview' as McpPageSectionId;
   }, [searchParams]);
+
+  // Sync ?view param with mode: read on mount to restore shared deeplinks, write on change.
+  useEffect(() => {
+    const viewParam = searchParams.get('view');
+    if (viewParam === 'open-source') setMode('open-source');
+    else if (viewParam === 'beginner') setMode('beginner');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (mode === 'open-source') {
+          next.set('view', 'open-source');
+        } else {
+          next.delete('view');
+        }
+        return next;
+      },
+      { replace: true },
+    );
+  }, [mode, setSearchParams]);
   const { data: mcp, isPending: isLoading, error } = useControlPlaneV2Query(controlPlaneName, namespace);
   const { crossplaneData, isLoading: isLoadingCrossplane } = useCrossplaneQuery(controlPlaneName, namespace);
   const { fluxData, isLoading: isLoadingFlux } = useFluxQuery(controlPlaneName, namespace);

--- a/src/spaces/mcp/pages/ManagedControlPlanePage.tsx
+++ b/src/spaces/mcp/pages/ManagedControlPlanePage.tsx
@@ -256,7 +256,7 @@ export default function ManagedControlPlanePage() {
   const { projectName, workspaceName, controlPlaneName } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const { t } = useTranslation();
-  const { mode } = useViewMode();
+  const { mode, setMode } = useViewMode();
   const [isEditManagedControlPlaneWizardOpen, setIsEditManagedControlPlaneWizardOpen] = useState(false);
   const [editManagedControlPlaneWizardSection, setEditManagedControlPlaneWizardSection] = useState<
     undefined | WizardStepType
@@ -268,6 +268,28 @@ export default function ManagedControlPlanePage() {
     }
     return 'overview' as McpPageSectionId;
   }, [searchParams]);
+
+  useEffect(() => {
+    const viewParam = searchParams.get('view');
+    if (viewParam === 'open-source') setMode('open-source');
+    else if (viewParam === 'beginner') setMode('beginner');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (mode === 'open-source') {
+          next.set('view', 'open-source');
+        } else {
+          next.delete('view');
+        }
+        return next;
+      },
+      { replace: true },
+    );
+  }, [mode, setSearchParams]);
 
   const setTabFromSection = (sectionId: McpPageSectionId) => {
     setSearchParams((prev) => {


### PR DESCRIPTION
## Summary

- **Deeplink support** — `?view=open-source` is added to the URL whenever headlamp mode is active. Sharing the URL now automatically opens the recipient in the same view.
- **On-load restore** — when `?view=open-source` or `?view=beginner` is present in the URL on mount, it overrides localStorage, so deeplinks work even for users who have a different stored preference.
- **Default to open-source** — when headlamp is available and the user has no explicit stored preference (`beginner`), the default is now `open-source` instead of `beginner`.

## Behaviour

| Scenario | Before | After |
|---|---|---|
| User copies URL in headlamp mode and shares it | Recipient opens in legacy view | Recipient opens in headlamp view |
| First-time user with headlamp enabled | Opens in legacy view | Opens in headlamp view |
| User explicitly toggled to legacy and shares link | — | Recipient opens in legacy view (no `?view` param) |

## Test plan

- [ ] Navigate to a v2 control plane — URL gains `?view=open-source` automatically
- [ ] Toggle to legacy mode — `?view` param is removed from URL
- [ ] Open the URL with `?view=open-source` in a fresh session — lands in headlamp mode
- [ ] Open URL without `?view` param as first-time user with headlamp enabled — defaults to headlamp
- [ ] Open URL with `?view=beginner` — lands in legacy mode regardless of default