### PR TITLE
feat(workspaces): restrict workspace access to members only

### DIFF
--- a/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.cy.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.cy.tsx
@@ -3,6 +3,7 @@ import '@ui5/webcomponents-cypress-commands';
 import { MemoryRouter } from 'react-router-dom';
 import { FeatureToggleProvider } from '../../../context/FeatureToggleContext.tsx';
 import { FrontendConfigContext, Landscape } from '../../../context/FrontendConfigContext.tsx';
+import { useAuthOnboarding } from '../../../spaces/onboarding/auth/AuthContextOnboarding.tsx';
 import { useDeleteWorkspace } from '../../../spaces/onboarding/hooks/useDeleteWorkspace.ts';
 import { useMcpsQuery } from '../../../spaces/onboarding/hooks/useMcpsQuery.ts';
 import { Workspace } from '../../../spaces/onboarding/types/Workspace.ts';
@@ -21,6 +22,15 @@ const frontendConfig = {
   },
 };
 
+const fakeUseAuthOnboarding: typeof useAuthOnboarding = () => ({
+  user: { sub: 'u0', email: 'test@example.com' },
+  isPending: false,
+  isAuthenticated: true,
+  error: null,
+  login: cy.stub() as never,
+  logout: cy.stub() as never,
+});
+
 const fakeUseMcpsQuery: typeof useMcpsQuery = () => ({
   data: [],
   error: undefined,
@@ -34,7 +44,7 @@ const fakeUseDeleteWorkspace: typeof useDeleteWorkspace = () => ({
 
 const makeWorkspace = (name: string): Workspace => ({
   metadata: { name, namespace: `project-test--ws-${name}`, annotations: {} },
-  spec: { members: [] },
+  spec: { members: [{ kind: 'User', name: 'test@example.com', roles: ['admin'] }] },
   status: { namespace: `project-test--ws-${name}` },
 });
 
@@ -55,6 +65,7 @@ function mountAllWorkspaces(
                 projectName="test"
                 workspaces={ws}
                 expandedWorkspaces={expandedWorkspaces}
+                useAuthOnboardingHook={fakeUseAuthOnboarding}
                 useMcpsQuery={fakeUseMcpsQuery}
                 useDeleteWorkspace={fakeUseDeleteWorkspace}
                 onToggleWorkspace={onToggleWorkspace}

--- a/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.tsx
@@ -3,7 +3,7 @@ import '@ui5/webcomponents-fiori/dist/illustrations/NoData.js';
 import '@ui5/webcomponents-fiori/dist/illustrations/EmptyList.js';
 import '@ui5/webcomponents-fiori/dist/illustrations/NoSearchResults.js';
 import ButtonDesign from '@ui5/webcomponents/dist/types/ButtonDesign.js';
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDeleteWorkspace as _useDeleteWorkspace } from '../../../spaces/onboarding/hooks/useDeleteWorkspace.ts';
 import { useMcpsQuery as _useMcpsQuery } from '../../../spaces/onboarding/hooks/useMcpsQuery.ts';
@@ -53,6 +53,17 @@ export default function ControlPlaneListAllWorkspaces({
     });
   }
 
+  const [forbiddenWorkspaces, setForbiddenWorkspaces] = useState<Set<string>>(new Set());
+
+  const handleForbiddenDetected = useCallback((workspaceName: string) => {
+    setForbiddenWorkspaces((prev) => {
+      if (prev.has(workspaceName)) return prev;
+      const next = new Set(prev);
+      next.add(workspaceName);
+      return next;
+    });
+  }, []);
+
   if (workspaces.length === 0) {
     return (
       <FlexBox direction="Column" alignItems="Center">
@@ -83,7 +94,10 @@ export default function ControlPlaneListAllWorkspaces({
           />
         </FlexBox>
       )}
-      {workspaces.map((workspace) => (
+      {[
+        ...workspaces.filter((ws) => !forbiddenWorkspaces.has(ws.metadata.name)),
+        ...workspaces.filter((ws) => forbiddenWorkspaces.has(ws.metadata.name)),
+      ].map((workspace) => (
         <ControlPlaneListWorkspaceGridTile
           key={`${projectName}-${workspace.metadata.name}`}
           projectName={projectName}
@@ -92,6 +106,7 @@ export default function ControlPlaneListAllWorkspaces({
           isExpanded={expandedWorkspaces.has(workspace.metadata.name)}
           useMcpsQuery={useMcpsQuery}
           useDeleteWorkspace={useDeleteWorkspace}
+          onForbiddenDetected={() => handleForbiddenDetected(workspace.metadata.name)}
           onToggleExpanded={() => onToggleWorkspace(workspace.metadata.name)}
           onVisibilityChange={(isVisible) => handleVisibilityChange(workspace.metadata.name, isVisible)}
         />

--- a/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListAllWorkspaces.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { useDeleteWorkspace as _useDeleteWorkspace } from '../../../spaces/onboarding/hooks/useDeleteWorkspace.ts';
 import { useMcpsQuery as _useMcpsQuery } from '../../../spaces/onboarding/hooks/useMcpsQuery.ts';
 import { useLink } from '../../../lib/shared/useLink.ts';
+import { useAuthOnboarding } from '../../../spaces/onboarding/auth/AuthContextOnboarding.tsx';
 import { Workspace } from '../../../spaces/onboarding/types/Workspace.ts';
 import { ControlPlaneListWorkspaceGridTile } from './ControlPlaneListWorkspaceGridTile.tsx';
 
@@ -17,6 +18,7 @@ interface Props {
   search?: string;
   expandedWorkspaces: Set<string>;
   onToggleWorkspace: (workspaceName: string) => void;
+  useAuthOnboardingHook?: typeof useAuthOnboarding;
   useMcpsQuery?: typeof _useMcpsQuery;
   useDeleteWorkspace?: typeof _useDeleteWorkspace;
 }
@@ -27,6 +29,7 @@ export default function ControlPlaneListAllWorkspaces({
   search = '',
   expandedWorkspaces,
   onToggleWorkspace,
+  useAuthOnboardingHook = useAuthOnboarding,
   useMcpsQuery = _useMcpsQuery,
   useDeleteWorkspace = _useDeleteWorkspace,
 }: Props) {
@@ -104,6 +107,7 @@ export default function ControlPlaneListAllWorkspaces({
           workspace={workspace}
           search={search}
           isExpanded={expandedWorkspaces.has(workspace.metadata.name)}
+          useAuthOnboardingHook={useAuthOnboardingHook}
           useMcpsQuery={useMcpsQuery}
           useDeleteWorkspace={useDeleteWorkspace}
           onForbiddenDetected={() => handleForbiddenDetected(workspace.metadata.name)}

--- a/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.cy.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.cy.tsx
@@ -5,6 +5,7 @@ import en from 'javascript-time-ago/locale/en';
 import { MemoryRouter } from 'react-router-dom';
 import { FeatureToggleProvider } from '../../../context/FeatureToggleContext.tsx';
 import { FrontendConfigContext } from '../../../context/FrontendConfigContext.tsx';
+import { useAuthOnboarding } from '../../../spaces/onboarding/auth/AuthContextOnboarding.tsx';
 import { useDeleteWorkspace } from '../../../spaces/onboarding/hooks/useDeleteWorkspace.ts';
 import { useMcpsQuery } from '../../../spaces/onboarding/hooks/useMcpsQuery.ts';
 import { ControlPlaneListItem, ReadyStatus } from '../../../spaces/onboarding/types/ControlPlane.ts';
@@ -185,5 +186,148 @@ describe('ControlPlaneListWorkspaceGridTile', () => {
       cy.get('[data-testid="workspace-panel-workspaceName"]').find('button').first().click();
       cy.get('@onToggle').should('have.been.calledOnce');
     });
+  });
+});
+
+describe('ControlPlaneListWorkspaceGridTile — access control', () => {
+  const memberUser: typeof useAuthOnboarding = () => ({
+    user: { sub: 'u1', email: 'member@example.com' },
+    isPending: false,
+    isAuthenticated: true,
+    error: null,
+    login: cy.stub() as never,
+    logout: cy.stub() as never,
+  });
+
+  const nonMemberUser: typeof useAuthOnboarding = () => ({
+    user: { sub: 'u2', email: 'outsider@example.com' },
+    isPending: false,
+    isAuthenticated: true,
+    error: null,
+    login: cy.stub() as never,
+    logout: cy.stub() as never,
+  });
+
+  const workspaceWithMember: Workspace = {
+    metadata: { name: 'workspaceName', namespace: 'project-webapp-playground--ws-workspaceName', annotations: {} },
+    spec: { members: [{ kind: 'User', name: 'member@example.com', roles: ['admin'] }] },
+    status: { namespace: 'project-webapp-playground--ws-workspaceName' },
+  };
+
+  function mountAccessTile(opts: {
+    useAuthOnboardingHook: typeof useAuthOnboarding;
+    ws?: Workspace;
+    useMcpsQuery?: typeof useMcpsQuery;
+  }) {
+    const ws = opts.ws ?? workspaceWithMember;
+    cy.mount(
+      <MockedProvider mocks={[]}>
+        <MemoryRouter>
+          <FrontendConfigContext.Provider value={frontendConfig}>
+            <SplitterProvider>
+              <FeatureToggleProvider>
+                <ControlPlaneListWorkspaceGridTile
+                  workspace={ws}
+                  projectName="some-project"
+                  isExpanded={false}
+                  useMcpsQuery={opts.useMcpsQuery ?? fakeUseMCPsListQuery}
+                  useDeleteWorkspace={fakeUseDeleteWorkspace}
+                  useAuthOnboardingHook={opts.useAuthOnboardingHook}
+                  onToggleExpanded={cy.stub()}
+                />
+              </FeatureToggleProvider>
+            </SplitterProvider>
+          </FrontendConfigContext.Provider>
+        </MemoryRouter>
+      </MockedProvider>,
+    );
+  }
+
+  it('shows expand toggle when user is a member', () => {
+    mountAccessTile({ useAuthOnboardingHook: memberUser });
+
+    cy.get('[data-testid="workspace-panel-workspaceName"]').find('button').first().should('have.attr', 'aria-expanded');
+    cy.get('[id^="forbidden-btn"]').should('not.exist');
+  });
+
+  it('shows locked icon and no expand toggle when user is not a member', () => {
+    mountAccessTile({ useAuthOnboardingHook: nonMemberUser });
+
+    cy.get('[id^="forbidden-btn"]').should('exist');
+    cy.get('[data-testid="workspace-panel-workspaceName"]').find('button[aria-expanded]').should('not.exist');
+  });
+
+  it('opens a popover with the permission error message when locked icon is clicked', () => {
+    mountAccessTile({ useAuthOnboardingHook: nonMemberUser });
+
+    cy.get('[id^="forbidden-btn"]').click();
+    cy.get('ui5-popover[open]').should('exist');
+  });
+
+  it('does not fire GetMCPsList for non-members even when expanded', () => {
+    const querySpy = cy.stub().as('querySpy').returns({
+      data: [],
+      error: undefined,
+      isPending: false,
+      isReadyForSubscriptions: false,
+    });
+
+    mountAccessTile({ useAuthOnboardingHook: nonMemberUser, useMcpsQuery: querySpy });
+
+    cy.get('@querySpy').should('always.have.been.calledWithMatch', 'project-some-project--ws-workspaceName', {
+      mode: 'skip',
+    });
+  });
+
+  it('hides member avatars when workspace is collapsed', () => {
+    cy.mount(
+      <MockedProvider mocks={[]}>
+        <MemoryRouter>
+          <FrontendConfigContext.Provider value={frontendConfig}>
+            <SplitterProvider>
+              <FeatureToggleProvider>
+                <ControlPlaneListWorkspaceGridTile
+                  workspace={workspaceWithMember}
+                  projectName="some-project"
+                  isExpanded={false}
+                  useMcpsQuery={fakeUseMCPsListQuery}
+                  useDeleteWorkspace={fakeUseDeleteWorkspace}
+                  useAuthOnboardingHook={memberUser}
+                  onToggleExpanded={cy.stub()}
+                />
+              </FeatureToggleProvider>
+            </SplitterProvider>
+          </FrontendConfigContext.Provider>
+        </MemoryRouter>
+      </MockedProvider>,
+    );
+
+    cy.get('ui5-avatar-group').should('not.exist');
+  });
+
+  it('shows member avatars when workspace is expanded', () => {
+    cy.mount(
+      <MockedProvider mocks={[]}>
+        <MemoryRouter>
+          <FrontendConfigContext.Provider value={frontendConfig}>
+            <SplitterProvider>
+              <FeatureToggleProvider>
+                <ControlPlaneListWorkspaceGridTile
+                  workspace={workspaceWithMember}
+                  projectName="some-project"
+                  isExpanded={true}
+                  useMcpsQuery={fakeUseMCPsListQuery}
+                  useDeleteWorkspace={fakeUseDeleteWorkspace}
+                  useAuthOnboardingHook={memberUser}
+                  onToggleExpanded={cy.stub()}
+                />
+              </FeatureToggleProvider>
+            </SplitterProvider>
+          </FrontendConfigContext.Provider>
+        </MemoryRouter>
+      </MockedProvider>,
+    );
+
+    cy.get('ui5-avatar-group').should('exist');
   });
 });

--- a/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.cy.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.cy.tsx
@@ -21,7 +21,7 @@ const workspace: Workspace = {
     namespace: 'project-webapp-playground--ws-workspaceName',
     annotations: {},
   },
-  spec: { members: [] },
+  spec: { members: [{ kind: 'User', name: 'test@example.com', roles: ['admin'] }] },
   status: { namespace: 'project-webapp-playground--ws-workspaceName' },
 };
 
@@ -57,6 +57,15 @@ const fakeManagedControlPlanes: ControlPlaneListItem[] = [
     status: { status: ReadyStatus.Ready, conditions: [], access: undefined },
   },
 ];
+
+const fakeUseAuthOnboarding: typeof useAuthOnboarding = () => ({
+  user: { sub: 'u0', email: 'test@example.com' },
+  isPending: false,
+  isAuthenticated: true,
+  error: null,
+  login: cy.stub() as never,
+  logout: cy.stub() as never,
+});
 
 const fakeUseMCPsListQuery: typeof useMcpsQuery = () => ({
   data: fakeManagedControlPlanes,
@@ -103,6 +112,7 @@ function mountTile({
                 isExpanded={isExpanded}
                 useMcpsQuery={fakeUseMCPsListQuery}
                 useDeleteWorkspace={deleteWorkspace}
+                useAuthOnboardingHook={fakeUseAuthOnboarding}
                 onToggleExpanded={onToggle}
               />
             </FeatureToggleProvider>
@@ -254,7 +264,10 @@ describe('ControlPlaneListWorkspaceGridTile — access control', () => {
     mountAccessTile({ useAuthOnboardingHook: nonMemberUser });
 
     cy.get('[id^="forbidden-btn"]').should('exist');
-    cy.get('[data-testid="workspace-panel-workspaceName"]').find('button[aria-expanded]').should('not.exist');
+    cy.get('[data-testid="workspace-panel-workspaceName"]')
+      .find('button[aria-expanded]')
+      .not('[id^="forbidden-btn"]')
+      .should('not.exist');
   });
 
   it('opens a popover with the permission error message when locked icon is clicked', () => {

--- a/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
+++ b/src/components/ControlPlanes/List/ControlPlaneListWorkspaceGridTile.tsx
@@ -2,15 +2,19 @@ import '@ui5/webcomponents-fiori/dist/illustrations/EmptyList.js';
 import '@ui5/webcomponents-fiori/dist/illustrations/NoData.js';
 import IllustrationMessageType from '@ui5/webcomponents-fiori/dist/types/IllustrationMessageType.js';
 import '@ui5/webcomponents-icons/dist/delete';
+import '@ui5/webcomponents-icons/dist/locked.js';
 import '@ui5/webcomponents-icons/dist/product';
 import '@ui5/webcomponents-icons/dist/slim-arrow-right';
-import { Button, FlexBox, Icon, ObjectPageSection, Title } from '@ui5/webcomponents-react';
-import { useEffect, useMemo, useState } from 'react';
+import { BusyIndicator, Button, FlexBox, Icon, ObjectPageSection, Popover, Title } from '@ui5/webcomponents-react';
+import PopoverPlacement from '@ui5/webcomponents/dist/types/PopoverPlacement.js';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFeatureToggle } from '../../../context/FeatureToggleContext.tsx';
 import { isForbiddenError } from '../../../lib/api/error.ts';
 import { DISPLAY_NAME_ANNOTATION } from '../../../lib/api/types/shared/keyNames.ts';
+import { MemberKind } from '../../../lib/api/types/shared/members.ts';
 import { useLink } from '../../../lib/shared/useLink.ts';
+import { useAuthOnboarding } from '../../../spaces/onboarding/auth/AuthContextOnboarding.tsx';
 import { useDeleteWorkspace as _useDeleteWorkspace } from '../../../spaces/onboarding/hooks/useDeleteWorkspace.ts';
 import { McpsQueryMode, useMcpsQuery as _useMcpsQuery } from '../../../spaces/onboarding/hooks/useMcpsQuery.ts';
 import { Workspace } from '../../../spaces/onboarding/types/Workspace.ts';
@@ -36,10 +40,12 @@ interface Props {
   workspace: Workspace;
   search?: string;
   isExpanded?: boolean;
+  onForbiddenDetected?: () => void;
   onToggleExpanded?: () => void;
   onVisibilityChange?: (isVisible: boolean) => void;
-  useMcpsQuery?: typeof _useMcpsQuery;
+  useAuthOnboardingHook?: typeof useAuthOnboarding;
   useDeleteWorkspace?: typeof _useDeleteWorkspace;
+  useMcpsQuery?: typeof _useMcpsQuery;
 }
 
 export function ControlPlaneListWorkspaceGridTile({
@@ -47,10 +53,12 @@ export function ControlPlaneListWorkspaceGridTile({
   workspace,
   search = '',
   isExpanded,
+  onForbiddenDetected,
   onToggleExpanded,
   onVisibilityChange,
-  useMcpsQuery = _useMcpsQuery,
+  useAuthOnboardingHook = useAuthOnboarding,
   useDeleteWorkspace = _useDeleteWorkspace,
+  useMcpsQuery = _useMcpsQuery,
 }: Props) {
   const [isCreateManagedControlPlaneWizardOpen, setIsCreateManagedControlPlaneWizardOpen] = useState(false);
   const [isCreateManagedControlPlaneWizardOpenV2, setIsCreateManagedControlPlaneWizardOpenV2] = useState(false);
@@ -62,16 +70,37 @@ export function ControlPlaneListWorkspaceGridTile({
 
   const { t } = useTranslation();
   const { enableMcpV2 } = useFeatureToggle();
+  const { user, isPending: authPending } = useAuthOnboardingHook();
+
+  const isMember: boolean | null =
+    authPending || !user
+      ? null
+      : (workspace.spec.members ?? []).some(
+          (m) =>
+            m.kind.toLowerCase() === MemberKind.User.toLowerCase() && m.name.toLowerCase() === user.email.toLowerCase(),
+        );
 
   const [dialogDeleteWsIsOpen, setDialogDeleteWsIsOpen] = useState(false);
   const [dialogEditWsIsOpen, setDialogEditWsIsOpen] = useState(false);
 
-  const fetchMode: McpsQueryMode = isExpanded ? 'full' : search.trim() ? 'minimal' : 'skip';
+  const fetchMode: McpsQueryMode =
+    isMember === false ? 'skip' : isExpanded ? 'full' : search.trim() ? 'minimal' : 'skip';
   const {
     data: managedControlPlanes,
     error: cpsError,
     isPending,
   } = useMcpsQuery(`project-${projectName}--ws-${workspaceName}`, { mode: fetchMode });
+
+  const isForbidden = isMember === false || (!!cpsError && isForbiddenError(cpsError));
+  const [forbiddenPopoverOpen, setForbiddenPopoverOpen] = useState(false);
+  const forbiddenButtonId = `forbidden-btn-${workspaceName}`;
+
+  const hasFiredForbidden = useRef(false);
+  useEffect(() => {
+    if (!isForbidden || hasFiredForbidden.current) return;
+    hasFiredForbidden.current = true;
+    onForbiddenDetected?.();
+  }, [isForbidden, onForbiddenDetected]);
 
   const query = search.trim().toLowerCase();
   const workspaceMatches =
@@ -86,9 +115,8 @@ export function ControlPlaneListWorkspaceGridTile({
       : managedControlPlanes;
 
   const hasMcpMatch = !isPending && query && !workspaceMatches && (visibleMcps ?? []).length > 0;
-  // Hide tile when searching and nothing matches (workspace name/displayName or any CP name)
   const hidden = !isPending && query && !workspaceMatches && !hasMcpMatch;
-  const shouldCollapsePanel = query ? !(workspaceMatches || hasMcpMatch) : !isExpanded;
+  const shouldCollapsePanel = isForbidden || (query ? !(workspaceMatches || hasMcpMatch) : !isExpanded);
 
   useEffect(() => {
     onVisibilityChange?.(!hidden);
@@ -97,34 +125,21 @@ export function ControlPlaneListWorkspaceGridTile({
   const { deleteWorkspace } = useDeleteWorkspace(projectNamespace, workspaceName);
   const telemetry = useTelemetry();
   const { mcpCreationGuide } = useLink();
-  const errorView = createErrorView(cpsError);
+
+  const errorView = (() => {
+    if (!cpsError || isForbidden) return null;
+    return <IllustratedError title={t('ControlPlaneListWorkspaceGridTile.loadingErrorMessage')} />;
+  })();
 
   function isWorkspaceReady(currentWorkspace: Workspace): boolean {
     return currentWorkspace.status != null && currentWorkspace.status.namespace != null;
-  }
-
-  function createErrorView(error: Error | undefined) {
-    if (error) {
-      if (isForbiddenError(error)) {
-        return (
-          <IllustratedError
-            title={t('ControlPlaneListWorkspaceGridTile.permissionErrorMessage')}
-            details={t('ControlPlaneListWorkspaceGridTile.permissionErrorMessageSubtitle')}
-            compact={true}
-          />
-        );
-      } else {
-        return <IllustratedError title={t('ControlPlaneListWorkspaceGridTile.loadingErrorMessage')} />;
-      }
-    }
-    return null;
   }
 
   const uniqueMembers = useMemo(() => {
     const seenKeys = new Set<string>();
     const fallbackNamespace = workspace.status?.namespace ?? '';
 
-    return (workspace.spec.members ?? []).filter((member: { name?: string; namespace?: string }) => {
+    return (workspace.spec.members ?? []).filter((member: { name?: string; namespace?: string | null }) => {
       const memberNamespace = member?.namespace ?? fallbackNamespace;
       const memberName = String(member?.name ?? '')
         .trim()
@@ -150,31 +165,72 @@ export function ControlPlaneListWorkspaceGridTile({
       >
         <section className={styles.workspaceSection} data-testid={`workspace-panel-${workspaceName}`}>
           <div className={styles.workspaceHeader}>
-            <button
-              type="button"
-              className={styles.workspaceToggle}
-              aria-expanded={!shouldCollapsePanel}
-              onClick={onToggleExpanded}
-            >
-              <Icon
-                name="slim-arrow-right"
-                className={`${styles.chevron} ${shouldCollapsePanel ? '' : styles.chevronOpen}`}
-              />
-              <Icon name="product" className={styles.workspaceIcon} />
-              <span className={`${styles.workspaceEyebrow} mono-font`}>{t('Entities.Workspace')} ·</span>
-              <Title level="H3" className={styles.workspaceTitle}>
-                {showDisplayName ? workspaceDisplayName : workspaceName}{' '}
-                {!isWorkspaceReady(workspace) ? '(Loading)' : ''}
-              </Title>
-            </button>
+            {isForbidden ? (
+              <>
+                <button
+                  id={forbiddenButtonId}
+                  type="button"
+                  className={styles.workspaceToggle}
+                  aria-expanded={false}
+                  onClick={() => setForbiddenPopoverOpen((o) => !o)}
+                >
+                  <Icon name="locked" className={styles.workspaceIcon} />
+                  <span className={`${styles.workspaceEyebrow} mono-font`}>{t('Entities.Workspace')} ·</span>
+                  <Title level="H3" className={styles.workspaceTitle}>
+                    {showDisplayName ? workspaceDisplayName : workspaceName}
+                  </Title>
+                </button>
+                <Popover
+                  open={forbiddenPopoverOpen}
+                  opener={forbiddenButtonId}
+                  placement={PopoverPlacement.Bottom}
+                  onClose={() => setForbiddenPopoverOpen(false)}
+                >
+                  <div style={{ padding: '0.5rem 1rem' }}>
+                    <p>{t('ControlPlaneListWorkspaceGridTile.permissionErrorMessage')}</p>
+                    <p style={{ color: 'var(--sapContent_LabelColor)', fontSize: '0.875rem' }}>
+                      {t('ControlPlaneListWorkspaceGridTile.permissionErrorMessageSubtitle')}
+                    </p>
+                  </div>
+                </Popover>
+              </>
+            ) : isMember === null ? (
+              <div className={styles.workspaceToggle}>
+                <BusyIndicator active delay={0} size="S" />
+                <span className={`${styles.workspaceEyebrow} mono-font`}>{t('Entities.Workspace')} ·</span>
+                <Title level="H3" className={styles.workspaceTitle}>
+                  {showDisplayName ? workspaceDisplayName : workspaceName}
+                </Title>
+              </div>
+            ) : (
+              <button
+                type="button"
+                className={styles.workspaceToggle}
+                aria-expanded={!shouldCollapsePanel}
+                onClick={onToggleExpanded}
+              >
+                <Icon
+                  name="slim-arrow-right"
+                  className={`${styles.chevron} ${shouldCollapsePanel ? '' : styles.chevronOpen}`}
+                />
+                <Icon name="product" className={styles.workspaceIcon} />
+                <span className={`${styles.workspaceEyebrow} mono-font`}>{t('Entities.Workspace')} ·</span>
+                <Title level="H3" className={styles.workspaceTitle}>
+                  {showDisplayName ? workspaceDisplayName : workspaceName}{' '}
+                  {!isWorkspaceReady(workspace) ? '(Loading)' : ''}
+                </Title>
+              </button>
+            )}
             <CopyButton collapsible text={workspace.status?.namespace || '-'} source="workspace-namespace" />
             <div className={styles.headerSpacer} />
-            <MembersAvatarView
-              members={uniqueMembers}
-              project={projectName}
-              workspace={workspaceName}
-              source="workspace-grid"
-            />
+            {!shouldCollapsePanel && (
+              <MembersAvatarView
+                members={uniqueMembers}
+                project={projectName}
+                workspace={workspaceName}
+                source="workspace-grid"
+              />
+            )}
             <FlexBox justifyContent={'SpaceBetween'} gap={10}>
               <YamlViewButton
                 variant="loader"

--- a/src/lib/api/types/shared/members.ts
+++ b/src/lib/api/types/shared/members.ts
@@ -35,7 +35,7 @@ export const MemberSchema = z.object({
   kind: z.string(),
   name: z.string(),
   roles: z.array(z.string()),
-  namespace: z.string().optional(),
+  namespace: z.string().nullish(),
   // V2-only: extraProviders[] entry name; undefined = default provider.
   provider: z.string().optional(),
 });


### PR DESCRIPTION
<img width="1309" height="359" alt="image" src="https://github.com/user-attachments/assets/62b2fbdf-cc1a-4da6-a834-7f26bef547e5" />


## Summary

- Non-members see a locked icon with a permission popover instead of the expand toggle; `GetMCPsList` is skipped for their namespaces to avoid unnecessary requests
- Forbidden workspaces sort to the bottom of the workspace list once detected
- Member avatars are hidden on collapsed panels to reduce visual noise (shown only when expanded)
- Fixes `MemberSchema` to accept `null` for `namespace` from GraphQL (was `.optional()`, rejecting `null` and silently treating all users as non-members)

## Test plan

- [ ] Member user: expand toggle visible, MCP list loads, member avatars show when expanded
- [ ] Non-member user: locked icon in header, popover opens on click, workspace stays collapsed, no `GetMCPsList` request fired
- [ ] Forbidden workspaces sink to the bottom of the list
- [ ] Search still works — typing a CP name auto-expands matching workspaces 