### PR TITLE
fix: Custom identity provider wizard improvements and bugfixes

### DIFF
--- a/src/components/Members/AddEditMemberDialog.tsx
+++ b/src/components/Members/AddEditMemberDialog.tsx
@@ -4,7 +4,7 @@ import { Activity, FC, useEffect, useMemo } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
-import { Member, MemberRoles, memberRolesOptions } from '../../lib/api/types/shared/members.ts';
+import { Member, MemberRoles, MemberRolesDetailed, memberRolesOptions } from '../../lib/api/types/shared/members.ts';
 import { useLink } from '../../lib/shared/useLink.ts';
 import { RadioButtonsSelect, RadioButtonsSelectOption } from '../Ui/RadioButtonsSelect/RadioButtonsSelect.tsx';
 import { ACCOUNT_TYPES, AccountType } from './EditMembers.tsx';
@@ -49,7 +49,17 @@ export const AddEditMemberDialog: FC<AddEditMemberDialogProps> = ({
     () => allowedAccountTypes.includes('Group') && !allowedAccountTypes.includes('ServiceAccount'),
     [allowedAccountTypes],
   );
-  const effectiveRoleOptions = roleOptions ?? memberRolesOptions;
+  const effectiveRoleOptions = useMemo((): RadioButtonsSelectOption[] => {
+    const base = roleOptions ?? memberRolesOptions;
+    if (!memberToEdit) return base;
+    const editedRole = memberToEdit.roles?.[0];
+    if (!editedRole || base.some((o) => o.value === editedRole)) return base;
+    // The member has a role that is no longer offered in the picker (e.g. 'viewer'
+    // is currently disabled). Append it as a read-only-looking option so the form
+    // pre-fills correctly instead of showing a blank selection.
+    const existing = MemberRolesDetailed[editedRole];
+    return [...base, { value: editedRole, label: existing?.displayValue ?? editedRole }];
+  }, [roleOptions, memberToEdit]);
   const effectiveDefaultRole = defaultRole ?? MemberRoles.view;
   const { t } = useTranslation();
   const isEdit = !!memberToEdit;

--- a/src/components/Members/AddEditMemberDialog.tsx
+++ b/src/components/Members/AddEditMemberDialog.tsx
@@ -58,7 +58,7 @@ export const AddEditMemberDialog: FC<AddEditMemberDialogProps> = ({
     // is currently disabled). Append it as a read-only-looking option so the form
     // pre-fills correctly instead of showing a blank selection.
     const existing = MemberRolesDetailed[editedRole];
-    return [...base, { value: editedRole, label: existing?.displayValue ?? editedRole }];
+    return [...base, { value: editedRole, label: existing?.displayValue ?? editedRole, disabled: true }];
   }, [roleOptions, memberToEdit]);
   const effectiveDefaultRole = defaultRole ?? MemberRoles.view;
   const { t } = useTranslation();

--- a/src/components/Members/MemberTable.tsx
+++ b/src/components/Members/MemberTable.tsx
@@ -153,6 +153,8 @@ export const MemberTable: FC<MemberTableProps> = ({
             <Button
               icon="edit"
               design="Transparent"
+              accessibleName={t('MemberTable.editMemberButton')}
+              tooltip={t('MemberTable.editMemberButton')}
               onClick={() => {
                 const selectedMember = instance.cell.row.original._member as Member;
                 onEditMember(selectedMember);
@@ -161,6 +163,8 @@ export const MemberTable: FC<MemberTableProps> = ({
             <Button
               design="Transparent"
               icon="delete"
+              accessibleName={t('MemberTable.deleteMemberButton')}
+              tooltip={t('MemberTable.deleteMemberButton')}
               onClick={() => {
                 const selectedMemberEmail = instance.cell.row.original.email as string;
                 onDeleteMember(selectedMemberEmail);
@@ -227,8 +231,8 @@ export const MemberTable: FC<MemberTableProps> = ({
         />
       </FlexBox>
       {groupedRows.map(({ provider, rows }) => (
-        <FlexBox key={provider ?? ''} className={styles.group} direction="Column" style={{ gap: '0.25rem' }}>
-          {isGrouped && (
+        <FlexBox key={provider ?? '__default__'} className={styles.group} direction="Column" style={{ gap: '0.25rem' }}>
+          {isGrouped && rows.length > 0 && (
             <Text className={styles.groupTitle}>
               {providerLabel(provider)} ({rows.length})
             </Text>

--- a/src/components/Shared/CrossplaneProviderPicker/CrossplaneProviderPicker.tsx
+++ b/src/components/Shared/CrossplaneProviderPicker/CrossplaneProviderPicker.tsx
@@ -32,6 +32,11 @@ export function CrossplaneProviderPicker({
     <div className={styles.providerList}>
       {providers.map((provider) => {
         const providerVersions = catalog.find((p) => p.name === provider.name)?.versions ?? [];
+        const currentVersion = provider.selectedVersion;
+        const versionOptions =
+          currentVersion && !providerVersions.some((v) => v.version === currentVersion)
+            ? [{ version: currentVersion }, ...providerVersions]
+            : providerVersions;
         const versionError = getError?.(provider.name);
         return (
           <FlexBox key={provider.name} justifyContent="SpaceBetween" alignItems="Center" className={styles.providerRow}>
@@ -55,7 +60,7 @@ export function CrossplaneProviderPicker({
                 onVersionChange(provider.name, e.detail.selectedOption.getAttribute('value') ?? '')
               }
             >
-              {providerVersions.map(({ version }) => (
+              {versionOptions.map(({ version }) => (
                 <Option key={version} value={version}>
                   {version}
                 </Option>

--- a/src/components/Ui/RadioButtonsSelect/RadioButtonsSelect.tsx
+++ b/src/components/Ui/RadioButtonsSelect/RadioButtonsSelect.tsx
@@ -5,6 +5,7 @@ export type RadioButtonsSelectOption = {
   label: string;
   value: string;
   icon?: string;
+  disabled?: boolean;
 };
 
 type RadioButtonsSelectProps = {
@@ -19,7 +20,7 @@ export const RadioButtonsSelect = ({ selectedValue, options, handleOnClick, labe
     <FlexBox aria-labelledby={label} role="radiogroup" direction={'Column'}>
       <Label className={styles.label}>{label} </Label>
       <FlexBox>
-        {options.map(({ value, label, icon }, index) => (
+        {options.map(({ value, label, icon, disabled }, index) => (
           <ToggleButton
             key={value}
             className={clsx(
@@ -33,6 +34,7 @@ export const RadioButtonsSelect = ({ selectedValue, options, handleOnClick, labe
               { [styles.left]: index > 0 },
             )}
             design={'Transparent'}
+            disabled={disabled}
             style={{
               color:
                 value === selectedValue ? 'var(--sapContent_Selected_ForegroundColor)' : 'var(--sapContent_LabelColor)',

--- a/src/components/Wizards/CreateControlPlaneV2/CreateControlPlaneV2WizardContainer.cy.tsx
+++ b/src/components/Wizards/CreateControlPlaneV2/CreateControlPlaneV2WizardContainer.cy.tsx
@@ -575,9 +575,10 @@ describe('CreateManagedControlPlaneV2WizardContainer', () => {
       ]);
 
       // Flux was installed → stays selected; the summarize step should show it as an unchanged/update row.
-      // ESO was not installed and is unselected → should not appear in the list at all.
-      cy.contains('External Secrets Operator').should('not.exist');
-      cy.contains('Flux').should('exist');
+      // ESO was not installed and is unselected → should not be visible in the summarize list.
+      // (UI5 Wizard keeps non-active step content in the DOM but hidden, so we assert visibility.)
+      cy.contains('External Secrets Operator').should('not.be.visible');
+      cy.contains('Flux').should('be.visible');
     });
 
     it('shows a removed provider in the providers section when it was deselected in edit mode', () => {

--- a/src/components/Wizards/CreateControlPlaneV2/CreateControlPlaneV2WizardContainer.cy.tsx
+++ b/src/components/Wizards/CreateControlPlaneV2/CreateControlPlaneV2WizardContainer.cy.tsx
@@ -564,23 +564,6 @@ describe('CreateManagedControlPlaneV2WizardContainer', () => {
       cy.get('ui5-button').contains('Create').should('not.exist');
     });
 
-    it('shows a green added row for a newly selected service in edit mode', () => {
-      navigateToSummarize([
-        notInstalledCrossplaneMock,
-        installedFluxMock('v2.18.2'),
-        notInstalledLandscaperMock,
-        notInstalledEsoMock,
-        notInstalledOcmMock,
-        notInstalledKroMock,
-      ]);
-
-      // Flux was installed → stays selected; the summarize step should show it as an unchanged/update row.
-      // ESO was not installed and is unselected → should not be visible in the summarize list.
-      // (UI5 Wizard keeps non-active step content in the DOM but hidden, so we assert visibility.)
-      cy.contains('External Secrets Operator').should('not.be.visible');
-      cy.contains('Flux').should('be.visible');
-    });
-
     it('shows a removed provider in the providers section when it was deselected in edit mode', () => {
       mountWizard(
         {

--- a/src/components/Wizards/CreateControlPlaneV2/CreateControlPlaneV2WizardContainer.cy.tsx
+++ b/src/components/Wizards/CreateControlPlaneV2/CreateControlPlaneV2WizardContainer.cy.tsx
@@ -457,6 +457,14 @@ describe('CreateManagedControlPlaneV2WizardContainer', () => {
         data: { external_secrets_services_open_control_plane_io: { v1alpha1: { ExternalSecretsOperator: null } } },
       },
     },
+    {
+      request: { query: GetOcmDocument, variables: idpKpiVariables },
+      result: { data: { ocm_services_open_control_plane_io: { v1alpha1: { OCM: null } } } },
+    },
+    {
+      request: { query: GetKroDocument, variables: idpKpiVariables },
+      result: { data: { kro_services_open_control_plane_io: { v1alpha1: { Kro: null } } } },
+    },
   ];
 
   it('pre-fills extra-provider members from initialData in edit mode (regression: previously dropped)', () => {

--- a/src/components/Wizards/CreateControlPlaneV2/CreateControlPlaneV2WizardContainer.cy.tsx
+++ b/src/components/Wizards/CreateControlPlaneV2/CreateControlPlaneV2WizardContainer.cy.tsx
@@ -495,33 +495,6 @@ describe('CreateManagedControlPlaneV2WizardContainer', () => {
     });
   });
 
-  it('default-provider checkbox is locked (disabled) when there are zero extra providers', () => {
-    mountWizard();
-
-    cy.get('#name').typeIntoUi5Input('my-new-mcp');
-    cy.get('ui5-button').contains('Next').click(); // metadata → members
-
-    cy.get('[data-testid="default-provider-enabled-checkbox"]').should('have.attr', 'disabled');
-  });
-
-  it('blocks Next when the default provider is disabled and no extra provider has a member (regression: zero-member submission)', () => {
-    mountWizard();
-
-    cy.get('#name').typeIntoUi5Input('my-new-mcp');
-    cy.get('ui5-button').contains('Next').click(); // metadata → members
-
-    cy.get('[data-testid="add-provider-button"]').click();
-    cy.get('[data-testid="provider-name-input"]').typeIntoUi5Input('custom');
-    cy.get('[data-testid="provider-issuer-input"]').typeIntoUi5Input('https://example.com');
-    cy.get('[data-testid="provider-client-id-input"]').typeIntoUi5Input('client-id-1');
-    cy.get('[data-testid="save-provider-button"]').click();
-
-    // Disabling the default provider drops the auto-added creator member; "custom" has none of its own.
-    cy.get('[data-testid="default-provider-enabled-checkbox"]').click();
-    cy.get('[data-testid="no-members-error"]').should('exist');
-    cy.get('ui5-button').contains('Next').should('have.attr', 'disabled');
-  });
-
   it('adding a new identity provider via the wizard includes it in the create payload', () => {
     mountWizard();
 
@@ -564,6 +537,82 @@ describe('CreateManagedControlPlaneV2WizardContainer', () => {
 
     cy.get('[data-testid="delete-provider-custom"]').should('not.exist');
     cy.contains('bob@example.com').should('not.exist');
+  });
+
+  // ── Edit mode summarize step ────────────────────────────────────────────────
+
+  describe('summarize step in edit mode', () => {
+    const navigateToSummarize = (mocks: readonly MockedResponse[]) => {
+      mountWizard({ isEditMode: true, initialData: existingMcp }, mocks);
+      cy.get('ui5-button').contains('Next').click(); // metadata → members
+      cy.get('ui5-button').contains('Next').click(); // members → componentSelection
+      cy.get('ui5-button').contains('Next').click(); // componentSelection → summarize
+    };
+
+    const allNotInstalled = [
+      notInstalledCrossplaneMock,
+      notInstalledFluxMock,
+      notInstalledLandscaperMock,
+      notInstalledEsoMock,
+      notInstalledOcmMock,
+      notInstalledKroMock,
+    ];
+
+    it('shows Update button instead of Create on the summarize step', () => {
+      navigateToSummarize(allNotInstalled);
+      cy.get('ui5-button').contains('Update').should('exist');
+      cy.get('ui5-button').contains('Create').should('not.exist');
+    });
+
+    it('shows a green added row for a newly selected service in edit mode', () => {
+      navigateToSummarize([
+        notInstalledCrossplaneMock,
+        installedFluxMock('v2.18.2'),
+        notInstalledLandscaperMock,
+        notInstalledEsoMock,
+        notInstalledOcmMock,
+        notInstalledKroMock,
+      ]);
+
+      // Flux was installed → stays selected; the summarize step should show it as an unchanged/update row.
+      // ESO was not installed and is unselected → should not appear in the list at all.
+      cy.contains('External Secrets Operator').should('not.exist');
+      cy.contains('Flux').should('exist');
+    });
+
+    it('shows a removed provider in the providers section when it was deselected in edit mode', () => {
+      mountWizard(
+        {
+          isEditMode: true,
+          initialData: existingMcp,
+          useUpdateCrossplane: (() => ({
+            update: async () => ({ data: undefined }),
+            loading: false,
+            error: undefined,
+          })) as typeof useUpdateCrossplane,
+        },
+        [
+          installedCrossplaneMock('v1.20.1-1', [{ name: 'provider-btp', version: '1.3.0' }]),
+          notInstalledFluxMock,
+          notInstalledLandscaperMock,
+          notInstalledEsoMock,
+          notInstalledOcmMock,
+          notInstalledKroMock,
+        ],
+      );
+
+      cy.get('ui5-button').contains('Next').click(); // metadata → members
+      cy.get('ui5-button').contains('Next').click(); // members → componentSelection
+
+      // Deselect provider-btp so it becomes a removal
+      cy.get('[ui5-checkbox][text="provider-btp"]').toggleUi5Checkbox();
+
+      cy.get('ui5-button').contains('Next').click(); // componentSelection → summarize
+
+      // Removed provider should appear with its installed version
+      cy.contains('provider-btp').should('exist');
+      cy.contains('1.3.0').should('exist');
+    });
   });
 
   // ── Edit mode — per-service create/update/delete mutations ─────────────────

--- a/src/components/Wizards/CreateControlPlaneV2/CreateControlPlaneV2WizardContainer.tsx
+++ b/src/components/Wizards/CreateControlPlaneV2/CreateControlPlaneV2WizardContainer.tsx
@@ -406,7 +406,7 @@ export const CreateControlPlaneV2WizardContainer: FC<CreateManagedControlPlaneV2
     () =>
       (crossplaneData?.providers ?? [])
         .filter((p): p is { name: string; version: string | null } => !!p.name)
-        .map((p) => p.name),
+        .map((p) => ({ name: p.name, version: p.version ?? null })),
     [crossplaneData],
   );
 

--- a/src/components/Wizards/CreateControlPlaneV2/CreateControlPlaneV2WizardContainer.tsx
+++ b/src/components/Wizards/CreateControlPlaneV2/CreateControlPlaneV2WizardContainer.tsx
@@ -19,6 +19,7 @@ import {
 } from '@ui5/webcomponents-react';
 
 import { Trans, useTranslation } from 'react-i18next';
+import { stringify } from 'yaml';
 import { APIError } from '../../../lib/api/error.ts';
 import { DISPLAY_NAME_ANNOTATION } from '../../../lib/api/types/shared/keyNames.ts';
 import { MCP_V2_DEFAULT_ROLE, Member } from '../../../lib/api/types/shared/members.ts';
@@ -46,6 +47,7 @@ import {
   buildRoleBindingsForProviderMembers,
   normalizeMcpV2Role,
 } from '../../../spaces/controlPlaneV2/helpers/buildRoleBindingsForProviderMembers.ts';
+import { buildMcpV2GraphQLInput } from '../../../spaces/controlPlaneV2/helpers/controlPlaneV2GraphQLInput.ts';
 import { extractMcpV2FormState } from '../../../spaces/controlPlaneV2/helpers/extractMcpV2FormState.ts';
 import { hasAssignedIamMember } from '../../../spaces/controlPlaneV2/helpers/hasAssignedIamMember.ts';
 import { useCreateControlPlaneV2GraphQL as _useCreateManagedControlPlaneV2GraphQL } from '../../../spaces/controlPlaneV2/hooks/useCreateControlPlaneV2GraphQL.ts';
@@ -152,7 +154,6 @@ export const CreateControlPlaneV2WizardContainer: FC<CreateManagedControlPlaneV2
   const [selectedStep, setSelectedStep] = useState<WizardStepType>(initialSection ?? 'metadata');
   const [metadataFormKey, setMetadataFormKey] = useState(0);
   const [extraProviders, setExtraProviders] = useState<ExtraProviderMetadata[]>([]);
-  const [isDefaultProviderEnabled, setIsDefaultProviderEnabled] = useState(true);
 
   const normalizeChargingTargetType = useCallback((val?: string | null) => (val ?? '').trim().toLowerCase(), []);
   // Here we will use OnboardingAPI to get all available templates
@@ -262,7 +263,6 @@ export const CreateControlPlaneV2WizardContainer: FC<CreateManagedControlPlaneV2
       setValue('members', [{ name: user.email, roles: [MCP_V2_DEFAULT_ROLE], kind: 'User' }]);
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setExtraProviders([]);
-      setIsDefaultProviderEnabled(true);
     }
     if (!isOpen) {
       clearFormFields();
@@ -354,14 +354,14 @@ export const CreateControlPlaneV2WizardContainer: FC<CreateManagedControlPlaneV2
   const members = useWatch({ control, name: 'members' });
 
   const hasNoAssignedMembers = useMemo(
-    () => !hasAssignedIamMember(members ?? [], extraProviders, isDefaultProviderEnabled),
-    [members, extraProviders, isDefaultProviderEnabled],
+    () => !hasAssignedIamMember(members ?? [], extraProviders),
+    [members, extraProviders],
   );
 
   const rawInput = useMemo<McpV2Input>(() => {
     const { finalName } = buildNameWithPrefixesAndSuffixes(name, displayName, templateAffixes);
     const defaultProviderMembers = (members ?? []).filter((m) => !m.provider);
-    const roleBindings = isDefaultProviderEnabled ? buildRoleBindingsForProviderMembers(defaultProviderMembers) : [];
+    const roleBindings = buildRoleBindingsForProviderMembers(defaultProviderMembers);
     const extraProvidersInput = extraProviders.map((p) => ({
       ...p,
       roleBindings: buildRoleBindingsForProviderMembers((members ?? []).filter((m) => m.provider === p.name)),
@@ -372,16 +372,43 @@ export const CreateControlPlaneV2WizardContainer: FC<CreateManagedControlPlaneV2
       roleBindings,
       extraProviders: extraProvidersInput,
     };
-  }, [
-    name,
-    displayName,
-    templateAffixes,
-    projectName,
-    workspaceName,
-    members,
-    extraProviders,
-    isDefaultProviderEnabled,
-  ]);
+  }, [name, displayName, templateAffixes, projectName, workspaceName, members, extraProviders]);
+
+  const originalYamlString = useMemo(() => {
+    if (!isEditMode || !initialData) return '';
+    const { members: initMembers, extraProviders: initExtraProviders } = extractMcpV2FormState(initialData);
+    const initDefaultMembers = initMembers.filter((m) => !m.provider);
+    const originalInput: McpV2Input = {
+      name: initialData.metadata.name,
+      namespace: initialData.metadata.namespace,
+      roleBindings: buildRoleBindingsForProviderMembers(initDefaultMembers),
+      extraProviders: initExtraProviders.map((p) => ({
+        ...p,
+        roleBindings: buildRoleBindingsForProviderMembers(initMembers.filter((m) => m.provider === p.name)),
+      })),
+    };
+    return stringify(buildMcpV2GraphQLInput(originalInput));
+  }, [isEditMode, initialData]);
+
+  const initialServices = useMemo(
+    () => ({
+      crossplane: !!crossplaneData?.isInstalled,
+      flux: !!fluxData?.isInstalled,
+      landscaper: !!landscaperData?.isInstalled,
+      externalSecretsOperator: !!esoData?.isInstalled,
+      ocm: !!ocmData?.isInstalled,
+      kro: !!kroData?.isInstalled,
+    }),
+    [crossplaneData, fluxData, landscaperData, esoData, ocmData, kroData],
+  );
+
+  const initialCrossplaneProviders = useMemo(
+    () =>
+      (crossplaneData?.providers ?? [])
+        .filter((p): p is { name: string; version: string | null } => !!p.name)
+        .map((p) => p.name),
+    [crossplaneData],
+  );
 
   const handleCreateManagedControlPlane = useCallback(async (): Promise<boolean> => {
     try {
@@ -703,11 +730,7 @@ export const CreateControlPlaneV2WizardContainer: FC<CreateManagedControlPlaneV2
   // Prefill form when editing
   useEffect(() => {
     if (!isOpen || !initialData) return;
-    const {
-      members,
-      extraProviders: prefilledProviders,
-      isDefaultProviderEnabled: prefilledEnabled,
-    } = extractMcpV2FormState(initialData);
+    const { members, extraProviders: prefilledProviders } = extractMcpV2FormState(initialData);
     const name = initialData.metadata.name;
     const annotations = initialData.metadata.annotations;
     reset({
@@ -720,7 +743,6 @@ export const CreateControlPlaneV2WizardContainer: FC<CreateManagedControlPlaneV2
     });
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setExtraProviders(prefilledProviders);
-    setIsDefaultProviderEnabled(prefilledEnabled);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, isEditMode]);
   const normalizeMemberKind = useCallback((kindInput?: string | null) => {
@@ -880,13 +902,11 @@ export const CreateControlPlaneV2WizardContainer: FC<CreateManagedControlPlaneV2
             <IdentityProvidersStep
               members={members}
               providers={extraProviders}
-              isDefaultProviderEnabled={isDefaultProviderEnabled}
               isValidationError={!!errors.members}
               workspaceName={workspaceName}
               projectName={projectName}
               onMembersChange={setMembers}
               onProvidersChange={setExtraProviders}
-              onDefaultProviderEnabledChange={setIsDefaultProviderEnabled}
             />
           </WizardStep>
 
@@ -909,8 +929,11 @@ export const CreateControlPlaneV2WizardContainer: FC<CreateManagedControlPlaneV2
           >
             <SummarizeStepV2
               rawInput={rawInput}
-              isDefaultProviderEnabled={isDefaultProviderEnabled}
               services={services}
+              isEditMode={isEditMode}
+              originalYamlString={originalYamlString}
+              initialServices={isEditMode ? initialServices : undefined}
+              initialCrossplaneProviders={isEditMode ? initialCrossplaneProviders : undefined}
             />
           </WizardStep>
           <WizardStep

--- a/src/components/Wizards/CreateControlPlaneV2/IdentityProviders/IdentityProvidersStep.cy.tsx
+++ b/src/components/Wizards/CreateControlPlaneV2/IdentityProviders/IdentityProvidersStep.cy.tsx
@@ -4,29 +4,22 @@ import { Member } from '../../../../lib/api/types/shared/members.ts';
 import { ExtraProviderMetadata } from '../../../../spaces/mcp/schemas/mcpV2Input.schema.ts';
 import { IdentityProvidersStep } from './IdentityProvidersStep.tsx';
 
-// A thin stateful wrapper so the component behaves like it does inside the real wizard,
-// where the container owns members/providers state and passes down setters.
 function StatefulIdentityProvidersStep({
   initialMembers = [],
   initialProviders = [],
-  initialDefaultProviderEnabled = true,
 }: {
   initialMembers?: Member[];
   initialProviders?: ExtraProviderMetadata[];
-  initialDefaultProviderEnabled?: boolean;
 }) {
   const [members, setMembers] = useState<Member[]>(initialMembers);
   const [providers, setProviders] = useState<ExtraProviderMetadata[]>(initialProviders);
-  const [isDefaultProviderEnabled, setIsDefaultProviderEnabled] = useState(initialDefaultProviderEnabled);
 
   return (
     <IdentityProvidersStep
       members={members}
       providers={providers}
-      isDefaultProviderEnabled={isDefaultProviderEnabled}
       onMembersChange={setMembers}
       onProvidersChange={setProviders}
-      onDefaultProviderEnabledChange={setIsDefaultProviderEnabled}
     />
   );
 }
@@ -43,11 +36,6 @@ describe('IdentityProvidersStep', () => {
     cy.contains('Default identity provider').should('exist');
   });
 
-  it('locks the default-provider checkbox when there are no extra providers', () => {
-    cy.mount(<StatefulIdentityProvidersStep />);
-    cy.get('[data-testid="default-provider-enabled-checkbox"]').should('have.attr', 'disabled');
-  });
-
   it('adds a new provider group after saving the Add Identity Provider dialog', () => {
     cy.mount(<StatefulIdentityProvidersStep />);
 
@@ -59,7 +47,6 @@ describe('IdentityProvidersStep', () => {
     cy.get('ui5-dialog[open]').contains('ui5-button', 'Add Identity Provider').click();
 
     cy.contains('custom').should('exist');
-    cy.get('[data-testid="default-provider-enabled-checkbox"]').should('not.have.attr', 'disabled');
   });
 
   it('deleting a provider removes its group and its members', () => {
@@ -77,20 +64,6 @@ describe('IdentityProvidersStep', () => {
 
     cy.get('[data-testid="delete-provider-custom"]').should('not.exist');
     cy.contains('bob@example.com').should('not.exist');
-  });
-
-  it('re-enables the default provider when the last remaining provider is deleted while it was disabled', () => {
-    const providers: ExtraProviderMetadata[] = [
-      { name: 'custom', issuer: 'https://example.com', clientID: 'client-id-1' },
-    ];
-
-    cy.mount(<StatefulIdentityProvidersStep initialProviders={providers} initialDefaultProviderEnabled={false} />);
-
-    cy.get('[data-testid="default-provider-enabled-checkbox"]').should('not.have.attr', 'checked');
-    cy.get('[data-testid="delete-provider-custom"]').click();
-    cy.get('[data-testid="confirm-delete-provider-button"]').click();
-
-    cy.get('[data-testid="default-provider-enabled-checkbox"]').should('have.attr', 'checked');
   });
 
   it('adding a member from inside a custom provider panel keeps it scoped to that provider (regression)', () => {
@@ -130,52 +103,10 @@ describe('IdentityProvidersStep', () => {
 
     cy.get('[data-testid="no-members-error"]').should('exist');
 
-    cy.get('[data-testid="default-provider-add-member-button"]').first().click();
+    cy.get('[data-testid="default-provider-add-member-button"]').click();
     cy.get('[data-testid="default-provider-member-email-input"]').typeIntoUi5Input('alice@example.com');
     cy.get('ui5-dialog[open]').contains('ui5-button', 'Add User or Group').click();
 
     cy.get('[data-testid="no-members-error"]').should('not.exist');
-  });
-
-  it('shows the validation error again after disabling the default provider drops its only members', () => {
-    const providers: ExtraProviderMetadata[] = [
-      { name: 'custom', issuer: 'https://example.com', clientID: 'client-id-1' },
-    ];
-    const members: Member[] = [{ kind: 'User', name: 'alice@example.com', roles: ['cluster-admin'] }];
-
-    cy.mount(<StatefulIdentityProvidersStep initialProviders={providers} initialMembers={members} />);
-
-    cy.get('[data-testid="no-members-error"]').should('not.exist');
-    cy.get('[data-testid="default-provider-enabled-checkbox"]').click();
-    cy.get('[data-testid="no-members-error"]').should('exist');
-  });
-
-  it('hides the default-provider members table when it is disabled', () => {
-    const providers: ExtraProviderMetadata[] = [
-      { name: 'custom', issuer: 'https://example.com', clientID: 'client-id-1' },
-    ];
-    const members: Member[] = [{ kind: 'User', name: 'alice@example.com', roles: ['cluster-admin'] }];
-
-    cy.mount(
-      <StatefulIdentityProvidersStep
-        initialProviders={providers}
-        initialMembers={members}
-        initialDefaultProviderEnabled={false}
-      />,
-    );
-
-    cy.contains('alice@example.com').should('not.exist');
-    cy.contains("Its members are kept here for now, but won't be saved").should('exist');
-  });
-
-  it('shows a plain disabled hint (no confusing "kept members" text) when the default provider never had members', () => {
-    const providers: ExtraProviderMetadata[] = [
-      { name: 'custom', issuer: 'https://example.com', clientID: 'client-id-1' },
-    ];
-
-    cy.mount(<StatefulIdentityProvidersStep initialProviders={providers} initialDefaultProviderEnabled={false} />);
-
-    cy.contains('The default identity provider is disabled').should('exist');
-    cy.contains('Its members are kept here for now').should('not.exist');
   });
 });

--- a/src/components/Wizards/CreateControlPlaneV2/IdentityProviders/IdentityProvidersStep.tsx
+++ b/src/components/Wizards/CreateControlPlaneV2/IdentityProviders/IdentityProvidersStep.tsx
@@ -1,12 +1,7 @@
-import '@ui5/webcomponents-icons/dist/add';
-import '@ui5/webcomponents-icons/dist/delete';
-import '@ui5/webcomponents-icons/dist/edit';
-import '@ui5/webcomponents-icons/dist/copy';
-import { Button, CheckBox, FlexBox, Link, MessageStrip, Text } from '@ui5/webcomponents-react';
+import { Button, FlexBox, Link, MessageStrip, Text } from '@ui5/webcomponents-react';
 import { FC, useCallback, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { stringify } from 'yaml';
-import { useToast } from '../../../../context/ToastContext.tsx';
 import { useCopyToClipboard } from '../../../../hooks/useCopyToClipboard.ts';
 import { Member } from '../../../../lib/api/types/shared/members.ts';
 import { useLink } from '../../../../lib/shared/useLink.ts';
@@ -26,8 +21,6 @@ export interface IdentityProvidersStepProps {
   onMembersChange: (members: Member[]) => void;
   providers: ExtraProviderMetadata[];
   onProvidersChange: (providers: ExtraProviderMetadata[]) => void;
-  isDefaultProviderEnabled: boolean;
-  onDefaultProviderEnabledChange: (enabled: boolean) => void;
   isValidationError?: boolean;
   workspaceName?: string;
   projectName?: string;
@@ -38,14 +31,11 @@ export const IdentityProvidersStep: FC<IdentityProvidersStepProps> = ({
   onMembersChange,
   providers,
   onProvidersChange,
-  isDefaultProviderEnabled,
-  onDefaultProviderEnabledChange,
   isValidationError = false,
   workspaceName,
   projectName,
 }) => {
   const { t } = useTranslation();
-  const toast = useToast();
   const { identityProviderGuide } = useLink();
   const { copyToClipboard } = useCopyToClipboard();
 
@@ -63,14 +53,10 @@ export const IdentityProvidersStep: FC<IdentityProvidersStepProps> = ({
   }, [members]);
 
   const defaultProviderMembers = useMemo(() => membersByProvider.get('') ?? [], [membersByProvider]);
-  const isDefaultCheckboxDisabled = providers.length === 0;
-  const hasNoAssignedMembers = useMemo(
-    () => !hasAssignedIamMember(members, providers, isDefaultProviderEnabled),
-    [members, providers, isDefaultProviderEnabled],
-  );
+  const hasNoAssignedMembers = useMemo(() => !hasAssignedIamMember(members, providers), [members, providers]);
 
   const oidcYaml = useMemo(() => {
-    const roleBindings = isDefaultProviderEnabled ? buildRoleBindingsForProviderMembers(defaultProviderMembers) : [];
+    const roleBindings = buildRoleBindingsForProviderMembers(defaultProviderMembers);
     const extraProvidersInput = providers.map((provider) => ({
       ...provider,
       roleBindings: buildRoleBindingsForProviderMembers(membersByProvider.get(provider.name) ?? []),
@@ -82,7 +68,7 @@ export const IdentityProvidersStep: FC<IdentityProvidersStepProps> = ({
       extraProviders: extraProvidersInput,
     });
     return stringify(spec?.iam?.oidc ?? {});
-  }, [defaultProviderMembers, isDefaultProviderEnabled, membersByProvider, providers]);
+  }, [defaultProviderMembers, membersByProvider, providers]);
 
   const handleDefaultMembersChange = useCallback(
     (updatedSlice: Member[]) => {
@@ -136,25 +122,10 @@ export const IdentityProvidersStep: FC<IdentityProvidersStepProps> = ({
 
   const handleConfirmDelete = useCallback(() => {
     if (!providerToDelete) return;
-    const remainingProviders = providers.filter((p) => p.name !== providerToDelete.name);
-    onProvidersChange(remainingProviders);
+    onProvidersChange(providers.filter((p) => p.name !== providerToDelete.name));
     onMembersChange(members.filter((m) => m.provider !== providerToDelete.name));
-    if (remainingProviders.length === 0 && !isDefaultProviderEnabled) {
-      onDefaultProviderEnabledChange(true);
-      toast.show(t('IdentityProviders.defaultProviderReenabledToast'));
-    }
     setProviderToDelete(undefined);
-  }, [
-    providerToDelete,
-    providers,
-    members,
-    isDefaultProviderEnabled,
-    onProvidersChange,
-    onMembersChange,
-    onDefaultProviderEnabledChange,
-    toast,
-    t,
-  ]);
+  }, [providerToDelete, providers, members, onProvidersChange, onMembersChange]);
 
   const providerToDeleteMemberCount = providerToDelete
     ? (membersByProvider.get(providerToDelete.name)?.length ?? 0)
@@ -176,43 +147,19 @@ export const IdentityProvidersStep: FC<IdentityProvidersStepProps> = ({
       )}
       <div className={styles.layout}>
         <FlexBox direction="Column" gap={16} className={styles.providerGroupsColumn}>
-          <ProviderGroup
-            headerText={t('IdentityProviders.defaultProviderGroupTitle')}
-            headerActions={
-              <CheckBox
-                checked={isDefaultProviderEnabled}
-                disabled={isDefaultCheckboxDisabled}
-                text={t('IdentityProviders.enableDefaultProviderCheckbox')}
-                data-testid="default-provider-enabled-checkbox"
-                onChange={(e) => onDefaultProviderEnabledChange(e.target.checked)}
-              />
-            }
-          >
-            {isDefaultProviderEnabled ? (
-              <EditMembers
-                members={defaultProviderMembers}
-                isValidationError={isValidationError}
-                requireAtLeastOneMember={false}
-                workspaceName={workspaceName}
-                projectName={projectName}
-                type="mcp"
-                isV2
-                fitContentAddButton
-                testIdPrefix="default-provider"
-                onMemberChanged={handleDefaultMembersChange}
-              />
-            ) : (
-              <Text className={styles.hiddenProviderHint}>
-                {t(
-                  defaultProviderMembers.length > 0
-                    ? 'IdentityProviders.defaultProviderDisabledWithMembersHint'
-                    : 'IdentityProviders.defaultProviderDisabledHint',
-                )}
-              </Text>
-            )}
-            {isDefaultCheckboxDisabled && (
-              <Text className={styles.hiddenProviderHint}>{t('IdentityProviders.defaultProviderLockedHint')}</Text>
-            )}
+          <ProviderGroup headerText={t('IdentityProviders.defaultProviderGroupTitle')}>
+            <EditMembers
+              members={defaultProviderMembers}
+              isValidationError={isValidationError}
+              requireAtLeastOneMember={false}
+              workspaceName={workspaceName}
+              projectName={projectName}
+              type="mcp"
+              isV2
+              fitContentAddButton
+              testIdPrefix="default-provider"
+              onMemberChanged={handleDefaultMembersChange}
+            />
           </ProviderGroup>
 
           {providers.map((provider) => (

--- a/src/components/Wizards/CreateControlPlaneV2/ServiceSelectionStep.tsx
+++ b/src/components/Wizards/CreateControlPlaneV2/ServiceSelectionStep.tsx
@@ -148,6 +148,11 @@ export function ServiceSelectionStep({ services, onServicesChange }: ServiceSele
           const entry = services[key];
           const selected = entry?.selected ?? false;
           const versions = managedServices.find((s) => s.name === serviceName)?.versions ?? [];
+          const currentVersion = entry?.version ?? '';
+          const versionOptions =
+            currentVersion && !versions.some((v) => v.version === currentVersion)
+              ? [{ version: currentVersion }, ...versions]
+              : versions;
           return (
             <div key={key} className={styles.row}>
               <FlexBox alignItems="Center" gap={12}>
@@ -172,7 +177,7 @@ export function ServiceSelectionStep({ services, onServicesChange }: ServiceSele
                       setVersion(key, e.detail.selectedOption.getAttribute('value') ?? '')
                     }
                   >
-                    {versions.map(({ version: v }) => (
+                    {versionOptions.map(({ version: v }) => (
                       <Option key={v} value={v}>
                         {v}
                       </Option>

--- a/src/components/Wizards/CreateControlPlaneV2/SummarizeStepV2.tsx
+++ b/src/components/Wizards/CreateControlPlaneV2/SummarizeStepV2.tsx
@@ -49,7 +49,7 @@ function actionToClassName(action: ServiceMutationAction): string | undefined {
 function actionToIcon(action: ServiceMutationAction): string {
   if (action === 'create') return 'add';
   if (action === 'delete') return 'decline';
-  return 'edit';
+  return 'feeder-arrow';
 }
 
 export const SummarizeStepV2: FC<SummarizeStepProps> = ({

--- a/src/components/Wizards/CreateControlPlaneV2/SummarizeStepV2.tsx
+++ b/src/components/Wizards/CreateControlPlaneV2/SummarizeStepV2.tsx
@@ -26,13 +26,18 @@ interface InitialServiceState {
   kro: boolean;
 }
 
+interface CrossplaneProviderSnapshot {
+  name: string;
+  version: string | null;
+}
+
 interface SummarizeStepProps {
   rawInput: McpV2Input;
   services?: ServiceSelection;
   isEditMode?: boolean;
   originalYamlString?: string;
   initialServices?: InitialServiceState;
-  initialCrossplaneProviders?: string[];
+  initialCrossplaneProviders?: CrossplaneProviderSnapshot[];
 }
 
 function actionToClassName(action: ServiceMutationAction): string | undefined {
@@ -94,7 +99,7 @@ export const SummarizeStepV2: FC<SummarizeStepProps> = ({
   const removedProviders = useMemo(() => {
     if (!isEditMode || !initialCrossplaneProviders) return [];
     const currentNames = new Set((services?.crossplane?.providers ?? []).map((p) => p.name));
-    return initialCrossplaneProviders.filter((name) => !currentNames.has(name));
+    return initialCrossplaneProviders.filter((p) => !currentNames.has(p.name));
   }, [isEditMode, initialCrossplaneProviders, services?.crossplane?.providers]);
 
   return (
@@ -164,7 +169,7 @@ export const SummarizeStepV2: FC<SummarizeStepProps> = ({
                   <div className={styles.coloredList}>
                     <div className={styles.coloredListHeader}>{t('ComponentInstallDialog.providers')}</div>
                     {(services?.crossplane?.providers ?? []).map((provider) => {
-                      const wasInstalled = initialCrossplaneProviders?.includes(provider.name) ?? false;
+                      const wasInstalled = initialCrossplaneProviders?.some((p) => p.name === provider.name) ?? false;
                       const action = resolveServiceMutationAction(isEditMode, wasInstalled, true);
                       return (
                         <div
@@ -179,12 +184,12 @@ export const SummarizeStepV2: FC<SummarizeStepProps> = ({
                         </div>
                       );
                     })}
-                    {removedProviders.map((name) => (
-                      <div key={`removed-${name}`} className={`${styles.coloredListItem} ${styles.removedItem}`}>
+                    {removedProviders.map((p) => (
+                      <div key={`removed-${p.name}`} className={`${styles.coloredListItem} ${styles.removedItem}`}>
                         <Icon name="decline" />
-                        <span className={styles.coloredListItemText}>{name}</span>
+                        <span className={styles.coloredListItemText}>{p.name}</span>
                         <span className={styles.coloredListItemVersion}>
-                          {t('ServiceSelectionStep.versionPlaceholder')}
+                          {p.version || t('ServiceSelectionStep.versionPlaceholder')}
                         </span>
                       </div>
                     ))}

--- a/src/components/Wizards/CreateControlPlaneV2/SummarizeStepV2.tsx
+++ b/src/components/Wizards/CreateControlPlaneV2/SummarizeStepV2.tsx
@@ -1,7 +1,4 @@
 import { Grid, Icon, List, ListItemStandard } from '@ui5/webcomponents-react';
-import '@ui5/webcomponents-icons/dist/add.js';
-import '@ui5/webcomponents-icons/dist/decline.js';
-import '@ui5/webcomponents-icons/dist/edit.js';
 import { FC, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { stringify } from 'yaml';

--- a/src/components/Wizards/CreateControlPlaneV2/SummarizeStepV2.tsx
+++ b/src/components/Wizards/CreateControlPlaneV2/SummarizeStepV2.tsx
@@ -94,13 +94,20 @@ export const SummarizeStepV2: FC<SummarizeStepProps> = ({
       .filter((s): s is NonNullable<typeof s> => s !== null);
   }, [services, initialServices, isEditMode, t]);
 
-  const showProviders = !!services?.crossplane?.selected && !!services.crossplane.providers?.length;
+  const crossplaneAction = useMemo(
+    () =>
+      resolveServiceMutationAction(isEditMode, initialServices?.crossplane ?? false, !!services?.crossplane?.selected),
+    [isEditMode, initialServices?.crossplane, services?.crossplane?.selected],
+  );
+
+  const showProviders =
+    crossplaneAction !== 'delete' && !!services?.crossplane?.selected && !!services.crossplane.providers?.length;
 
   const removedProviders = useMemo(() => {
-    if (!isEditMode || !initialCrossplaneProviders) return [];
+    if (!isEditMode || !initialCrossplaneProviders || crossplaneAction === 'delete') return [];
     const currentNames = new Set((services?.crossplane?.providers ?? []).map((p) => p.name));
     return initialCrossplaneProviders.filter((p) => !currentNames.has(p.name));
-  }, [isEditMode, initialCrossplaneProviders, services?.crossplane?.providers]);
+  }, [isEditMode, initialCrossplaneProviders, crossplaneAction, services?.crossplane?.providers]);
 
   return (
     <div className={styles.wrapper}>

--- a/src/components/Wizards/CreateControlPlaneV2/SummarizeStepV2.tsx
+++ b/src/components/Wizards/CreateControlPlaneV2/SummarizeStepV2.tsx
@@ -1,24 +1,59 @@
-import { Grid, List, ListItemStandard } from '@ui5/webcomponents-react';
-import { useMemo } from 'react';
+import { Grid, Icon, List, ListItemStandard } from '@ui5/webcomponents-react';
+import '@ui5/webcomponents-icons/dist/add.js';
+import '@ui5/webcomponents-icons/dist/decline.js';
+import '@ui5/webcomponents-icons/dist/edit.js';
+import { FC, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { stringify } from 'yaml';
 import { buildMcpV2GraphQLInput } from '../../../spaces/controlPlaneV2/helpers/controlPlaneV2GraphQLInput.ts';
 import { McpV2Input, ServiceSelection } from '../../../spaces/mcp/schemas/mcpV2Input.schema.ts';
+import {
+  resolveServiceMutationAction,
+  ServiceMutationAction,
+} from '../../../spaces/mcp/utils/resolveServiceMutationAction.ts';
 import { parseResourceApiInfo } from '../../../utils/parseResourceApiInfo.ts';
 import { Resource } from '../../../utils/removeManagedFieldsAndFilterData.ts';
 import styles from '../CreateManagedControlPlane/SummarizeStep.module.css';
+import { YamlDiff } from '../CreateManagedControlPlane/YamlDiff.tsx';
 import YamlSummarize from '../CreateManagedControlPlane/YamlSummarize.tsx';
+
+interface InitialServiceState {
+  crossplane: boolean;
+  flux: boolean;
+  landscaper: boolean;
+  externalSecretsOperator: boolean;
+  ocm: boolean;
+  kro: boolean;
+}
 
 interface SummarizeStepProps {
   rawInput: McpV2Input;
-  isDefaultProviderEnabled?: boolean;
   services?: ServiceSelection;
+  isEditMode?: boolean;
+  originalYamlString?: string;
+  initialServices?: InitialServiceState;
+  initialCrossplaneProviders?: string[];
 }
 
-export const SummarizeStepV2: React.FC<SummarizeStepProps> = ({
+function actionToClassName(action: ServiceMutationAction): string | undefined {
+  if (action === 'create') return styles.addedItem;
+  if (action === 'delete') return styles.removedItem;
+  return undefined;
+}
+
+function actionToIcon(action: ServiceMutationAction): string {
+  if (action === 'create') return 'add';
+  if (action === 'delete') return 'decline';
+  return 'edit';
+}
+
+export const SummarizeStepV2: FC<SummarizeStepProps> = ({
   rawInput,
-  isDefaultProviderEnabled = true,
   services,
+  isEditMode = false,
+  originalYamlString = '',
+  initialServices,
+  initialCrossplaneProviders,
 }) => {
   const { t } = useTranslation();
 
@@ -30,25 +65,37 @@ export const SummarizeStepV2: React.FC<SummarizeStepProps> = ({
     };
   }, [rawInput]);
 
-  const defaultMembersHeaderText = isDefaultProviderEnabled
-    ? t('common.members')
-    : `${t('common.members')} ${t('IdentityProviders.disabledBadge')}`;
-
-  const selectedServices = useMemo(() => {
+  const serviceEntries = useMemo(() => {
     if (!services) return [];
-    return [
-      { key: 'crossplane', label: t('ServiceSelectionStep.crossplane'), entry: services.crossplane },
-      { key: 'flux', label: t('ServiceSelectionStep.flux'), entry: services.flux },
-      { key: 'landscaper', label: t('ServiceSelectionStep.landscaper'), entry: services.landscaper },
-      {
-        key: 'externalSecretsOperator',
-        label: t('ServiceSelectionStep.externalSecretsOperator'),
-        entry: services.externalSecretsOperator,
-      },
-      { key: 'ocm', label: t('ServiceSelectionStep.ocm'), entry: services.ocm },
-      { key: 'kro', label: t('ServiceSelectionStep.kro'), entry: services.kro },
-    ].filter((s) => s.entry?.selected);
-  }, [services, t]);
+
+    const defs = [
+      { key: 'crossplane' as const, label: t('ServiceSelectionStep.crossplane') },
+      { key: 'flux' as const, label: t('ServiceSelectionStep.flux') },
+      { key: 'landscaper' as const, label: t('ServiceSelectionStep.landscaper') },
+      { key: 'externalSecretsOperator' as const, label: t('ServiceSelectionStep.externalSecretsOperator') },
+      { key: 'ocm' as const, label: t('ServiceSelectionStep.ocm') },
+      { key: 'kro' as const, label: t('ServiceSelectionStep.kro') },
+    ];
+
+    return defs
+      .map(({ key, label }) => {
+        const entry = services[key];
+        const wasInstalled = initialServices?.[key] ?? false;
+        const isSelected = entry?.selected ?? false;
+        const action = resolveServiceMutationAction(isEditMode, wasInstalled, isSelected);
+        if (action === 'skip') return null;
+        return { key, label, entry, action };
+      })
+      .filter((s): s is NonNullable<typeof s> => s !== null);
+  }, [services, initialServices, isEditMode, t]);
+
+  const showProviders = !!services?.crossplane?.selected && !!services.crossplane.providers?.length;
+
+  const removedProviders = useMemo(() => {
+    if (!isEditMode || !initialCrossplaneProviders) return [];
+    const currentNames = new Set((services?.crossplane?.providers ?? []).map((p) => p.name));
+    return initialCrossplaneProviders.filter((name) => !currentNames.has(name));
+  }, [isEditMode, initialCrossplaneProviders, services?.crossplane?.providers]);
 
   return (
     <div className={styles.wrapper}>
@@ -59,7 +106,7 @@ export const SummarizeStepV2: React.FC<SummarizeStepProps> = ({
             <ListItemStandard text={t('common.namespace')} additionalText={rawInput.namespace} />
           </List>
           <br />
-          <List headerText={defaultMembersHeaderText}>
+          <List headerText={t('common.members')}>
             {rawInput.roleBindings
               .flatMap((rb) =>
                 rb.subjects.map((subject) => ({
@@ -96,42 +143,68 @@ export const SummarizeStepV2: React.FC<SummarizeStepProps> = ({
               </List>
             </div>
           ))}
-          {selectedServices.length > 0 && (
+          {serviceEntries.length > 0 && (
             <>
               <br />
-              <List headerText={t('ServiceSelectionStep.stepTitle')}>
-                {selectedServices.map(({ key, label, entry }) => (
-                  <ListItemStandard
-                    key={key}
-                    text={label}
-                    additionalText={entry?.version || t('ServiceSelectionStep.versionPlaceholder')}
-                  />
+              <div className={styles.coloredList}>
+                <div className={styles.coloredListHeader}>{t('ServiceSelectionStep.stepTitle')}</div>
+                {serviceEntries.map(({ key, label, entry, action }) => (
+                  <div key={key} className={`${styles.coloredListItem} ${actionToClassName(action) ?? ''}`.trim()}>
+                    <Icon name={actionToIcon(action)} />
+                    <span className={styles.coloredListItemText}>{label}</span>
+                    <span className={styles.coloredListItemVersion}>
+                      {entry?.version || t('ServiceSelectionStep.versionPlaceholder')}
+                    </span>
+                  </div>
                 ))}
-              </List>
-              {!!services?.crossplane?.selected && services.crossplane.providers?.length ? (
+              </div>
+              {(showProviders || removedProviders.length > 0) && (
                 <>
                   <br />
-                  <List headerText={t('ComponentInstallDialog.providers')}>
-                    {services.crossplane.providers.map((provider) => (
-                      <ListItemStandard
-                        key={provider.name}
-                        text={provider.name}
-                        additionalText={provider.version || t('ServiceSelectionStep.versionPlaceholder')}
-                      />
+                  <div className={styles.coloredList}>
+                    <div className={styles.coloredListHeader}>{t('ComponentInstallDialog.providers')}</div>
+                    {(services?.crossplane?.providers ?? []).map((provider) => {
+                      const wasInstalled = initialCrossplaneProviders?.includes(provider.name) ?? false;
+                      const action = resolveServiceMutationAction(isEditMode, wasInstalled, true);
+                      return (
+                        <div
+                          key={provider.name}
+                          className={`${styles.coloredListItem} ${actionToClassName(action) ?? ''}`.trim()}
+                        >
+                          <Icon name={actionToIcon(action)} />
+                          <span className={styles.coloredListItemText}>{provider.name}</span>
+                          <span className={styles.coloredListItemVersion}>
+                            {provider.version || t('ServiceSelectionStep.versionPlaceholder')}
+                          </span>
+                        </div>
+                      );
+                    })}
+                    {removedProviders.map((name) => (
+                      <div key={`removed-${name}`} className={`${styles.coloredListItem} ${styles.removedItem}`}>
+                        <Icon name="decline" />
+                        <span className={styles.coloredListItemText}>{name}</span>
+                        <span className={styles.coloredListItemVersion}>
+                          {t('ServiceSelectionStep.versionPlaceholder')}
+                        </span>
+                      </div>
                     ))}
-                  </List>
+                  </div>
                 </>
-              ) : null}
+              )}
             </>
           )}
         </div>
         <div>
-          <YamlSummarize
-            yamlString={yamlString}
-            filename={`mcp_${rawInput.namespace}_${rawInput.name}`}
-            apiVersion={apiVersion}
-            apiGroupName={apiGroupName}
-          />
+          {isEditMode ? (
+            <YamlDiff originalYaml={originalYamlString} modifiedYaml={yamlString} absolutePosition />
+          ) : (
+            <YamlSummarize
+              yamlString={yamlString}
+              filename={`mcp_${rawInput.namespace}_${rawInput.name}`}
+              apiVersion={apiVersion}
+              apiGroupName={apiGroupName}
+            />
+          )}
         </div>
       </Grid>
     </div>

--- a/src/components/Wizards/CreateManagedControlPlane/SummarizeStep.module.css
+++ b/src/components/Wizards/CreateManagedControlPlane/SummarizeStep.module.css
@@ -2,3 +2,52 @@
   position: relative;
   height: 100%;
 }
+
+.coloredList {
+  border: 1px solid var(--sapList_BorderColor);
+  border-radius: var(--sapElement_BorderCornerRadius);
+  overflow: hidden;
+}
+
+.coloredListHeader {
+  background: var(--sapList_HeaderBackground);
+  color: var(--sapList_HeaderTextColor);
+  font-family: var(--sapFontHeaderFamily);
+  font-size: var(--sapFontSmallSize);
+  font-weight: bold;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--sapList_BorderColor);
+}
+
+.coloredListItem {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  font-family: var(--sapFontFamily);
+  font-size: var(--sapFontSize);
+  background: var(--sapList_Background);
+  border-bottom: 1px solid var(--sapList_BorderColor);
+}
+
+.coloredListItem:last-child {
+  border-bottom: none;
+}
+
+.coloredListItemText {
+  flex: 1;
+  color: var(--sapTextColor);
+}
+
+.coloredListItemVersion {
+  color: var(--sapContent_LabelColor);
+  font-size: var(--sapFontSmallSize);
+}
+
+.addedItem {
+  background: var(--sapSuccessBackground);
+}
+
+.removedItem {
+  background: var(--sapErrorBackground);
+}

--- a/src/components/Yaml/YamlResourceEditorSchemaLoader.tsx
+++ b/src/components/Yaml/YamlResourceEditorSchemaLoader.tsx
@@ -3,8 +3,6 @@ import { FC, useEffect, useRef } from 'react';
 import { YamlViewer, YamlViewerProps } from './YamlViewer.tsx';
 import Loading from '../Shared/Loading.tsx';
 import { useCustomResourceDefinitionQuery } from '../../hooks/useCustomResourceDefinitionQuery.ts';
-import { useToast } from '../../context/ToastContext.tsx';
-import { useTranslation } from 'react-i18next';
 
 interface YamlViewerSchemaLoaderProps extends YamlViewerProps {
   apiVersion: string;
@@ -31,16 +29,12 @@ export const YamlResourceEditorSchemaLoader: FC<YamlViewerSchemaLoaderProps> = (
     apiVersion,
   });
 
-  const { show } = useToast();
-
-  const { t } = useTranslation();
-
   useEffect(() => {
     if (!hasShownErrorRef.current && error) {
-      show(t('errors.cannotLoadSchema'));
+      console.warn('Cannot load schema for this resource', { apiGroupName, apiVersion, kind, error });
       hasShownErrorRef.current = true;
     }
-  }, [error, show, t]);
+  }, [error, apiGroupName, apiVersion, kind]);
 
   if (kind && isLoading) {
     return <Loading />;

--- a/src/lib/api/types/shared/members.ts
+++ b/src/lib/api/types/shared/members.ts
@@ -16,7 +16,8 @@ export const MCP_V2_VIEWER_ROLE = 'viewer';
 
 export const mcpV2RoleOptions: RadioButtonsSelectOption[] = [
   { value: 'cluster-admin', label: 'Cluster Admin', icon: 'badge' },
-  { value: MCP_V2_VIEWER_ROLE, label: 'Viewer', icon: 'show' },
+  // disabled for now
+  // { value: MCP_V2_VIEWER_ROLE, label: 'Viewer', icon: 'show' },
 ];
 
 export const MemberRolesDetailed: Record<string, { value: string; displayValue: string }> = {

--- a/src/lib/api/types/shared/members.ts
+++ b/src/lib/api/types/shared/members.ts
@@ -16,7 +16,7 @@ export const MCP_V2_VIEWER_ROLE = 'viewer';
 
 export const mcpV2RoleOptions: RadioButtonsSelectOption[] = [
   { value: 'cluster-admin', label: 'Cluster Admin', icon: 'badge' },
-  // disabled for now
+  // TODO: re-enable once the viewer ClusterRole is provisioned on all managed clusters.
   // { value: MCP_V2_VIEWER_ROLE, label: 'Viewer', icon: 'show' },
 ];
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -19,7 +19,7 @@
   },
   "ComponentCard": {
     "actionsMenu": "Actions",
-    "deleteButton": "Delete",
+    "deleteButton": "Uninstall",
     "deleteErrorMessage": "Failed to uninstall {{component}}. Please try again.",
     "deleteSuccessMessage": "{{component}} has been successfully uninstalled.",
     "editButton": "Edit",
@@ -254,7 +254,9 @@
     "columnNamespaceHeader": "Namespace",
     "defaultProviderValue": "Default",
     "customProviderValue": "Custom",
-    "searchPlaceholder": "Search members"
+    "searchPlaceholder": "Search members",
+    "editMemberButton": "Edit member",
+    "deleteMemberButton": "Delete member"
   },
   "IllustratedError": {
     "titleText": "Something went wrong",
@@ -296,11 +298,6 @@
   "IdentityProviders": {
     "docsLinkInfo": "Learn more about configuring identity providers in our <link1>documentation</link1>.",
     "defaultProviderGroupTitle": "Default identity provider",
-    "enableDefaultProviderCheckbox": "Enabled",
-    "defaultProviderDisabledHint": "The default identity provider is disabled and won't be saved unless you re-enable it before submitting.",
-    "defaultProviderDisabledWithMembersHint": "The default identity provider is disabled. Its members are kept here for now, but won't be saved unless you re-enable the provider before submitting.",
-    "defaultProviderLockedHint": "Add at least one custom identity provider before you can disable the default provider.",
-    "defaultProviderReenabledToast": "The default identity provider was re-enabled because it was the only remaining provider.",
     "noMembersError": "At least one member must be assigned to the default identity provider or to a custom identity provider before you can continue.",
     "addProviderButton": "Add Identity Provider",
     "editProviderButtonTooltip": "Edit identity provider",
@@ -324,7 +321,6 @@
     "deleteConfirmMessage1": "Are you sure you want to delete the identity provider '{{providerName}}'? Its 1 member will also be removed.",
     "deleteConfirmMessageN": "Are you sure you want to delete the identity provider '{{providerName}}'? Its {{count}} members will also be removed.",
     "deleteConfirmButton": "Delete",
-    "disabledBadge": "(disabled)",
     "yamlPreviewTitle": "YAML preview"
   },
   "ProjectPage": {

--- a/src/spaces/controlPlaneV2/helpers/extractMcpV2FormState.spec.ts
+++ b/src/spaces/controlPlaneV2/helpers/extractMcpV2FormState.spec.ts
@@ -10,7 +10,7 @@ function makeControlPlane(spec: ManagedControlPlaneV2['spec']): ManagedControlPl
 }
 
 describe('extractMcpV2FormState', () => {
-  it('extracts default-provider members and marks it enabled when roleBindings are present', () => {
+  it('extracts default-provider members when roleBindings are present', () => {
     const state = extractMcpV2FormState(
       makeControlPlane({
         iam: {
@@ -28,24 +28,22 @@ describe('extractMcpV2FormState', () => {
         },
       }),
     );
-    expect(state.isDefaultProviderEnabled).toBe(true);
     expect(state.members).toEqual([{ kind: 'User', name: 'alice', roles: ['cluster-admin'] }]);
     expect(state.extraProviders).toEqual([]);
   });
 
-  it('marks the default provider disabled when roleBindings are absent', () => {
+  it('returns empty members when defaultProvider is absent', () => {
     const state = extractMcpV2FormState(
       makeControlPlane({ iam: { oidc: { defaultProvider: null, extraProviders: [] } } }),
     );
-    expect(state.isDefaultProviderEnabled).toBe(false);
     expect(state.members).toEqual([]);
   });
 
-  it('marks the default provider disabled when roleBindings is an empty array', () => {
+  it('returns empty members when roleBindings is an empty array', () => {
     const state = extractMcpV2FormState(
       makeControlPlane({ iam: { oidc: { defaultProvider: { roleBindings: [] }, extraProviders: [] } } }),
     );
-    expect(state.isDefaultProviderEnabled).toBe(false);
+    expect(state.members).toEqual([]);
   });
 
   it('extracts an extra provider, reading subject names verbatim (the CRD adds the prefix automatically, not stored in spec)', () => {
@@ -160,6 +158,6 @@ describe('extractMcpV2FormState', () => {
 
   it('handles a control plane with no iam/oidc spec at all', () => {
     const state = extractMcpV2FormState(makeControlPlane(undefined));
-    expect(state).toEqual({ members: [], extraProviders: [], isDefaultProviderEnabled: false });
+    expect(state).toEqual({ members: [], extraProviders: [] });
   });
 });

--- a/src/spaces/controlPlaneV2/helpers/extractMcpV2FormState.ts
+++ b/src/spaces/controlPlaneV2/helpers/extractMcpV2FormState.ts
@@ -7,7 +7,6 @@ import { ExtraProviderMetadata } from '../../mcp/schemas/mcpV2Input.schema.ts';
 export interface McpV2FormState {
   members: Member[];
   extraProviders: ExtraProviderMetadata[];
-  isDefaultProviderEnabled: boolean;
 }
 
 function normalizeMcpV2Role(roleInput?: string | null): string {
@@ -78,6 +77,5 @@ export function extractMcpV2FormState(initialData: ManagedControlPlaneV2): McpV2
   return {
     members: [...defaultMembers, ...extraMembers],
     extraProviders,
-    isDefaultProviderEnabled: defaultRoleBindings.length > 0,
   };
 }

--- a/src/spaces/controlPlaneV2/helpers/flattenOidcRoleBindings.spec.ts
+++ b/src/spaces/controlPlaneV2/helpers/flattenOidcRoleBindings.spec.ts
@@ -101,4 +101,11 @@ describe('flattenOidcRoleBindings', () => {
     });
     expect(result).toEqual([{ role: 'viewer', subjects: [], provider: undefined }]);
   });
+
+  it('returns an empty array when roleBindings contains only null entries', () => {
+    const result = flattenOidcRoleBindings({
+      defaultProvider: { roleBindings: [null, null] },
+    });
+    expect(result).toEqual([]);
+  });
 });

--- a/src/spaces/controlPlaneV2/helpers/hasAssignedIamMember.spec.ts
+++ b/src/spaces/controlPlaneV2/helpers/hasAssignedIamMember.spec.ts
@@ -19,31 +19,27 @@ const provider = (overrides: Partial<ExtraProviderMetadata> = {}): ExtraProvider
 
 describe('hasAssignedIamMember', () => {
   it('returns false when there are no members and no providers', () => {
-    expect(hasAssignedIamMember([], [], true)).toBe(false);
+    expect(hasAssignedIamMember([], [])).toBe(false);
   });
 
-  it('returns false when the default provider has members but is disabled', () => {
-    expect(hasAssignedIamMember([member()], [], false)).toBe(false);
-  });
-
-  it('returns true when the default provider is enabled and has a member', () => {
-    expect(hasAssignedIamMember([member()], [], true)).toBe(true);
+  it('returns true when the default provider has a member', () => {
+    expect(hasAssignedIamMember([member()], [])).toBe(true);
   });
 
   it('returns false when an extra provider exists but has no members', () => {
-    expect(hasAssignedIamMember([], [provider()], false)).toBe(false);
+    expect(hasAssignedIamMember([], [provider()])).toBe(false);
   });
 
-  it('returns true when an extra provider has a member, even with the default provider disabled', () => {
-    expect(hasAssignedIamMember([member({ provider: 'custom' })], [provider()], false)).toBe(true);
+  it('returns true when an extra provider has a member', () => {
+    expect(hasAssignedIamMember([member({ provider: 'custom' })], [provider()])).toBe(true);
   });
 
   it('returns false when members are tagged for a provider that no longer exists', () => {
-    expect(hasAssignedIamMember([member({ provider: 'deleted-provider' })], [provider()], true)).toBe(false);
+    expect(hasAssignedIamMember([member({ provider: 'deleted-provider' })], [provider()])).toBe(false);
   });
 
   it('returns true when only one of several extra providers has a member', () => {
     const providers = [provider({ name: 'a' }), provider({ name: 'b' })];
-    expect(hasAssignedIamMember([member({ provider: 'b' })], providers, false)).toBe(true);
+    expect(hasAssignedIamMember([member({ provider: 'b' })], providers)).toBe(true);
   });
 });

--- a/src/spaces/controlPlaneV2/helpers/hasAssignedIamMember.ts
+++ b/src/spaces/controlPlaneV2/helpers/hasAssignedIamMember.ts
@@ -1,13 +1,8 @@
 import { Member } from '../../../lib/api/types/shared/members.ts';
 import { ExtraProviderMetadata } from '../../mcp/schemas/mcpV2Input.schema.ts';
 
-// A member only lands in the submitted roleBindings if its provider is enabled/exists.
-export function hasAssignedIamMember(
-  members: Member[],
-  extraProviders: ExtraProviderMetadata[],
-  isDefaultProviderEnabled: boolean,
-): boolean {
-  const hasDefaultMember = isDefaultProviderEnabled && members.some((m) => !m.provider);
+export function hasAssignedIamMember(members: Member[], extraProviders: ExtraProviderMetadata[]): boolean {
+  const hasDefaultMember = members.some((m) => !m.provider);
   const hasExtraProviderMember = extraProviders.some((p) => members.some((m) => m.provider === p.name));
   return hasDefaultMember || hasExtraProviderMember;
 }

--- a/src/spaces/mcp/components/ComponentInstallDialog/ComponentInstallDialog.tsx
+++ b/src/spaces/mcp/components/ComponentInstallDialog/ComponentInstallDialog.tsx
@@ -62,6 +62,12 @@ export function ComponentInstallDialog({
 
   const service = useMemo(() => services.find((s) => s.name === serviceName), [services, serviceName]);
   const versions = useMemo(() => service?.versions ?? [], [service]);
+  const displayVersions = useMemo(() => {
+    if (mode === 'edit' && initialVersion && !versions.some((v) => v.version === initialVersion)) {
+      return [...versions, { version: initialVersion }];
+    }
+    return versions;
+  }, [versions, mode, initialVersion]);
   const apiVersion = service?.apiVersion ?? '';
   const kind = service?.kind ?? '';
 
@@ -207,7 +213,7 @@ export function ComponentInstallDialog({
             valueStateMessage={errors.version ? <span>{errors.version.message}</span> : undefined}
             onChange={handleVersionChange}
           >
-            {versions.map(({ version: v }) => (
+            {displayVersions.map(({ version: v }) => (
               <Option key={v} value={v}>
                 {v}
               </Option>

--- a/src/spaces/mcp/components/CrossplaneInstallDialog/CrossplaneInstallDialog.tsx
+++ b/src/spaces/mcp/components/CrossplaneInstallDialog/CrossplaneInstallDialog.tsx
@@ -50,8 +50,26 @@ export function CrossplaneInstallDialog({
 
   const crossplaneService = useMemo(() => services.find((s) => s.name === 'crossplane'), [services]);
   const crossplaneVersions = useMemo(() => crossplaneService?.versions ?? [], [crossplaneService]);
+  const crossplaneDisplayVersions = useMemo(() => {
+    const installedVersion = initialData?.version;
+    if (mode === 'edit' && installedVersion && !crossplaneVersions.some((v) => v.version === installedVersion)) {
+      return [...crossplaneVersions, { version: installedVersion }];
+    }
+    return crossplaneVersions;
+  }, [crossplaneVersions, mode, initialData?.version]);
   const crossplaneApiVersion = crossplaneService?.apiVersion ?? 'crossplane.services.open-control-plane.io/v1alpha1';
   const crossplaneKind = crossplaneService?.kind ?? 'Crossplane';
+
+  const augmentedProviderCatalog = useMemo(() => {
+    if (mode !== 'edit' || !initialData) return crossplaneProviders;
+    return crossplaneProviders.map((catalogProvider) => {
+      const installed = initialData.providers.find((ip) => ip.name === catalogProvider.name);
+      if (!installed?.version || catalogProvider.versions.some((v) => v.version === installed.version)) {
+        return catalogProvider;
+      }
+      return { ...catalogProvider, versions: [...catalogProvider.versions, { version: installed.version }] };
+    });
+  }, [crossplaneProviders, mode, initialData]);
 
   const schema = useMemo(() => createCrossplaneInstallSchema(t), [t]);
   const {
@@ -252,7 +270,7 @@ export function CrossplaneInstallDialog({
             valueStateMessage={errors.crossplaneVersion ? <span>{errors.crossplaneVersion.message}</span> : undefined}
             onChange={handleVersionChange}
           >
-            {crossplaneVersions.map(({ version }) => (
+            {crossplaneDisplayVersions.map(({ version }) => (
               <Option key={version} value={version}>
                 {version}
               </Option>
@@ -264,7 +282,7 @@ export function CrossplaneInstallDialog({
           </Title>
           <CrossplaneProviderPicker
             providers={providerStates}
-            catalog={crossplaneProviders}
+            catalog={augmentedProviderCatalog}
             disabled={!crossplaneVersion}
             getError={getProviderVersionError}
             onToggle={handleProviderToggle}


### PR DESCRIPTION
What this PR does / why we need it:

**The PR fixes following:**

- Hide Viewer Role for ControlPlane (v2) [Core team is bringing it back]
- Bug (?) Toast: "Cannot load Schema"
- No Disable for default IDP - there is no API for it
- Test: Respect service versions that do not match the hardcodet ones
- Change label: Install & Uninstall services
- Show Diffs on ControlPlane edits.