### PR TITLE
docs: fix create controlplane link

### DIFF
--- a/src/lib/shared/useLink.ts
+++ b/src/lib/shared/useLink.ts
@@ -11,7 +11,7 @@ export function useLink() {
     gettingStartedGuide: createLink('/docs/managed-control-planes/get-started/get-started-mcp'),
     workspaceCreationGuide: createLink('/docs/managed-control-planes/get-started/get-started-mcp#4-create-workspace'),
     mcpCreationGuide: createLink(
-      '/docs/managed-control-planes/get-started/get-started-mcp#5-create-managedcontrolplane',
+      '/docs/managed-control-planes/get-started/onboard/get-started-mcp',
     ),
     serviceAccoutsGuide: createLink(
       '/docs/managed-control-planes/access/service-accounts#create-and-list-serviceaccounts',

--- a/src/lib/shared/useLink.ts
+++ b/src/lib/shared/useLink.ts
@@ -10,9 +10,7 @@ export function useLink() {
     documentationHomepage: createLink('/'),
     gettingStartedGuide: createLink('/docs/managed-control-planes/get-started/get-started-mcp'),
     workspaceCreationGuide: createLink('/docs/managed-control-planes/get-started/get-started-mcp#4-create-workspace'),
-    mcpCreationGuide: createLink(
-      '/docs/managed-control-planes/get-started/onboard/get-started-mcp',
-    ),
+    mcpCreationGuide: createLink('/docs/managed-control-planes/get-started/onboard/get-started-mcp'),
     serviceAccoutsGuide: createLink(
       '/docs/managed-control-planes/access/service-accounts#create-and-list-serviceaccounts',
     ),


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix URL path to allow user to learn more about control plane creation
