### PR TITLE
feat(wizard): YAML preview on all ControlPlane wizard steps

### DIFF
--- a/src/components/Wizards/CreateControlPlaneV2/CreateControlPlaneV2WizardContainer.tsx
+++ b/src/components/Wizards/CreateControlPlaneV2/CreateControlPlaneV2WizardContainer.tsx
@@ -1,4 +1,5 @@
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import '@ui5/webcomponents-icons/dist/accept';
 
 import IllustrationMessageType from '@ui5/webcomponents-fiori/dist/types/IllustrationMessageType.js';
 
@@ -6,19 +7,10 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import type { WizardStepChangeEventDetail } from '@ui5/webcomponents-fiori/dist/Wizard.js';
 import { useForm, useWatch } from 'react-hook-form';
 
-import {
-  Bar,
-  Button,
-  Dialog,
-  FlexBox,
-  Text,
-  Ui5CustomEvent,
-  Wizard,
-  WizardDomRef,
-  WizardStep,
-} from '@ui5/webcomponents-react';
+import { Bar, Button, Dialog, Text, Ui5CustomEvent, Wizard, WizardDomRef, WizardStep } from '@ui5/webcomponents-react';
 
 import { Trans, useTranslation } from 'react-i18next';
+import { stringify } from 'yaml';
 import { APIError } from '../../../lib/api/error.ts';
 import { DISPLAY_NAME_ANNOTATION } from '../../../lib/api/types/shared/keyNames.ts';
 import { MCP_V2_DEFAULT_ROLE, Member } from '../../../lib/api/types/shared/members.ts';
@@ -44,6 +36,7 @@ import {
   buildRoleBindingsForProviderMembers,
   normalizeMcpV2Role,
 } from '../../../spaces/controlPlaneV2/helpers/buildRoleBindingsForProviderMembers.ts';
+import { buildMcpV2GraphQLInput } from '../../../spaces/controlPlaneV2/helpers/controlPlaneV2GraphQLInput.ts';
 import { extractMcpV2FormState } from '../../../spaces/controlPlaneV2/helpers/extractMcpV2FormState.ts';
 import { hasAssignedIamMember } from '../../../spaces/controlPlaneV2/helpers/hasAssignedIamMember.ts';
 import { useCreateControlPlaneV2GraphQL as _useCreateManagedControlPlaneV2GraphQL } from '../../../spaces/controlPlaneV2/hooks/useCreateControlPlaneV2GraphQL.ts';
@@ -67,6 +60,7 @@ import styles from '../CreateManagedControlPlane/CreateManagedControlPlaneWizard
 import { IdentityProvidersStep } from './IdentityProviders/IdentityProvidersStep.tsx';
 import { ServiceSelectionStep } from './ServiceSelectionStep.tsx';
 import { SummarizeStepV2 } from './SummarizeStepV2.tsx';
+import { WizardYamlPreview } from './WizardYamlPreview.tsx';
 
 type CreateManagedControlPlaneV2WizardContainerProps = {
   isOpen: boolean;
@@ -346,6 +340,51 @@ export const CreateControlPlaneV2WizardContainer: FC<CreateManagedControlPlaneV2
     extraProviders,
     isDefaultProviderEnabled,
   ]);
+
+  const wizardYamlString = useMemo(() => stringify(buildMcpV2GraphQLInput(rawInput)), [rawInput]);
+
+  const servicesYamlString = useMemo(() => {
+    const cpName = rawInput.name || '<name>';
+    const cpNamespace = rawInput.namespace || '<namespace>';
+    const docs: object[] = [buildMcpV2GraphQLInput(rawInput)];
+    if (services?.crossplane?.selected) {
+      docs.push({
+        apiVersion: 'crossplane.services.open-control-plane.io/v1alpha1',
+        kind: 'Crossplane',
+        metadata: { name: cpName, namespace: cpNamespace },
+        spec: {
+          version: services.crossplane.version || 'latest',
+          ...(services.crossplane.providers?.length
+            ? {
+                providers: services.crossplane.providers.map((p) => ({ name: p.name, version: p.version || 'latest' })),
+              }
+            : {}),
+        },
+      });
+    }
+    if (services?.flux?.selected)
+      docs.push({
+        apiVersion: 'flux.services.open-control-plane.io/v1alpha1',
+        kind: 'Flux',
+        metadata: { name: cpName, namespace: cpNamespace },
+        spec: { version: services.flux.version || 'latest' },
+      });
+    if (services?.landscaper?.selected)
+      docs.push({
+        apiVersion: 'landscaper.services.open-control-plane.io/v1alpha2',
+        kind: 'Landscaper',
+        metadata: { name: cpName, namespace: cpNamespace },
+        spec: { version: services.landscaper.version || 'latest' },
+      });
+    if (services?.externalSecretsOperator?.selected)
+      docs.push({
+        apiVersion: 'externalsecrets.services.open-control-plane.io/v1alpha1',
+        kind: 'ExternalSecretsOperator',
+        metadata: { name: cpName, namespace: cpNamespace },
+        spec: { version: services.externalSecretsOperator.version || 'latest' },
+      });
+    return docs.map((d) => stringify(d)).join('---\n');
+  }, [rawInput, services]);
 
   const handleCreateManagedControlPlane = useCallback(async (): Promise<boolean> => {
     try {
@@ -758,8 +797,8 @@ export const CreateControlPlaneV2WizardContainer: FC<CreateManagedControlPlaneV2
             selected={selectedStep === 'metadata'}
             data-step="metadata"
           >
-            <FlexBox direction={'Row'} justifyContent={'SpaceBetween'} gap={16}>
-              <div className={styles.metadataForm}>
+            <div className={styles.yamlSplitLayout}>
+              <div className={styles.metadataFormColumn}>
                 <MetadataForm
                   key={metadataFormKey}
                   watch={watch}
@@ -774,23 +813,27 @@ export const CreateControlPlaneV2WizardContainer: FC<CreateManagedControlPlaneV2
                   displayNameSuffix={templateAffixes.displayNameSuffix}
                   isV2
                 />
+                {isDuplicateMode && (
+                  <div className={styles.infoboxContainer}>
+                    <Infobox size={'sm'}>
+                      <Text>
+                        <Trans
+                          i18nKey="editMCP.duplicatingMCPInfo1"
+                          components={{ span: <span className="mono-font" /> }}
+                        />
+                      </Text>
+                      <Text>
+                        <Trans i18nKey="editMCP.duplicatingMCPInfo2" components={{ b: <b /> }} />
+                      </Text>
+                    </Infobox>
+                  </div>
+                )}
               </div>
-              {isDuplicateMode && (
-                <div className={styles.infoboxContainer}>
-                  <Infobox size={'sm'}>
-                    <Text>
-                      <Trans
-                        i18nKey="editMCP.duplicatingMCPInfo1"
-                        components={{ span: <span className="mono-font" /> }}
-                      />
-                    </Text>
-                    <Text>
-                      <Trans i18nKey="editMCP.duplicatingMCPInfo2" components={{ b: <b /> }} />
-                    </Text>
-                  </Infobox>
-                </div>
-              )}
-            </FlexBox>
+              <WizardYamlPreview
+                yamlString={wizardYamlString}
+                filename={`mcp_${rawInput.namespace}_${rawInput.name || 'new'}`}
+              />
+            </div>
           </WizardStep>
           <WizardStep
             icon="user-edit"
@@ -819,7 +862,13 @@ export const CreateControlPlaneV2WizardContainer: FC<CreateManagedControlPlaneV2
             selected={selectedStep === 'componentSelection'}
             data-step="componentSelection"
           >
-            <ServiceSelectionStep services={services} onServicesChange={setServices} />
+            <div className={styles.yamlSplitLayout}>
+              <ServiceSelectionStep services={services} onServicesChange={setServices} />
+              <WizardYamlPreview
+                yamlString={servicesYamlString}
+                filename={`mcp_${rawInput.namespace}_${rawInput.name || 'new'}`}
+              />
+            </div>
           </WizardStep>
 
           <WizardStep
@@ -833,10 +882,11 @@ export const CreateControlPlaneV2WizardContainer: FC<CreateManagedControlPlaneV2
               rawInput={rawInput}
               isDefaultProviderEnabled={isDefaultProviderEnabled}
               services={services}
+              servicesYamlString={servicesYamlString}
             />
           </WizardStep>
           <WizardStep
-            icon="activities"
+            icon="accept"
             titleText={t('common.success')}
             disabled={isStepDisabled('success')}
             selected={selectedStep === 'success'}

--- a/src/components/Wizards/CreateControlPlaneV2/SummarizeStepV2.module.css
+++ b/src/components/Wizards/CreateControlPlaneV2/SummarizeStepV2.module.css
@@ -1,0 +1,37 @@
+.summary {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-width: 0;
+}
+
+.sectionTitle {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: var(--sapContent_LabelColor);
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.sectionContent {
+  border: 1px solid var(--sapList_BorderColor, #e5e5e5);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.row {
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--sapList_BorderColor, #e5e5e5);
+}
+
+.row:last-child {
+  border-bottom: none;
+}
+
+.logo {
+  width: 1.25rem;
+  height: 1.25rem;
+  object-fit: contain;
+}

--- a/src/components/Wizards/CreateControlPlaneV2/SummarizeStepV2.tsx
+++ b/src/components/Wizards/CreateControlPlaneV2/SummarizeStepV2.tsx
@@ -1,137 +1,146 @@
-import { Grid, List, ListItemStandard } from '@ui5/webcomponents-react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { stringify } from 'yaml';
+import { FlexBox, Label, Text } from '@ui5/webcomponents-react';
 import { buildMcpV2GraphQLInput } from '../../../spaces/controlPlaneV2/helpers/controlPlaneV2GraphQLInput.ts';
 import { McpV2Input, ServiceSelection } from '../../../spaces/mcp/schemas/mcpV2Input.schema.ts';
-import { parseResourceApiInfo } from '../../../utils/parseResourceApiInfo.ts';
-import { Resource } from '../../../utils/removeManagedFieldsAndFilterData.ts';
-import styles from '../CreateManagedControlPlane/SummarizeStep.module.css';
-import YamlSummarize from '../CreateManagedControlPlane/YamlSummarize.tsx';
+import LogoCrossplane from '../../../assets/images/logo-crossplane.svg';
+import LogoEso from '../../../assets/images/logo-eso.svg';
+import LogoFlux from '../../../assets/images/logo-flux.svg';
+import LogoLandscaper from '../../../assets/images/logo-landscaper.svg';
+import { WizardYamlPreview } from './WizardYamlPreview.tsx';
+import styles from './SummarizeStepV2.module.css';
+import sharedStyles from '../CreateManagedControlPlane/CreateManagedControlPlaneWizardContainer.module.css';
 
 interface SummarizeStepProps {
   rawInput: McpV2Input;
   isDefaultProviderEnabled?: boolean;
   services?: ServiceSelection;
+  servicesYamlString?: string;
 }
+
+interface SummaryRow {
+  label: string;
+  value: string;
+  logo?: string;
+}
+
+function SummarySection({ title, rows }: { title: string; rows: SummaryRow[] }) {
+  if (rows.length === 0) return null;
+  return (
+    <div>
+      <Text className={styles.sectionTitle}>{title}</Text>
+      <div className={styles.sectionContent}>
+        {rows.map(({ label, value, logo }) => (
+          <FlexBox key={`${label}-${value}`} justifyContent="SpaceBetween" alignItems="Center" className={styles.row}>
+            <FlexBox alignItems="Center" gap={8}>
+              {logo && <img src={logo} alt="" className={styles.logo} />}
+              <Label>{label}</Label>
+            </FlexBox>
+            <Text className="mono-font">{value}</Text>
+          </FlexBox>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const SERVICE_LOGOS: Record<string, string> = {
+  crossplane: LogoCrossplane,
+  flux: LogoFlux,
+  landscaper: LogoLandscaper,
+  externalSecretsOperator: LogoEso,
+};
+
+const SERVICE_LABELS: Record<string, string> = {
+  crossplane: 'ServiceSelectionStep.crossplane',
+  flux: 'ServiceSelectionStep.flux',
+  landscaper: 'ServiceSelectionStep.landscaper',
+  externalSecretsOperator: 'ServiceSelectionStep.externalSecretsOperator',
+};
 
 export const SummarizeStepV2: React.FC<SummarizeStepProps> = ({
   rawInput,
   isDefaultProviderEnabled = true,
   services,
+  servicesYamlString,
 }) => {
   const { t } = useTranslation();
 
-  const { yamlString, apiGroupName, apiVersion } = useMemo(() => {
-    const res = buildMcpV2GraphQLInput(rawInput);
-    return {
-      yamlString: stringify(res),
-      ...parseResourceApiInfo(res as unknown as Resource),
-    };
-  }, [rawInput]);
+  const yamlString = useMemo(
+    () => servicesYamlString ?? stringify(buildMcpV2GraphQLInput(rawInput)),
+    [rawInput, servicesYamlString],
+  );
 
-  const defaultMembersHeaderText = isDefaultProviderEnabled
-    ? t('common.members')
-    : `${t('common.members')} ${t('IdentityProviders.disabledBadge')}`;
+  const defaultMemberRows: SummaryRow[] = isDefaultProviderEnabled
+    ? rawInput.roleBindings.flatMap((rb) =>
+        rb.subjects.map((subject) => ({
+          label: subject.name,
+          value: `${subject.kind} · ${rb.roleRefs[0]?.name ?? ''}`,
+        })),
+      )
+    : [{ label: t('IdentityProviders.disabledBadge'), value: '' }];
 
   const selectedServices = useMemo(() => {
     if (!services) return [];
-    return [
-      { key: 'crossplane', label: t('ServiceSelectionStep.crossplane'), entry: services.crossplane },
-      { key: 'flux', label: t('ServiceSelectionStep.flux'), entry: services.flux },
-      { key: 'landscaper', label: t('ServiceSelectionStep.landscaper'), entry: services.landscaper },
-      {
-        key: 'externalSecretsOperator',
-        label: t('ServiceSelectionStep.externalSecretsOperator'),
-        entry: services.externalSecretsOperator,
-      },
-    ].filter((s) => s.entry?.selected);
+    return Object.entries(SERVICE_LABELS)
+      .map(([key, labelKey]) => ({
+        key,
+        label: t(labelKey),
+        logo: SERVICE_LOGOS[key],
+        entry: services[key as keyof ServiceSelection],
+      }))
+      .filter((s) => s.entry?.selected);
   }, [services, t]);
 
+  const serviceRows: SummaryRow[] = selectedServices.map(({ label, logo, entry }) => ({
+    label,
+    value: entry?.version || t('ServiceSelectionStep.versionPlaceholder'),
+    logo,
+  }));
+
+  const providerRows: SummaryRow[] =
+    services?.crossplane?.selected && services.crossplane.providers?.length
+      ? services.crossplane.providers.map((provider) => ({
+          label: provider.name,
+          value: provider.version || t('ServiceSelectionStep.versionPlaceholder'),
+        }))
+      : [];
+
   return (
-    <div className={styles.wrapper}>
-      <Grid defaultSpan="XL6 L6 M6 S6">
-        <div>
-          <List headerText={t('common.metadata')}>
-            <ListItemStandard text={t('common.name')} additionalText={rawInput.name} />
-            <ListItemStandard text={t('common.namespace')} additionalText={rawInput.namespace} />
-          </List>
-          <br />
-          <List headerText={defaultMembersHeaderText}>
-            {rawInput.roleBindings
-              .flatMap((rb) =>
-                rb.subjects.map((subject) => ({
-                  ...subject,
-                  role: rb.roleRefs[0]?.name ?? '',
-                })),
-              )
-              .map((subject) => (
-                <ListItemStandard
-                  key={`${subject.kind}:${subject.name}:${subject.role}`}
-                  text={subject.name}
-                  additionalText={`${subject.kind} · ${subject.role}`}
-                />
-              ))}
-          </List>
-          {rawInput.extraProviders.map((provider) => (
-            <div key={provider.name}>
-              <br />
-              <List headerText={provider.name}>
-                {provider.roleBindings
-                  .flatMap((rb) =>
-                    rb.subjects.map((subject) => ({
-                      ...subject,
-                      role: rb.roleRefs[0]?.name ?? '',
-                    })),
-                  )
-                  .map((subject) => (
-                    <ListItemStandard
-                      key={`${provider.name}:${subject.kind}:${subject.name}:${subject.role}`}
-                      text={subject.name}
-                      additionalText={`${subject.kind} · ${subject.role}`}
-                    />
-                  ))}
-              </List>
-            </div>
-          ))}
-          {selectedServices.length > 0 && (
-            <>
-              <br />
-              <List headerText={t('ServiceSelectionStep.stepTitle')}>
-                {selectedServices.map(({ key, label, entry }) => (
-                  <ListItemStandard
-                    key={key}
-                    text={label}
-                    additionalText={entry?.version || t('ServiceSelectionStep.versionPlaceholder')}
-                  />
-                ))}
-              </List>
-              {!!services?.crossplane?.selected && services.crossplane.providers?.length ? (
-                <>
-                  <br />
-                  <List headerText={t('ComponentInstallDialog.providers')}>
-                    {services.crossplane.providers.map((provider) => (
-                      <ListItemStandard
-                        key={provider.name}
-                        text={provider.name}
-                        additionalText={provider.version || t('ServiceSelectionStep.versionPlaceholder')}
-                      />
-                    ))}
-                  </List>
-                </>
-              ) : null}
-            </>
-          )}
-        </div>
-        <div>
-          <YamlSummarize
-            yamlString={yamlString}
-            filename={`mcp_${rawInput.namespace}_${rawInput.name}`}
-            apiVersion={apiVersion}
-            apiGroupName={apiGroupName}
+    <div className={sharedStyles.yamlSplitLayout}>
+      <div className={styles.summary}>
+        <SummarySection
+          title={t('common.metadata')}
+          rows={[
+            { label: t('common.name'), value: rawInput.name },
+            { label: t('common.namespace'), value: rawInput.namespace },
+          ]}
+        />
+
+        <SummarySection title={t('common.members')} rows={defaultMemberRows} />
+
+        {rawInput.extraProviders.map((provider) => (
+          <SummarySection
+            key={provider.name}
+            title={`${t('IdentityProviders.customIdp')}: ${provider.name}`}
+            rows={provider.roleBindings.flatMap((rb) =>
+              rb.subjects.map((subject) => ({
+                label: subject.name,
+                value: `${subject.kind} · ${rb.roleRefs[0]?.name ?? ''}`,
+              })),
+            )}
           />
-        </div>
-      </Grid>
+        ))}
+
+        {serviceRows.length > 0 && <SummarySection title={t('ServiceSelectionStep.stepTitle')} rows={serviceRows} />}
+
+        {providerRows.length > 0 && (
+          <SummarySection title={t('ComponentInstallDialog.providers')} rows={providerRows} />
+        )}
+      </div>
+
+      <WizardYamlPreview yamlString={yamlString} filename={`mcp_${rawInput.namespace}_${rawInput.name}`} />
     </div>
   );
 };

--- a/src/components/Wizards/CreateControlPlaneV2/WizardYamlPreview.module.css
+++ b/src/components/Wizards/CreateControlPlaneV2/WizardYamlPreview.module.css
@@ -1,0 +1,12 @@
+.container {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.viewer {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}

--- a/src/components/Wizards/CreateControlPlaneV2/WizardYamlPreview.tsx
+++ b/src/components/Wizards/CreateControlPlaneV2/WizardYamlPreview.tsx
@@ -1,0 +1,30 @@
+import { FC } from 'react';
+import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard.ts';
+import { YamlViewer } from '../../Yaml/YamlViewer.tsx';
+import styles from './WizardYamlPreview.module.css';
+import '@ui5/webcomponents-icons/dist/copy';
+import { Button, FlexBox } from '@ui5/webcomponents-react';
+import { useTranslation } from 'react-i18next';
+
+interface WizardYamlPreviewProps {
+  yamlString: string;
+  filename: string;
+}
+
+export const WizardYamlPreview: FC<WizardYamlPreviewProps> = ({ yamlString, filename }) => {
+  const { t } = useTranslation();
+  const { copyToClipboard } = useCopyToClipboard();
+
+  return (
+    <FlexBox direction="Column" gap={8} className={styles.container}>
+      <FlexBox justifyContent="End">
+        <Button icon="copy" design="Transparent" onClick={() => copyToClipboard(yamlString)}>
+          {t('buttons.copy')}
+        </Button>
+      </FlexBox>
+      <div className={styles.viewer}>
+        <YamlViewer yamlString={yamlString} filename={filename} height="100%" />
+      </div>
+    </FlexBox>
+  );
+};

--- a/src/components/Wizards/CreateManagedControlPlane/CreateManagedControlPlaneWizardContainer.module.css
+++ b/src/components/Wizards/CreateManagedControlPlane/CreateManagedControlPlaneWizardContainer.module.css
@@ -9,9 +9,22 @@
   max-width: 480px;
 }
 
-.infoboxContainer {
-  flex: 1;
-  padding-left: 2rem;
-  padding-top: 0.5rem;
-  max-width: 400px;
+.metadataFormColumn {
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.yamlSplitLayout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  align-items: stretch;
+  height: min(calc(100vh - 16rem), 640px);
+}
+
+@media (max-width: 768px) {
+  .yamlSplitLayout {
+    grid-template-columns: 1fr;
+    height: auto;
+  }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -314,7 +314,11 @@
     "deleteConfirmMessageN": "Are you sure you want to delete the identity provider '{{providerName}}'? Its {{count}} members will also be removed.",
     "deleteConfirmButton": "Delete",
     "disabledBadge": "(disabled)",
-    "yamlPreviewTitle": "YAML preview"
+    "yamlPreviewTitle": "YAML preview",
+    "customIdp": "Custom IdP",
+    "disableDefaultConfirmTitle": "Disable Default Identity Provider",
+    "disableDefaultConfirmMessage": "Disabling the default identity provider will remove all its members. Are you sure?",
+    "disableDefaultConfirmButton": "Disable and remove members"
   },
   "ProjectPage": {
     "backToProjects": "Go to all projects"

--- a/src/spaces/mcp/components/ComponentInstallDialog/ComponentInstallDialog.tsx
+++ b/src/spaces/mcp/components/ComponentInstallDialog/ComponentInstallDialog.tsx
@@ -215,9 +215,6 @@ export function ComponentInstallDialog({
           </Select>
         </div>
         <div className={styles.yamlColumn}>
-          <Title level="H5" className={styles.sectionTitle}>
-            {t('ComponentInstallDialog.yamlPreview')}
-          </Title>
           <div className={styles.yamlViewer}>
             <YamlViewer yamlString={yamlPreview} filename={mcpName} />
           </div>

--- a/src/spaces/mcp/components/CrossplaneInstallDialog/CrossplaneInstallDialog.tsx
+++ b/src/spaces/mcp/components/CrossplaneInstallDialog/CrossplaneInstallDialog.tsx
@@ -272,9 +272,6 @@ export function CrossplaneInstallDialog({
           />
         </div>
         <div className={styles.yamlColumn}>
-          <Title level="H5" className={styles.sectionTitle}>
-            {t('ComponentInstallDialog.yamlPreview')}
-          </Title>
           <div className={styles.yamlViewer}>
             <YamlViewer yamlString={yamlPreview} filename={mcpName} />
           </div>


### PR DESCRIPTION
## Summary

- New `WizardYamlPreview` shared component: copy button + constrained Monaco editor that fills the dialog height
- **Metadata step**: split layout — form on left, live CR YAML on right (updates as name is typed)
- **Service selection step**: YAML shows the full multi-doc output (ControlPlane CR + one CR per selected service)
- **Summarize step**: redesigned left column with card-style rows, service logos, clear section headers — replaces old UI5 List layout; YAML right column shows complete multi-resource output
- **Success step**: icon changed from `activities` → `accept`
- Removes redundant "YAML preview" title label from install dialogs

## Dependencies
> Blocked on: #739 (`feat/yaml-viewer-height-prop`)

## ⚠️ Tests missing
Cypress component tests for the new split layouts and YAML content are not included. They should be added before merging.

## Test plan
- [ ] All 4 wizard steps show YAML on the right
- [ ] YAML updates live as form fields change
- [ ] YAML panel fills dialog height and scrolls internally
- [ ] Service YAML shows separate documents per selected service
- [ ] Summarize shows service logos