### PR TITLE
feat(wizard-idp): collapse disabled IDP, confirm on disable, accent colors

### DIFF
--- a/src/components/Wizards/CreateControlPlaneV2/IdentityProviders/IdentityProviders.module.css
+++ b/src/components/Wizards/CreateControlPlaneV2/IdentityProviders/IdentityProviders.module.css
@@ -19,10 +19,6 @@
   min-width: 0;
 }
 
-.yamlPreviewTitle {
-  font-weight: 600;
-}
-
 .providerGroupPanel {
   /* Recolor the panel's own shadow-DOM background (both header and content
      areas consume these custom properties) instead of the default white/
@@ -33,6 +29,12 @@
   width: 100%;
   margin-bottom: 1.5rem;
   border-radius: 0.5rem;
+}
+
+/* Applied when default provider is disabled — grays out title text only,
+   leaving the checkbox interactive */
+.providerGroupPanelDimmed .providerGroupHeaderTitle {
+  color: var(--sapContent_DisabledTextColor, #8c8c8c);
 }
 
 .providerGroupHeader {

--- a/src/components/Wizards/CreateControlPlaneV2/IdentityProviders/IdentityProvidersStep.tsx
+++ b/src/components/Wizards/CreateControlPlaneV2/IdentityProviders/IdentityProvidersStep.tsx
@@ -1,8 +1,8 @@
-import '@ui5/webcomponents-icons/dist/add';
-import '@ui5/webcomponents-icons/dist/delete';
-import '@ui5/webcomponents-icons/dist/edit';
-import '@ui5/webcomponents-icons/dist/copy';
-import { Button, CheckBox, FlexBox, Link, MessageStrip, Text } from '@ui5/webcomponents-react';
+import '@ui5/webcomponents-icons/dist/add.js';
+import '@ui5/webcomponents-icons/dist/delete.js';
+import '@ui5/webcomponents-icons/dist/edit.js';
+import '@ui5/webcomponents-icons/dist/copy.js';
+import { Button, CheckBox, Dialog, FlexBox, Link, MessageStrip, Text } from '@ui5/webcomponents-react';
 import { FC, useCallback, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { stringify } from 'yaml';
@@ -52,6 +52,7 @@ export const IdentityProvidersStep: FC<IdentityProvidersStepProps> = ({
   const [isProviderDialogOpen, setIsProviderDialogOpen] = useState(false);
   const [providerToEdit, setProviderToEdit] = useState<ExtraProviderMetadata | undefined>(undefined);
   const [providerToDelete, setProviderToDelete] = useState<ExtraProviderMetadata | undefined>(undefined);
+  const [showDisableDefaultConfirm, setShowDisableDefaultConfirm] = useState(false);
 
   const membersByProvider = useMemo(() => {
     const grouped = new Map<string, Member[]>();
@@ -63,7 +64,6 @@ export const IdentityProvidersStep: FC<IdentityProvidersStepProps> = ({
   }, [members]);
 
   const defaultProviderMembers = useMemo(() => membersByProvider.get('') ?? [], [membersByProvider]);
-  const isDefaultCheckboxDisabled = providers.length === 0;
   const hasNoAssignedMembers = useMemo(
     () => !hasAssignedIamMember(members, providers, isDefaultProviderEnabled),
     [members, providers, isDefaultProviderEnabled],
@@ -178,13 +178,21 @@ export const IdentityProvidersStep: FC<IdentityProvidersStepProps> = ({
         <FlexBox direction="Column" gap={16} className={styles.providerGroupsColumn}>
           <ProviderGroup
             headerText={t('IdentityProviders.defaultProviderGroupTitle')}
+            collapsed={!isDefaultProviderEnabled}
+            dimmed={!isDefaultProviderEnabled}
             headerActions={
               <CheckBox
                 checked={isDefaultProviderEnabled}
-                disabled={isDefaultCheckboxDisabled}
                 text={t('IdentityProviders.enableDefaultProviderCheckbox')}
                 data-testid="default-provider-enabled-checkbox"
-                onChange={(e) => onDefaultProviderEnabledChange(e.target.checked)}
+                onChange={(e) => {
+                  const enabling = e.target.checked;
+                  if (!enabling && defaultProviderMembers.length > 0) {
+                    setShowDisableDefaultConfirm(true);
+                  } else {
+                    onDefaultProviderEnabledChange(enabling);
+                  }
+                }}
               />
             }
           >
@@ -202,16 +210,7 @@ export const IdentityProvidersStep: FC<IdentityProvidersStepProps> = ({
                 onMemberChanged={handleDefaultMembersChange}
               />
             ) : (
-              <Text className={styles.hiddenProviderHint}>
-                {t(
-                  defaultProviderMembers.length > 0
-                    ? 'IdentityProviders.defaultProviderDisabledWithMembersHint'
-                    : 'IdentityProviders.defaultProviderDisabledHint',
-                )}
-              </Text>
-            )}
-            {isDefaultCheckboxDisabled && (
-              <Text className={styles.hiddenProviderHint}>{t('IdentityProviders.defaultProviderLockedHint')}</Text>
+              <Text className={styles.hiddenProviderHint}>{t('IdentityProviders.defaultProviderDisabledHint')}</Text>
             )}
           </ProviderGroup>
 
@@ -219,6 +218,7 @@ export const IdentityProvidersStep: FC<IdentityProvidersStepProps> = ({
             <ProviderGroup
               key={provider.name}
               headerText={provider.name}
+              accentName={provider.name}
               headerActions={
                 <>
                   <Button
@@ -271,7 +271,6 @@ export const IdentityProvidersStep: FC<IdentityProvidersStepProps> = ({
 
         <FlexBox direction="Column" gap={16} className={styles.yaml}>
           <FlexBox direction="Row" justifyContent="SpaceBetween" alignItems="Center">
-            <Text className={styles.yamlPreviewTitle}>{t('IdentityProviders.yamlPreviewTitle')}</Text>
             <Button icon="copy" design="Transparent" onClick={() => copyToClipboard(oidcYaml)}>
               {t('buttons.copy')}
             </Button>
@@ -296,6 +295,29 @@ export const IdentityProvidersStep: FC<IdentityProvidersStepProps> = ({
         onCancel={handleCancelDelete}
         onConfirm={handleConfirmDelete}
       />
+      <Dialog
+        open={showDisableDefaultConfirm}
+        headerText={t('IdentityProviders.disableDefaultConfirmTitle')}
+        footer={
+          <FlexBox justifyContent="End" gap={8} style={{ padding: '0.5rem' }}>
+            <Button design="Transparent" onClick={() => setShowDisableDefaultConfirm(false)}>
+              {t('common.cancel')}
+            </Button>
+            <Button
+              design="Emphasized"
+              onClick={() => {
+                onMembersChange(members.filter((m) => !!m.provider));
+                onDefaultProviderEnabledChange(false);
+                setShowDisableDefaultConfirm(false);
+              }}
+            >
+              {t('IdentityProviders.disableDefaultConfirmButton')}
+            </Button>
+          </FlexBox>
+        }
+      >
+        <Text style={{ padding: '1rem' }}>{t('IdentityProviders.disableDefaultConfirmMessage')}</Text>
+      </Dialog>
     </>
   );
 };

--- a/src/components/Wizards/CreateControlPlaneV2/IdentityProviders/ProviderGroup.tsx
+++ b/src/components/Wizards/CreateControlPlaneV2/IdentityProviders/ProviderGroup.tsx
@@ -1,18 +1,52 @@
 import { FlexBox, Panel, Title } from '@ui5/webcomponents-react';
-import { FC, ReactNode } from 'react';
+import { FC, ReactNode, useMemo } from 'react';
 import styles from './IdentityProviders.module.css';
+
+function hashString(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash * 31 + str.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}
+
+function accentColorForName(name: string): string {
+  const index = (hashString(name.toLowerCase()) % 10) + 1;
+  return `var(--sapAvatar_${index}_Background)`;
+}
 
 export interface ProviderGroupProps {
   headerText: string;
   headerActions?: ReactNode;
   children: ReactNode;
+  collapsed?: boolean;
+  dimmed?: boolean;
+  accentName?: string;
 }
 
-export const ProviderGroup: FC<ProviderGroupProps> = ({ headerText, headerActions, children }) => {
+export const ProviderGroup: FC<ProviderGroupProps> = ({
+  headerText,
+  headerActions,
+  children,
+  collapsed = false,
+  dimmed = false,
+  accentName,
+}) => {
+  const accentColor = useMemo(() => (accentName ? accentColorForName(accentName) : undefined), [accentName]);
+
   return (
     <Panel
-      className={styles.providerGroupPanel}
-      collapsed={false}
+      className={`${styles.providerGroupPanel}${dimmed ? ` ${styles.providerGroupPanelDimmed}` : ''}`}
+      collapsed={collapsed}
+      fixed={collapsed}
+      style={
+        accentColor
+          ? ({
+              '--sapGroup_ContentBackground': `color-mix(in srgb, ${accentColor} 12%, var(--sapBackgroundColor, #fafafa))`,
+              '--sapGroup_TitleBackground': `color-mix(in srgb, ${accentColor} 12%, var(--sapBackgroundColor, #fafafa))`,
+            } as React.CSSProperties)
+          : undefined
+      }
       header={
         <FlexBox alignItems="Center" justifyContent="SpaceBetween" className={styles.providerGroupHeader}>
           <Title level="H5" className={styles.providerGroupHeaderTitle}>


### PR DESCRIPTION
## Summary

**Default provider UX**
- Always-enabled checkbox (previously locked when no custom providers existed)
- When disabled: panel collapses and grays out, but checkbox remains clickable
- Disabling with existing members shows confirmation: *"Disabling removes all members — are you sure?"*

**Custom IdP colors**
- Each custom IdP gets a deterministic pastel background color derived from its name, using UI5 avatar accent color variables at 12% opacity (`color-mix`)
- Matching the avatar color pattern already used elsewhere in the app

**ProviderGroup component**
- New `collapsed`, `fixed`, `dimmed`, `accentName` props
- `fixed={collapsed}` prevents users from expanding a disabled panel

## Dependencies
> Blocked on: #740 → #739

## ⚠️ Tests missing
Cypress tests for: disable confirmation dialog, checkbox always enabled, panel collapse/expand behavior, and accent color rendering are not included. They should be added before merging.

## Test plan
- [ ] Default provider collapses when unchecked
- [ ] Unchecking with members shows confirmation dialog; cancelling keeps members
- [ ] Confirming clears members and disables
- [ ] Custom IDPs show unique pastel background colors
- [ ] Colors are consistent across page reloads (deterministic)